### PR TITLE
Define generated skill layout and precedence rules

### DIFF
--- a/docs/builder-inventory-workflow.md
+++ b/docs/builder-inventory-workflow.md
@@ -8,6 +8,7 @@ It builds directly on:
 
 - the Claude-first MVP stance from issue `#29`
 - the fragment schema from issue `#11`
+- the generated-skill layout contract from issue `#12`
 - the roadmap goal of turning Peakweb into a workflow operating layer instead of a loose prompt library
 
 ## Why This Exists
@@ -80,6 +81,7 @@ Use one or more signals to infer builder decisions such as:
 - whether team-sizing guidance is needed
 - whether runtime/model-routing guidance is needed
 - whether a repo-local generated skill is likely to need multiple companion fragments
+- whether existing repo-local Claude or Peakweb files should be reviewed before regeneration
 
 The builder should infer choices only when the evidence reaches the confidence threshold defined below.
 
@@ -94,6 +96,8 @@ Every inferred choice should retain:
 - any conflicting or missing evidence
 
 This keeps generated behavior reviewable and gives the questionnaire phase a clean starting point.
+
+The recorded evidence should ultimately feed the metadata bundle defined in [`docs/generated-skill-layout.md`](./generated-skill-layout.md), especially `inventory.yaml`, `decisions.yaml`, and `review.md`.
 
 ### 5. Ask Only The Necessary Follow-Up Questions
 

--- a/docs/builder-questionnaire-flow.md
+++ b/docs/builder-questionnaire-flow.md
@@ -9,6 +9,7 @@ It builds on:
 - the Claude-first MVP stance from issue `#29`
 - the fragment schema from issue `#11`
 - the builder inventory and confidence model from issue `#14`
+- the generated-skill layout contract from issue `#12`
 
 ## Why This Exists
 
@@ -50,6 +51,8 @@ That means:
 - infer second
 - ask third
 - record uncertainty explicitly
+
+That recorded uncertainty should appear in the builder metadata bundle and review handoff defined in [`docs/generated-skill-layout.md`](./generated-skill-layout.md).
 
 In a Claude-first MVP, the builder should prefer safe defaults when the impact is low, but it should not guess silently on high-impact workflow choices.
 
@@ -93,6 +96,8 @@ An assumed decision must always include:
 - the supporting evidence
 - the reason it was not escalated to a question
 
+Assumed decisions must also be written into the generated review artifacts so a reviewer can see why the builder proceeded.
+
 ### `unresolved`
 
 Use `unresolved` when:
@@ -107,6 +112,8 @@ Examples:
 - review automation is referenced, but it is unclear whether it is required or legacy
 
 An unresolved decision should usually create a follow-up question.
+
+If the builder still ends with an unresolved decision after the questionnaire phase, it should surface that clearly in `decisions.yaml` and `review.md` rather than burying it inside the generated skill text.
 
 ### `not-applicable`
 

--- a/docs/generated-skill-layout.md
+++ b/docs/generated-skill-layout.md
@@ -247,7 +247,6 @@ Manual edits to generated `SKILL.md` files are allowed in MVP because human revi
 
 However:
 
-- direct edits should be treated as temporary unless reflected back into fragments or builder inputs
 - direct edits should be treated as temporary unless reflected into fragments or builder inputs
 - the metadata bundle should record the builder run that last generated the files
 - reviewers should expect later regenerations to overwrite untracked manual drift

--- a/docs/generated-skill-layout.md
+++ b/docs/generated-skill-layout.md
@@ -137,6 +137,25 @@ The `skill.json` file should include at minimum:
 
 The goal is not to create a heavy runtime format. The goal is to make each generated skill independently understandable and traceable.
 
+Example `skill.json`:
+
+```json
+{
+  "name": "peakweb-workflow",
+  "generated_by": "skill-builder",
+  "generated_at": "2026-04-15T00:00:00Z",
+  "schema_version": 1,
+  "repository": "github.com/peakweb-team/pw-agency-agents",
+  "role": "primary orchestration",
+  "selected_fragments": [
+    "orchestration/team-sizing",
+    "project-management/github-issues",
+    "delivery/pull-request-review"
+  ],
+  "source_manifest": ".agency/skills/peakweb/manifest.yaml"
+}
+```
+
 ## Required Builder Metadata Output
 
 Besides the skill content itself, the builder should write a metadata bundle under `.agency/skills/peakweb/`.
@@ -229,6 +248,7 @@ Manual edits to generated `SKILL.md` files are allowed in MVP because human revi
 However:
 
 - direct edits should be treated as temporary unless reflected back into fragments or builder inputs
+- direct edits should be treated as temporary unless reflected into fragments or builder inputs
 - the metadata bundle should record the builder run that last generated the files
 - reviewers should expect later regenerations to overwrite untracked manual drift
 

--- a/docs/generated-skill-layout.md
+++ b/docs/generated-skill-layout.md
@@ -1,0 +1,277 @@
+# Generated Skill Layout And Precedence Rules
+
+This document defines the proposed contract for issue `#12`:
+
+- [#12 Define generated skill layout and precedence rules](https://github.com/peakweb-team/pw-agency-agents/issues/12)
+
+It builds on:
+
+- the Claude-first MVP direction from issue `#29`
+- the fragment metadata contract in [`docs/fragment-schema.md`](./fragment-schema.md)
+- the builder inventory workflow in [`docs/builder-inventory-workflow.md`](./builder-inventory-workflow.md)
+- the builder questionnaire flow in [`docs/builder-questionnaire-flow.md`](./builder-questionnaire-flow.md)
+- the roadmap direction toward a workflow operating system instead of a loose prompt library
+
+## Why This Exists
+
+The builder can only be trustworthy if its output lands in a predictable place, uses stable names, and is reviewable like normal project code.
+
+For the Claude-first MVP, the layout should feel natural for repo-local Claude usage while still preserving Peakweb-specific assembly metadata for humans.
+
+This document defines:
+
+- where generated project-local skills live
+- how generated skills are named
+- how generated repo-local skills interact with installed user-level skills
+- what non-skill artifacts the builder should write for review and versioning
+
+## Design Goals
+
+- keep generated skills project-local and easy to commit
+- align the execution-facing path with Claude-style repo-local skill loading
+- make repo-local Peakweb output the authoritative layer for that repository
+- preserve enough builder metadata for review, debugging, and regeneration
+- avoid name collisions with user-authored or third-party skills
+
+## Output Roots
+
+The builder should write generated output under two project-local roots.
+
+### 1. Execution-Facing Skill Root
+
+The primary skill output root is:
+
+- `.claude/skills/peakweb/`
+
+This is the directory that should contain generated skills in the shape the Claude-first MVP is expected to consume directly.
+
+Each generated skill lives in its own folder under that root.
+
+Examples:
+
+- `.claude/skills/peakweb/peakweb-workflow/`
+- `.claude/skills/peakweb/peakweb-pr-review/`
+- `.claude/skills/peakweb/peakweb-runtime-guardrails/`
+
+### 2. Builder Metadata Root
+
+The builder should also write a repo-local metadata bundle under:
+
+- `.agency/skills/peakweb/`
+
+This metadata root is Peakweb-specific and exists so the generated skills stay reviewable and reproducible without polluting the execution-facing skill folders.
+
+The metadata bundle should be committed alongside the generated skills.
+
+## Naming Conventions
+
+Generated skill names should be deterministic, human-readable, and namespaced.
+
+### Skill Folder Prefix
+
+Every generated skill folder should begin with:
+
+- `peakweb-`
+
+This avoids collisions with:
+
+- installed user-level skills
+- hand-authored project-local skills
+- future non-Peakweb repo-local skills
+
+### Primary Skill Name
+
+The builder should generate one primary orchestration skill named:
+
+- `peakweb-workflow`
+
+This is the default entry point for project-specific execution behavior.
+
+### Companion Skill Names
+
+Companion skills should use short capability-oriented suffixes rather than provider names when possible.
+
+Examples:
+
+- `peakweb-pr-review`
+- `peakweb-task-tracking`
+- `peakweb-runtime-guardrails`
+- `peakweb-release-handoff`
+
+Provider-specific naming is acceptable only when the behavior is genuinely provider-bound and the generic name would hide an important distinction.
+
+Example:
+
+- `peakweb-jira-task-tracking`
+
+### Slug Rules
+
+Generated skill folder names should:
+
+- use lowercase kebab-case
+- start with `peakweb-`
+- stay stable across regenerations unless the fragment set materially changes
+- avoid repository-name prefixes in the skill folder itself
+
+The repository identity belongs in metadata, not in every skill name.
+
+## Generated Skill Contents
+
+Each generated skill folder under `.claude/skills/peakweb/` should contain:
+
+- `SKILL.md`
+  - the assembled skill instructions intended for direct use
+- `skill.json`
+  - lightweight machine-readable metadata for the generated skill
+
+The `skill.json` file should include at minimum:
+
+- `name`
+- `generated_by`
+- `generated_at`
+- `schema_version`
+- `repository`
+- `role`
+- `selected_fragments`
+- `source_manifest`
+
+The goal is not to create a heavy runtime format. The goal is to make each generated skill independently understandable and traceable.
+
+## Required Builder Metadata Output
+
+Besides the skill content itself, the builder should write a metadata bundle under `.agency/skills/peakweb/`.
+
+The MVP metadata bundle should include:
+
+- `manifest.yaml`
+  - top-level summary of the builder run, generated skills, and schema versions
+- `inventory.yaml`
+  - normalized signals, evidence sources, and confidence levels from the inventory phase
+- `decisions.yaml`
+  - confirmed, assumed, unresolved, and not-applicable decisions from the questionnaire phase
+- `fragments.lock.yaml`
+  - exact selected fragments, composition order, and fragment versions or source refs
+- `review.md`
+  - human-readable summary of why the skills were generated this way and what should be reviewed manually
+
+These files make generated output reviewable, diffable, and regenerable.
+
+## Precedence Rules
+
+Generated repo-local skills are the authoritative Peakweb layer for the current repository.
+
+### Rule 1: Repo-Local Generated Skills Beat Installed Peakweb Skills
+
+If a generated repo-local Peakweb skill and an installed user-level Peakweb skill both satisfy the same need, the repo-local generated skill wins.
+
+Reason:
+
+- the generated skill reflects repository evidence and confirmed project choices
+- the installed skill is only a reusable default
+
+### Rule 2: Exact Local Name Match Shadows User-Level Match
+
+If a repo-local generated skill and a user-level installed skill have the same skill name, the repo-local one should be treated as the active version for that repository.
+
+This is the cleanest override rule and should be the builder's default assumption.
+
+### Rule 3: Generated Skills Should Not Intentionally Shadow Unrelated Third-Party Skills
+
+The `peakweb-` prefix exists so Peakweb-generated output does not accidentally override unrelated local skills such as a hand-written `jira-helper` or `review-checklist`.
+
+Generated skills should override Peakweb defaults through namespace ownership, not through generic names.
+
+### Rule 4: Hand-Edited Repo-Local Generated Skills Remain Authoritative Until Regenerated
+
+If a repository owner edits a generated `SKILL.md` locally, that edited repo-local file remains authoritative for the repository until the builder is run again and overwrites or replaces it.
+
+The builder should therefore surface regeneration and review expectations clearly instead of pretending generated output is immutable.
+
+## Versioning And Review Expectations
+
+Generated skills are not throwaway cache files. They are project configuration and should be treated like other reviewed repository assets.
+
+### Commit Expectations
+
+The following should be committed together:
+
+- generated skill folders under `.claude/skills/peakweb/`
+- the builder metadata bundle under `.agency/skills/peakweb/`
+
+Committing both roots preserves the execution artifact and the reasoning behind it.
+
+### Review Expectations
+
+Every builder run should produce a `review.md` file that highlights:
+
+- what changed from the previous generation
+- which decisions were assumed instead of confirmed
+- any unresolved decisions still affecting the generated skill set
+- fragments that were added, removed, or replaced
+
+This review file should make doc-only PR review practical.
+
+### Regeneration Expectations
+
+Regeneration is expected when:
+
+- repository workflow evidence materially changes
+- the builder questionnaire answers change
+- fragment contract or builder schema versions change
+- the team intentionally wants to revise project-local operating behavior
+
+The builder should aim for deterministic output so regenerations produce clean diffs.
+
+### Manual Edit Expectations
+
+Manual edits to generated `SKILL.md` files are allowed in MVP because human reviewability is a core product goal.
+
+However:
+
+- direct edits should be treated as temporary unless reflected back into fragments or builder inputs
+- the metadata bundle should record the builder run that last generated the files
+- reviewers should expect later regenerations to overwrite untracked manual drift
+
+## Example Generated Layout
+
+```text
+.claude/
+  skills/
+    peakweb/
+      peakweb-workflow/
+        SKILL.md
+        skill.json
+      peakweb-pr-review/
+        SKILL.md
+        skill.json
+      peakweb-runtime-guardrails/
+        SKILL.md
+        skill.json
+
+.agency/
+  skills/
+    peakweb/
+      manifest.yaml
+      inventory.yaml
+      decisions.yaml
+      fragments.lock.yaml
+      review.md
+```
+
+## MVP Boundary
+
+This contract is intentionally narrow for v1.
+
+It does not require:
+
+- a cross-platform generated-skill layout for every AI tool
+- a binary cache format
+- automatic migration of manual edits back into fragments
+- support for unlimited companion skills
+
+It does require:
+
+- deterministic repo-local output
+- predictable Peakweb namespacing
+- clear repo-local precedence over installed Peakweb defaults
+- enough metadata to review and regenerate generated skills safely

--- a/skills/README.md
+++ b/skills/README.md
@@ -35,11 +35,13 @@ That document defines which repo signals the builder should look for, how it sho
 
 The questionnaire and unresolved-decision contract now lives in [`docs/builder-questionnaire-flow.md`](../docs/builder-questionnaire-flow.md).
 
+The generated-skill output, naming, and precedence contract now lives in [`docs/generated-skill-layout.md`](../docs/generated-skill-layout.md).
+
 ## Intended Flow
 
 1. Peakweb Agency Agents is installed into the user's home directory with the base agent roster and reusable skill fragments.
 2. The user runs the `skill-builder` skill inside a target project.
 3. The builder inspects the repo, confirms any missing details through a short questionnaire, and selects the relevant fragments.
-4. The builder assembles one or more project-local skills under a versioned project directory such as `.agency/skills/`.
+4. The builder assembles one primary skill and any needed companion skills under `.claude/skills/peakweb/`, then writes reviewable builder metadata under `.agency/skills/peakweb/`.
 
 This is scaffolding for the first iteration, not the final packaging or install behavior.

--- a/skills/skill-builder/SKILL.md
+++ b/skills/skill-builder/SKILL.md
@@ -58,9 +58,11 @@ Choose the smallest useful set of fragments from `skills/fragments/`. For each s
 - what evidence supported it
 - any assumptions or unresolved risks
 
+Follow the generated output contract in `docs/generated-skill-layout.md` for naming, folder layout, precedence, and required review artifacts.
+
 ### Phase 4: Skill Assembly
 
-Generate one or more project-local skills under `.agency/skills/`. Favor:
+Generate one primary skill and any needed companion skills under `.claude/skills/peakweb/`, and write builder metadata under `.agency/skills/peakweb/`. Favor:
 
 - one primary orchestration skill for task execution
 - small companion skills only when they reduce complexity
@@ -72,6 +74,8 @@ Each generated skill must:
 - define team-sizing heuristics
 - define context/model usage expectations
 - prefer repo-local conventions over user-level defaults
+
+The builder metadata bundle must include the inventory record, decision record, fragment lock information, and a human-readable review summary.
 
 ### Phase 5: Handoff
 
@@ -90,3 +94,4 @@ Provide:
 - Do not invent integrations that were not detected or confirmed.
 - Keep the generated output editable by humans.
 - Treat project-local skills as the authoritative override layer for that repository.
+- Keep generated skill names in the `peakweb-` namespace so repo-local overrides stay explicit and predictable.


### PR DESCRIPTION
## Summary
- add a generated-skill layout contract for issue #12
- define repo-local output roots, naming conventions, precedence behavior, and review/versioning expectations
- update builder and skills docs so inventory, questionnaire, and assembly workflows reference the same contract

## Testing
- not run (docs-only changes)

Closes #12

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a specification for generated-skill naming, output layout, and precedence rules between repo-local and installed skills.
  * Updated builder workflow to produce a primary skill plus companion skills and to write structured builder metadata alongside generated outputs.
  * Strengthened requirements to record inventory, decision outcomes (including assumed/unresolved), and a human-readable review artifact linked to generated-skill metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->