### PR TITLE
Define Claude-first MVP strategy (#29)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,229 @@
+# Peakweb Agency Agents Roadmap
+
+This roadmap defines what Peakweb Agency Agents is trying to become beyond the original `agency-agents` roster.
+
+The short version:
+
+- `agency-agents` gives users a strong library of specialist personas.
+- Peakweb Agency Agents aims to add a reusable execution layer on top of that roster.
+- The centerpiece of that execution layer is a **skill builder** that assembles project-specific skills from reusable fragments.
+
+## Product Direction
+
+Peakweb Agency Agents should help teams move from:
+
+- a generic library of agents
+
+to:
+
+- a project-aware operating layer that reflects how the team actually ships software
+
+That means the system should understand:
+
+- what task system the team uses
+- where code review happens
+- how PRs are raised and reviewed
+- how many agents a task really needs
+- how context and models should be used efficiently
+
+## Core Contract
+
+Peakweb Agency Agents will **not** auto-configure third-party tools.
+
+Instead:
+
+- users configure access to their systems through MCP, CLI tools, environment variables, repo conventions, or other supported mechanisms
+- Peakweb provides fragment logic, builder behavior, setup guidance, and validation expectations
+- generated skills assume integrations are already available and correctly configured
+
+This is an important boundary. We can help users connect systems, but we are not promising automatic provisioning or vendor setup.
+
+## Design Principles
+
+- **Claude-first MVP**: optimize the first release for Claude and Claude Code rather than trying to support every AI platform immediately.
+- **Capabilities over vendors**: fragments should depend on shared workflow capabilities, not hardcoded brand logic.
+- **Composable over monolithic**: use small fragments that can be assembled into project-specific skills.
+- **Repo-local precedence**: generated skills should live in the project and override user-level defaults.
+- **Smallest capable team**: orchestration should start with the minimum agent team needed for the task.
+- **Efficient by default**: context use, model routing, and subtask boundaries should minimize waste.
+- **Human-reviewable output**: generated skills should be easy to understand, edit, and version.
+
+## Epics
+
+### Epic 1: Skill Builder Foundation
+
+Create the builder workflow that inventories a repository, asks a minimal questionnaire, and generates project-local skills from reusable fragments.
+
+Goals:
+
+- define the builder workflow from repo inventory through generated output
+- define where generated skills live and how they override user-level skills
+- define how the builder records assumptions, confidence, and unresolved questions
+- generate project-local skills that are understandable and versionable
+
+Non-goals:
+
+- building a universal one-size-fits-all skill
+- generating opaque machine-only output
+- auto-configuring external systems
+
+### Epic 2: Fragment And Assembly Architecture
+
+Define the fragment model and assembly engine so project-specific skills can be composed from reusable building blocks.
+
+Goals:
+
+- define fragment types, metadata, applicability rules, and composition behavior
+- distinguish generic workflow fragments from provider-specific fragments
+- allow generated skills to combine multiple fragments without duplicating rules
+- define validation rules for fragment compatibility and conflicts
+
+Non-goals:
+
+- encoding every workflow directly into the builder itself
+- mixing provider logic into generic orchestration fragments
+- supporting unlimited customization in v1
+
+### Epic 3: External Integration Contract
+
+Define the capability model that fragments can rely on when interacting with external systems.
+
+Goals:
+
+- define shared capabilities such as task lookup, status updates, PR creation, review requests, review feedback retrieval, and delivery signal access
+- define how a project declares which configured integration satisfies each capability
+- define expected fallback behavior when a capability is unavailable
+- make it clear where provider-specific setup ends and Peakweb behavior begins
+
+Non-goals:
+
+- shipping automatic MCP or vendor provisioning
+- embedding credentials or secrets management into the framework
+- assuming every provider exposes the same surface area
+
+### Epic 4: Delivery Workflow Coverage
+
+Provide a strong starting point for the most common software-delivery platforms and review patterns in the market.
+
+Goals:
+
+- support major task systems such as GitHub Issues, Jira, Linear, Azure Boards, and GitLab Issues
+- support major code-hosting and PR systems such as GitHub, GitLab, and Bitbucket
+- support common review patterns such as native review, CodeRabbit, and layered review automation
+- make provider selection part of builder output rather than hardcoded defaults
+
+Non-goals:
+
+- covering every marketplace tool in the first release
+- guaranteeing identical depth for every provider on day one
+- coupling support to only Peakweb's internal tool choices
+
+### Epic 5: Team Sizing And Orchestration Strategy
+
+Teach the system to choose the smallest capable team and coordinate work across implementation, review, and validation.
+
+Goals:
+
+- define solo vs small-team vs expanded-team heuristics
+- map task characteristics to likely agent roles and specialist needs
+- define handoff expectations between implementers, reviewers, and validators
+- keep team formation proportionate to task scope and risk
+
+Non-goals:
+
+- defaulting every task to a swarm
+- pretending one orchestration style fits every repo
+- optimizing for maximum agent count instead of delivery quality
+
+### Epic 6: Runtime Efficiency And Model Routing
+
+Add shared rules for context use, task scoping, and model selection across generated skills.
+
+Goals:
+
+- define efficient file-reading and context-loading behavior
+- define when stronger models are warranted and when cheaper paths are enough
+- define how to split work into bounded subtasks without duplication
+- improve reliability and cost-efficiency in large repositories
+
+Non-goals:
+
+- hardcoding provider-specific model implementations
+- forcing complex routing for small tasks
+- optimizing purely for cost at the expense of correctness
+
+### Epic 7: Installation, Packaging, And Adoption
+
+Make the new skills layer installable, understandable, and usable alongside the existing agent roster.
+
+Goals:
+
+- ship the base agents and reusable skill fragments together
+- document how users run the builder inside a project
+- document how repo-local generated skills take precedence over user-level defaults
+- provide setup guides for common integration paths without promising automation
+
+Non-goals:
+
+- hiding the distinction between source fragments and generated project-local output
+- introducing breaking install behavior without migration guidance
+- assuming all users want project-local generation immediately
+
+### Epic 8: Documentation, Examples, And Reference Projects
+
+Use docs and examples to show how the system behaves across different team/tool combinations.
+
+Goals:
+
+- document the product boundary clearly, especially around integrations
+- provide example generated skills for representative stacks and workflows
+- provide examples for GitHub-heavy, Jira-heavy, and mixed-tool environments
+- make it easy for users to understand why Peakweb differs from the upstream project
+
+Non-goals:
+
+- relying on marketing copy alone to explain the system
+- documenting only Peakweb's internal setup
+- assuming users will infer the builder workflow from fragments alone
+
+## Recommended Sequencing
+
+### Phase 1
+
+- Issue `#29` should be treated as a front-of-queue decision gate for MVP platform stance.
+- Epic 1: Skill Builder Foundation
+- Epic 2: Fragment And Assembly Architecture
+- Epic 3: External Integration Contract
+
+### Phase 2
+
+- Epic 4: Delivery Workflow Coverage
+- Epic 5: Team Sizing And Orchestration Strategy
+- Epic 6: Runtime Efficiency And Model Routing
+
+### Phase 3
+
+- Epic 7: Installation, Packaging, And Adoption
+- Epic 8: Documentation, Examples, And Reference Projects
+
+## First Issue Candidates
+
+Once the roadmap is agreed, the first issue batch should likely focus on:
+
+1. Define fragment schema and metadata contract.
+2. Define generated skill layout and precedence rules.
+3. Define external capability model for integrations.
+4. Define builder inventory workflow and confidence model.
+5. Define builder questionnaire and unresolved-decision flow.
+6. Define fragment assembly and conflict-resolution rules.
+7. Draft provider matrix for major delivery platforms and review tools.
+
+## Explicit Non-Goals For V1
+
+To keep the first version sharp, V1 should explicitly avoid:
+
+- auto-configuring third-party integrations
+- trying to support every vendor at launch
+- shipping a giant all-in-one master skill
+- hiding generated behavior in ways users cannot review
+- coupling the product only to Peakweb's internal tooling choices

--- a/docs/claude-first-mvp-strategy.md
+++ b/docs/claude-first-mvp-strategy.md
@@ -1,0 +1,242 @@
+# Claude-First MVP Strategy
+
+This document captures the research outcome for issue `#29`:
+
+- [#29 Research Claude-first MVP strategy and Anthropic compatibility approach](https://github.com/peakweb-team/pw-agency-agents/issues/29)
+
+## Decision
+
+Peakweb Agency Agents should be **Claude-first for the MVP**.
+
+That means:
+
+- the first builder and generated-skill experience should optimize for Claude and Claude Code
+- project-local override behavior should align with Claude-centric workflows
+- Peakweb should avoid spending MVP time on first-class support for every AI platform
+
+At the same time, the architecture should remain **clean enough to broaden later** if adoption justifies it.
+
+In practice, that means:
+
+- Claude-first product decisions
+- capability-oriented internal design
+- no premature multi-platform abstraction layer
+
+## Why This Is The Right MVP Stance
+
+Peakweb Agency Agents is a fork of a project that is already Claude-forward in how teams are likely to use it.
+
+Trying to make the MVP equally optimized for every AI platform would create three immediate risks:
+
+1. It would dilute the builder experience before we have a strong reference implementation.
+2. It would push us toward generic abstractions that are not yet justified by real user demand.
+3. It would slow down the highest-value work: making the skill builder excellent for the most likely first users.
+
+The MVP should therefore optimize for the environment most aligned with the upstream project and the current product direction: Claude and Claude Code.
+
+## What Anthropic Appears To Offer
+
+Based on official Anthropic material:
+
+- Anthropic has a **Skills** concept: folders containing instructions, scripts, and resources that Claude can load when relevant.
+- Skills are described as **composable**, and Anthropic positions them as usable across Claude apps, Claude Code, and the API.
+- Claude Code supports a strong **project-local configuration** model, which aligns well with repo-local override behavior.
+
+These ideas are highly relevant to Peakweb's direction.
+
+## Additional Lessons From Anthropic's `skill-creator`
+
+Anthropic's public `skills/skill-creator` implementation adds a few practical lessons beyond the high-level product docs.
+
+### 1. Skill Creation Is Itself A Workflow
+
+Anthropic treats skill creation as a repeatable workflow, not just a one-off writing task.
+
+That aligns strongly with Peakweb's builder direction:
+
+- discover intent
+- ask focused clarifying questions
+- draft the skill
+- evaluate it
+- refine it
+
+### 2. Start With Intent, Not Structure
+
+The `skill-creator` flow starts by understanding what the user wants the skill to enable, when it should trigger, and what outputs are expected.
+
+Peakweb should mirror this. The builder should start from:
+
+- desired workflow behavior
+- trigger context
+- output expectations
+
+and only then move into fragment selection and generated skill structure.
+
+### 3. Ask Only The Questions That Matter
+
+Anthropic's flow is interview-driven, but targeted. It tries to fill gaps from context first, then asks only what is still ambiguous.
+
+That is a strong fit for Peakweb's builder questionnaire design.
+
+### 4. Progressive Disclosure Matters
+
+Anthropic explicitly separates:
+
+- metadata
+- the main skill body
+- additional resources
+
+This is an important pattern for Peakweb as well. It suggests our fragment system should not collapse everything into one giant generated output when layered structure would keep runtime loading cleaner.
+
+### 5. Evaluation Should Be Part Of The Loop
+
+Anthropic's `skill-creator` strongly emphasizes test prompts, evaluation, and iterative refinement.
+
+Peakweb probably does not need the full evaluation harness in the first builder release, but this is still an important takeaway:
+
+- the builder should eventually support iteration, not just initial generation
+- generated skills should be easy to test against real repo tasks
+
+### 6. Description And Triggering Quality Matter
+
+Anthropic treats the skill description as a core triggering mechanism.
+
+For Peakweb, that means generated skills should pay close attention to:
+
+- when the skill should activate
+- what kinds of projects or workflows it applies to
+- what wording helps the Claude-side experience trigger reliably
+
+## How These Lessons Affect Peakweb
+
+These Anthropic patterns reinforce the MVP direction without changing the core decision:
+
+- we should learn from Anthropic's workflow design
+- we should not depend on Anthropic's implementation directly
+
+Most importantly, they strengthen the case that Peakweb's builder should be:
+
+- intent-first
+- minimally inquisitive
+- compositional
+- iterative over time
+- optimized for Claude triggering behavior
+
+## What We Should Mirror
+
+We should intentionally mirror these Anthropic patterns in the MVP:
+
+### 1. Composable Skills
+
+Peakweb should treat skills as small, purpose-built building blocks that can be assembled together rather than one giant universal prompt.
+
+### 2. Minimal Loading
+
+The builder and runtime should favor loading only the fragments and context needed for the current task, not the entire system.
+
+### 3. Project-Local Overrides
+
+Generated skills should live inside the repository and take precedence over broader user-level defaults.
+
+### 4. Claude Code As The Primary Execution Context
+
+The first implementation should assume Claude Code is the most important target environment for skill-builder usage and generated skill consumption.
+
+## What We Should Stay Independent From
+
+We should not build Peakweb as a thin wrapper around Anthropic-owned implementation details.
+
+Specifically:
+
+- we should not assume Anthropic's internal or product-level skill-builder behavior is available as a stable public dependency
+- we should not require Anthropic-specific platform features beyond what a normal Claude/Claude Code user can reasonably access
+- we should not encode our fragment architecture in a way that only makes sense inside Anthropic-owned tooling
+
+Peakweb should learn from Anthropic's product direction without becoming dependent on product surfaces we do not control.
+
+## What We Should Avoid In MVP
+
+We should explicitly avoid the following in the first release:
+
+### 1. Cross-Platform Feature Parity
+
+The MVP should not aim for equivalent support across Claude, OpenAI tooling, Gemini tooling, or any other ecosystem.
+
+### 2. Deep Platform Abstraction
+
+We do not need a full vendor-neutral runtime layer before we have a working Claude-first builder and generated-skill story.
+
+### 3. Platform-Agnostic Marketing That Drives Platform-Agnostic Engineering
+
+It is fine to say the architecture may broaden later. It is not fine to let that possibility force MVP design into generic mush.
+
+## What "Agnostic Architecture" Means For MVP
+
+For the MVP, "agnostic" should mean:
+
+- provider capabilities are modeled cleanly
+- fragment responsibilities are separated from vendor names where reasonable
+- generated skills are human-readable and portable in principle
+
+It should **not** mean:
+
+- every platform gets a first-class implementation now
+- every design decision must be optimized for hypothetical future runtimes
+- Claude-specific UX is treated as a liability instead of an MVP advantage
+
+In short:
+
+- be Claude-first in product
+- be disciplined in architecture
+- do not overbuild for future platforms
+
+## Implications For Phase 1 Issues
+
+This decision should directly shape the early issue work.
+
+### Implication For `#11`
+
+Fragment schema should support a Claude-first execution model first, with only the abstraction needed to avoid obvious dead ends.
+
+### Implication For `#12`
+
+Generated skill layout and precedence should be designed around Claude-centric project-local behavior as the primary reference path.
+
+### Implication For `#13`
+
+The external capability model should stay vendor-aware enough for future expansion, but the first implementation should be biased toward the delivery workflows most likely to be used alongside Claude Code.
+
+### Implication For `#14` And `#15`
+
+Builder inventory and questionnaire design should prefer Claude-forward defaults when repository evidence is ambiguous, while still making assumptions explicit.
+
+### Implication For `#17`
+
+Provider matrix research remains useful, but broad provider coverage should not be mistaken for a requirement that MVP execute equally well on every AI platform.
+
+## Recommended Product Boundary
+
+For the MVP, the product boundary should be:
+
+- **Primary target**: Claude Code users
+- **Primary output**: project-local generated skills and supporting fragments
+- **Primary workflow**: repo inspection, minimal questionnaire, fragment assembly, repo-local override behavior
+- **Expansion path**: broader AI-platform support only after real adoption and concrete demand
+
+## Recommendation
+
+Peakweb Agency Agents should proceed with:
+
+- a **Claude-first MVP**
+- a **capability-oriented internal design**
+- a **deliberately deferred** broader platform-support story
+
+This gives us the best chance of shipping something coherent, useful, and differentiated before investing in ecosystem breadth.
+
+## References
+
+Official Anthropic sources reviewed:
+
+- [Claude Skills: Customize AI for your workflows](https://www.anthropic.com/news/skills?t=n)
+- [Claude Code overview](https://docs.anthropic.com/en/docs/claude-code/overview)
+- [Claude Code product page](https://www.anthropic.com/product/claude-code)


### PR DESCRIPTION
Closes #29

## Summary
- document the Claude-first MVP recommendation for Peakweb Agency Agents
- capture the boundary between learning from Anthropic Skills patterns and depending on Anthropic-owned product surfaces
- update the roadmap to make the Claude-first stance an explicit Phase 1 decision gate
- include additional lessons from Anthropic's public `skill-creator` implementation for Peakweb's builder direction

## Testing
- documentation/research change only

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive product roadmap outlining strategic direction, core design principles, eight key epics, and recommended phase sequencing.
  * Added Claude-first MVP strategy documentation establishing platform focus, product boundaries, and design approach for the initial release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->