### PR TITLE
Define fragment schema and metadata contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,31 @@ In short: the original project is a roster. Peakweb aims to become a reusable de
 
 ---
 
+## Skill Builder
+
+The centerpiece of this fork is the **skill builder**: a project-aware layer that turns the base agent library into repo-specific operating instructions.
+
+Instead of expecting every team to use the same giant skill, the builder is intended to:
+
+- inspect a repository for clues about its stack, workflow, and tooling
+- ask a short follow-up questionnaire only when the repo cannot answer something confidently
+- choose the right strategy fragments for that team, such as GitHub Issues, Jira, CodeRabbit, team-sizing rules, and runtime/model routing
+- assemble one or more project-local skills that live with the codebase and can be versioned alongside it
+
+This is the core difference from the original project. Peakweb Agency Agents is not just a bigger roster of personas; it is trying to generate the **right operating layer for each project**.
+
+The intended flow looks like this:
+
+1. Install Peakweb Agency Agents at the user level.
+2. Run the `skill-builder` skill inside a target repository.
+3. Let it inspect the repo and confirm only the missing workflow details.
+4. Generate project-local skills from reusable fragments.
+5. Commit those generated skills with the project so the team can review and evolve them over time.
+
+That gives teams a practical path from generic specialist agents to a repeatable delivery system tailored to how they actually work.
+
+---
+
 ## 🗂️ Repository Layout
 
 - `agents/` contains the source roster, grouped by division.
@@ -75,6 +100,8 @@ Each agent file contains:
 Browse the agents below and copy/adapt the ones you need!
 
 Project-specific skills are starting to live in [`skills/`](skills/README.md). The long-term direction is for a builder skill to assemble repo-specific skills from reusable fragments and place the generated result inside the target project.
+
+The fragment metadata contract for that builder is documented in [`docs/fragment-schema.md`](docs/fragment-schema.md).
 
 ### Option 3: Use with Other Tools (GitHub Copilot, Antigravity, Gemini CLI, OpenCode, OpenClaw, Cursor, Aider, Windsurf, Kimi Code)
 

--- a/docs/fragment-schema.md
+++ b/docs/fragment-schema.md
@@ -153,7 +153,7 @@ Required `selection` fields:
   - Type: integer
   - Meaning: relative selection weight for deterministic tie-breaking
 
-`evidence_any` may be an empty array for broad baseline fragments, but it must still be present so the shape stays consistent.
+The `evidence_any` field may be an empty array for broad baseline fragments, but it must still be present so the shape stays consistent.
 
 ### `composition`
 
@@ -170,7 +170,7 @@ Required `composition` fields:
   - Type: array of fragment ids
   - Meaning: fragments commonly paired with this one
 
-`suggests` may be empty, but it must be present.
+The `suggests` field may be empty, but it must be present.
 
 ## Optional Metadata
 

--- a/docs/fragment-schema.md
+++ b/docs/fragment-schema.md
@@ -1,0 +1,438 @@
+# Fragment Schema And Metadata Contract
+
+This document defines the canonical fragment contract for issue `#11`:
+
+- [#11 Define fragment schema and metadata contract](https://github.com/peakweb-team/pw-agency-agents/issues/11)
+
+It is intentionally shaped by:
+
+- the Claude-first MVP stance from issue `#29`
+- the workflow-discipline lessons from issue `#31`
+- the product direction in [`ROADMAP.md`](../ROADMAP.md)
+
+The goal is not to make fragments abstract for abstraction's sake. The goal is to give Peakweb a small, deterministic contract that can support:
+
+- a Claude-first MVP
+- workflow operating system behavior instead of a loose prompt library
+- adaptive specialist-team assembly instead of a fixed swarm
+- human-readable, repo-local generated skills
+
+## Design Intent
+
+Fragments are reusable units of workflow behavior that the builder can select and compose into project-local skills.
+
+Each fragment should do two things at once:
+
+1. Expose enough metadata for the builder to select it predictably.
+2. Preserve readable guidance that humans can review, edit, and version.
+
+This follows the same general discipline that makes Anthropic-style skills and `superpowers`-style workflows useful:
+
+- small composable units
+- explicit triggers
+- predictable inclusion rules
+- strong operational guidance
+
+Peakweb differs in one important way: fragments are not the end product. They are source material for generating a project-specific operating layer.
+
+## Canonical File Shape
+
+Each fragment is a Markdown file with two parts:
+
+1. YAML frontmatter for machine-readable metadata
+2. Markdown body for human-readable behavior guidance
+
+The canonical shape is:
+
+```md
+---
+schema_version: 1
+id: orchestration/team-sizing
+title: Team Sizing
+fragment_type: generic
+layer: orchestration
+summary: Select the smallest capable team for a task.
+capabilities:
+  - orchestration.team-sizing
+selection:
+  evidence_any:
+    - repo.multi_area_delivery
+  preference: 60
+composition:
+  suggests:
+    - delivery/pull-request-review
+  order: 40
+---
+
+# Fragment: Team Sizing
+
+## Purpose
+...
+```
+
+The frontmatter is the contract the builder reads.
+
+The body is the contract a human reviewer reads.
+
+## Required Metadata
+
+Every fragment must define the following fields.
+
+### `schema_version`
+
+- Type: integer
+- Required: yes
+- Purpose: version the fragment metadata contract
+- MVP value: `1`
+
+### `id`
+
+- Type: string
+- Required: yes
+- Purpose: stable unique identifier
+- Format: path-like and repo-relative in spirit, such as `project-management/github-issues`
+
+### `title`
+
+- Type: string
+- Required: yes
+- Purpose: human-readable label for docs and generated-skill explanations
+
+### `fragment_type`
+
+- Type: enum
+- Required: yes
+- Allowed values:
+  - `generic`
+  - `provider`
+- Purpose: distinguish workflow-logic fragments from vendor-bound fragments
+
+### `layer`
+
+- Type: enum string
+- Required: yes
+- Initial values:
+  - `project-management`
+  - `delivery`
+  - `orchestration`
+  - `runtime`
+- Purpose: place the fragment in the builder's composition model
+
+### `summary`
+
+- Type: string
+- Required: yes
+- Purpose: one-sentence description of the fragment's job
+
+### `capabilities`
+
+- Type: array of strings
+- Required: yes
+- Purpose: describe the workflow capability this fragment adds
+- Example values:
+  - `task-tracker.read`
+  - `task-tracker.update`
+  - `delivery.pr-review`
+  - `orchestration.team-sizing`
+  - `runtime.context-routing`
+
+This is the main place where Peakweb stays capability-oriented instead of hardcoding vendor logic everywhere.
+
+### `selection`
+
+- Type: object
+- Required: yes
+- Purpose: define the minimum builder-readable applicability contract
+
+Required `selection` fields:
+
+- `evidence_any`
+  - Type: array of strings
+  - Meaning: at least one signal should be present for the fragment to be considered a natural fit
+- `preference`
+  - Type: integer
+  - Meaning: relative selection weight for deterministic tie-breaking
+
+`evidence_any` may be an empty array for broad baseline fragments, but it must still be present so the shape stays consistent.
+
+### `composition`
+
+- Type: object
+- Required: yes
+- Purpose: define the minimum builder-readable composition contract
+
+Required `composition` fields:
+
+- `order`
+  - Type: integer
+  - Meaning: stable sort order when assembling generated output
+- `suggests`
+  - Type: array of fragment ids
+  - Meaning: fragments commonly paired with this one
+
+`suggests` may be empty, but it must be present.
+
+## Optional Metadata
+
+These fields are optional in v1, but they are the preferred extension points when a fragment needs tighter applicability or composition rules.
+
+### Top-Level Optional Fields
+
+#### `provider`
+
+- Type: string
+- Allowed only for `fragment_type: provider`
+- Example values:
+  - `github`
+  - `jira`
+  - `gitlab`
+
+#### `status`
+
+- Type: enum string
+- Suggested values:
+  - `active`
+  - `experimental`
+  - `deprecated`
+- Default assumption when omitted: `active`
+
+#### `owners`
+
+- Type: array of strings
+- Purpose: identify maintainers or stewarding teams for larger fragment libraries
+
+#### `tags`
+
+- Type: array of strings
+- Purpose: lightweight discovery metadata for docs or tooling
+
+### Optional `selection` Fields
+
+#### `evidence_all`
+
+- Type: array of strings
+- Meaning: every listed signal should be present before the fragment is selected confidently
+
+#### `evidence_none`
+
+- Type: array of strings
+- Meaning: if any listed signal is present, the fragment should be excluded
+
+#### `requires_confirmation`
+
+- Type: array of strings
+- Meaning: signals that should trigger a questionnaire prompt instead of an automatic decision
+
+#### `confidence`
+
+- Type: enum string
+- Suggested values:
+  - `low`
+  - `medium`
+  - `high`
+- Meaning: how safe auto-selection is when repository evidence is incomplete
+
+### Optional `composition` Fields
+
+#### `requires`
+
+- Type: array of fragment ids
+- Meaning: fragments that should already be present for this fragment to make sense
+
+#### `conflicts`
+
+- Type: array of fragment ids
+- Meaning: incompatible fragments that should not be assembled into the same primary operating path
+
+#### `exclusive_within`
+
+- Type: array of strings
+- Meaning: exclusivity buckets where the builder should choose one primary fragment
+- Example values:
+  - `primary-task-tracker`
+  - `primary-pr-review-system`
+
+#### `emits`
+
+- Type: array of strings
+- Meaning: named behavior blocks the fragment contributes to generated skills
+- Example values:
+  - `issue-intake`
+  - `review-loop`
+  - `team-sizing-rules`
+
+This gives the builder a way to reason about overlap without requiring full assembly logic in v1.
+
+## Generic vs Provider Fragments
+
+This distinction must stay explicit.
+
+### Generic Fragments
+
+Generic fragments define reusable workflow behavior that should survive provider changes.
+
+Examples:
+
+- `orchestration/team-sizing`
+- `runtime/context-and-model-routing`
+- future planning, validation, or handoff fragments
+
+Generic fragments should:
+
+- express capabilities in neutral workflow language
+- describe heuristics, sequencing, and operating rules
+- avoid assuming a specific vendor surface unless the body is explicitly calling out an optional example
+
+Generic fragments should not:
+
+- require `provider`
+- hardcode GitHub, Jira, or other vendor instructions into the metadata contract
+
+### Provider Fragments
+
+Provider fragments bind workflow behavior to an actual configured system.
+
+Examples:
+
+- `project-management/github-issues`
+- `project-management/jira`
+- future GitLab review or CodeRabbit delivery fragments
+
+Provider fragments should:
+
+- define `provider`
+- declare the capabilities they satisfy for the builder
+- explain vendor-specific operating expectations in the body
+- use composition metadata to show which generic fragments they pair with or exclude
+
+Provider fragments should not:
+
+- become the place where all orchestration logic lives
+- replace generic runtime, validation, or team-sizing behavior that belongs in reusable workflow fragments
+
+## Minimum Deterministic Selection Contract
+
+Issue `#11` does not define full assembly logic, but it does need enough structure for deterministic selection.
+
+The builder must be able to do the following from metadata alone:
+
+1. Identify candidate fragments by `layer`.
+2. Filter candidates with `selection.evidence_any`, `selection.evidence_all`, and `selection.evidence_none`.
+3. Recognize when ambiguous evidence should trigger a follow-up question through `selection.requires_confirmation`.
+4. Prefer one fragment over another using `selection.preference`.
+5. Prevent invalid combinations using `composition.conflicts` and `composition.exclusive_within`.
+6. Assemble output in a stable order using `composition.order`, then `id` as the final tie-breaker.
+
+That is enough for MVP selection discipline without locking us into a premature full-blown rule engine.
+
+## Body Structure Expectations
+
+The Markdown body remains flexible, but fragments should usually include:
+
+- `## Purpose`
+- `## Include When`
+- `## Expected Behaviors` or `## Heuristics`
+- `## Builder Notes`
+
+This keeps fragments readable and aligned with the current repo style while letting metadata carry the machine-facing burden.
+
+## Example Definitions
+
+The examples below show the recommended difference between a generic orchestration fragment and a provider-specific task-tracker fragment.
+
+### Example: Generic Fragment
+
+```md
+---
+schema_version: 1
+id: orchestration/team-sizing
+title: Team Sizing
+fragment_type: generic
+layer: orchestration
+summary: Select the smallest capable specialist team for the task.
+capabilities:
+  - orchestration.team-sizing
+selection:
+  evidence_any:
+    - repo.multi_step_delivery
+    - repo.cross_functional_changes
+  evidence_all: []
+  evidence_none: []
+  preference: 70
+composition:
+  requires: []
+  suggests:
+    - delivery/pull-request-review
+    - runtime/context-and-model-routing
+  conflicts: []
+  exclusive_within: []
+  emits:
+    - team-sizing-rules
+  order: 40
+---
+```
+
+Why it is generic:
+
+- it expresses specialist-team behavior without naming a vendor
+- it supports Peakweb's adaptive-team model directly
+- it can pair with GitHub, Jira, or future task-system fragments
+
+### Example: Provider Fragment
+
+```md
+---
+schema_version: 1
+id: project-management/github-issues
+title: GitHub Issues
+fragment_type: provider
+layer: project-management
+summary: Use GitHub Issues as the primary task tracker for delivery work.
+provider: github
+capabilities:
+  - task-tracker.read
+  - task-tracker.update
+selection:
+  evidence_any:
+    - forge.github
+    - task_tracker.github_issues
+  evidence_all: []
+  evidence_none:
+    - task_tracker.jira_primary
+  requires_confirmation:
+    - forge.github_without_issue_usage
+  preference: 85
+composition:
+  requires: []
+  suggests:
+    - orchestration/team-sizing
+    - delivery/pull-request-review
+  conflicts:
+    - project-management/jira
+  exclusive_within:
+    - primary-task-tracker
+  emits:
+    - task-intake
+    - task-status-updates
+  order: 20
+---
+```
+
+Why it is provider-specific:
+
+- it binds task-tracker behavior to GitHub specifically
+- it satisfies provider-backed capabilities
+- it participates in exclusivity with alternative task-tracker providers
+
+## MVP Guidance
+
+To stay aligned with issues `#29` and `#31`, v1 fragments should optimize for a Claude-first workflow without becoming Claude-locked in the wrong layer.
+
+That means:
+
+- generated skills may be Claude-centric in tone and execution assumptions
+- fragment metadata should stay capability-oriented where possible
+- workflow discipline should be explicit enough to support planning, handoffs, validation, and review loops
+- team behavior should stay adaptive, with the smallest capable specialist set as the default
+
+In short: Peakweb should borrow the composability and workflow discipline of the best Claude-forward systems, while keeping its fragment contract clean, reviewable, and portable enough to evolve.

--- a/skills/README.md
+++ b/skills/README.md
@@ -21,6 +21,12 @@ This directory is the starting point for the Peakweb skills layer.
 - `fragments/runtime/`
   - Context budgeting, tool usage, and model-routing guidance.
 
+## Fragment Contract
+
+Fragments are no longer just loose Markdown notes. The canonical fragment schema now lives in [`docs/fragment-schema.md`](../docs/fragment-schema.md), and the fragment source directory is documented in [`skills/fragments/README.md`](./fragments/README.md).
+
+That contract keeps the builder deterministic while preserving readable, reviewable fragment bodies.
+
 ## Intended Flow
 
 1. Peakweb Agency Agents is installed into the user's home directory with the base agent roster and reusable skill fragments.

--- a/skills/fragments/README.md
+++ b/skills/fragments/README.md
@@ -1,0 +1,42 @@
+# Skill Fragments
+
+This directory contains the reusable fragment source material that the Peakweb builder selects from when generating project-local skills.
+
+## Contract
+
+Fragments now follow a canonical metadata contract documented here:
+
+- [docs/fragment-schema.md](../../docs/fragment-schema.md)
+
+In v1, each fragment is:
+
+1. a Markdown file
+2. with YAML frontmatter for builder-readable metadata
+3. followed by a human-readable body that explains the behavior
+
+## Current Layers
+
+- `project-management/`
+  - task-system and workflow-of-record fragments
+- `delivery/`
+  - PR, review, and downstream delivery-loop fragments
+- `orchestration/`
+  - team-sizing, role-shaping, and coordination fragments
+- `runtime/`
+  - context, model-routing, and execution-discipline fragments
+
+## Builder Expectations
+
+The builder should treat fragments as composable operating-system parts for a repository, not just prompt snippets.
+
+That means fragment metadata should help the builder answer:
+
+- when this fragment applies
+- what capability it contributes
+- what it conflicts with
+- what it commonly pairs with
+- where it belongs in assembled output
+
+## MVP Bias
+
+The fragment system is Claude-first for MVP, but the schema remains capability-oriented so Peakweb can broaden later without rebuilding the entire contract.

--- a/skills/fragments/delivery/pull-request-review.md
+++ b/skills/fragments/delivery/pull-request-review.md
@@ -1,3 +1,32 @@
+---
+schema_version: 1
+id: delivery/pull-request-review
+title: Pull Request Review
+fragment_type: generic
+layer: delivery
+summary: Standardize how implementation work becomes a PR, how review is requested, and how reviewer feedback is handled.
+capabilities:
+  - delivery.pr-review
+selection:
+  evidence_any:
+    - workflow.pull_requests
+    - forge.github
+    - forge.gitlab
+  evidence_all: []
+  evidence_none: []
+  preference: 75
+composition:
+  requires: []
+  suggests:
+    - orchestration/team-sizing
+    - runtime/context-and-model-routing
+  conflicts: []
+  exclusive_within: []
+  emits:
+    - review-loop
+  order: 60
+---
+
 # Fragment: Pull Request Review
 
 ## Purpose

--- a/skills/fragments/orchestration/team-sizing.md
+++ b/skills/fragments/orchestration/team-sizing.md
@@ -1,3 +1,33 @@
+---
+schema_version: 1
+id: orchestration/team-sizing
+title: Team Sizing
+fragment_type: generic
+layer: orchestration
+summary: Select the smallest capable agent team for a task based on scope, risk, and domain breadth.
+capabilities:
+  - orchestration.team-sizing
+selection:
+  evidence_any:
+    - repo.multi_step_delivery
+    - repo.cross_functional_changes
+    - workflow.review_and_validation_expected
+  evidence_all: []
+  evidence_none: []
+  preference: 70
+composition:
+  requires: []
+  suggests:
+    - project-management/github-issues
+    - delivery/pull-request-review
+    - runtime/context-and-model-routing
+  conflicts: []
+  exclusive_within: []
+  emits:
+    - team-sizing-rules
+  order: 40
+---
+
 # Fragment: Team Sizing
 
 ## Purpose

--- a/skills/fragments/orchestration/team-sizing.md
+++ b/skills/fragments/orchestration/team-sizing.md
@@ -19,6 +19,7 @@ composition:
   requires: []
   suggests:
     - project-management/github-issues
+    - project-management/jira
     - delivery/pull-request-review
     - runtime/context-and-model-routing
   conflicts: []

--- a/skills/fragments/project-management/github-issues.md
+++ b/skills/fragments/project-management/github-issues.md
@@ -1,3 +1,39 @@
+---
+schema_version: 1
+id: project-management/github-issues
+title: GitHub Issues
+fragment_type: provider
+layer: project-management
+summary: Use GitHub Issues as the system of record for task intake, progress logging, and traceability.
+provider: github
+capabilities:
+  - task-tracker.read
+  - task-tracker.update
+selection:
+  evidence_any:
+    - forge.github
+    - task_tracker.github_issues
+    - repo.references_issue_numbers
+  evidence_all: []
+  evidence_none: []
+  requires_confirmation:
+    - forge.github_without_confirmed_issue_workflow
+  preference: 85
+composition:
+  requires: []
+  suggests:
+    - orchestration/team-sizing
+    - delivery/pull-request-review
+  conflicts:
+    - project-management/jira
+  exclusive_within:
+    - primary-task-tracker
+  emits:
+    - task-intake
+    - task-status-updates
+  order: 20
+---
+
 # Fragment: GitHub Issues
 
 ## Purpose

--- a/skills/fragments/project-management/jira.md
+++ b/skills/fragments/project-management/jira.md
@@ -1,3 +1,39 @@
+---
+schema_version: 1
+id: project-management/jira
+title: Jira
+fragment_type: provider
+layer: project-management
+summary: Use Jira as the planning and delivery source of truth while keeping implementation behavior aligned with ticket discipline.
+provider: jira
+capabilities:
+  - task-tracker.read
+  - task-tracker.update
+selection:
+  evidence_any:
+    - task_tracker.jira
+    - repo.references_jira_keys
+    - docs.references_jira_workflows
+  evidence_all: []
+  evidence_none: []
+  requires_confirmation:
+    - forge.github_with_possible_jira_reference_only
+  preference: 90
+composition:
+  requires: []
+  suggests:
+    - orchestration/team-sizing
+    - delivery/pull-request-review
+  conflicts:
+    - project-management/github-issues
+  exclusive_within:
+    - primary-task-tracker
+  emits:
+    - task-intake
+    - task-status-updates
+  order: 20
+---
+
 # Fragment: Jira
 
 ## Purpose

--- a/skills/fragments/runtime/context-and-model-routing.md
+++ b/skills/fragments/runtime/context-and-model-routing.md
@@ -1,3 +1,35 @@
+---
+schema_version: 1
+id: runtime/context-and-model-routing
+title: Context And Model Routing
+fragment_type: generic
+layer: runtime
+summary: Guide agents to use context windows, tools, and model capability intentionally instead of wasting budget on every step.
+capabilities:
+  - runtime.context-routing
+  - runtime.model-routing
+selection:
+  evidence_any:
+    - repo.large
+    - repo.monorepo
+    - workflow.parallel_agents
+    - workflow.model_budget_matters
+  evidence_all: []
+  evidence_none: []
+  preference: 65
+composition:
+  requires: []
+  suggests:
+    - orchestration/team-sizing
+    - delivery/pull-request-review
+  conflicts: []
+  exclusive_within: []
+  emits:
+    - context-budgeting
+    - model-routing-rules
+  order: 80
+---
+
 # Fragment: Context And Model Routing
 
 ## Purpose


### PR DESCRIPTION
## Summary
- document the canonical fragment schema and metadata contract for issue #11
- add a fragments README and link the contract from the skills docs
- apply the new frontmatter contract to the existing project-management, orchestration, delivery, and runtime fragments as live examples

## Context
This follows the Claude-first MVP stance from #29, the workflow-discipline lessons from #31, and the roadmap direction toward a workflow operating system with adaptive specialist teams.

## Testing
- verified the current fragment files expose the required frontmatter fields

Closes #11

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a Skill Builder guide describing a repo-aware workflow to generate project-local skills.
  * Published a Fragment Schema documenting standardized fragment metadata, selection rules, and examples.
  * Introduced a Skill Fragments section with layered organization (project-management, delivery, orchestration, runtime).
  * Standardized fragment metadata for PR review, team-sizing, task trackers, and model-routing components.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->