### PR TITLE
Add direct-brief intake to builder specs

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ The core agent library remains valuable because each agent is:
 The original `agency-agents` project is a strong source library. Peakweb Agency Agents is intended to add the missing execution layer.
 
 - **Composable skills, not one giant prompt**: We want project-specific behavior to be assembled from reusable fragments.
-- **Project-aware orchestration**: Skills can adapt to whether a team uses GitHub Issues, Jira, CodeRabbit, or other delivery tooling.
+- **Project-aware orchestration**: Skills can adapt to whether a team uses GitHub Issues, Jira, CodeRabbit, other delivery tooling, or a direct-brief bootstrap flow.
 - **Better team sizing**: Tasks should start with the smallest capable team instead of always behaving like a single agent or a fixed swarm.
 - **PR and reviewer workflows**: Opening PRs, coordinating review, and responding to feedback should be part of the system, not ad hoc operator work.
 - **Context and model efficiency**: Large repos need routing rules for what to read, when to parallelize, and when to spend on stronger models.
@@ -47,7 +47,7 @@ Instead of expecting every team to use the same giant skill, the builder is inte
 
 - inspect a repository for clues about its stack, workflow, and tooling
 - ask a short follow-up questionnaire only when the repo cannot answer something confidently
-- choose the right strategy fragments for that team, such as GitHub Issues, Jira, CodeRabbit, team-sizing rules, and runtime/model routing
+- choose the right strategy fragments for that team, such as GitHub Issues, Jira, direct-brief intake, CodeRabbit, team-sizing rules, and runtime/model routing
 - assemble one or more project-local skills that live with the codebase and can be versioned alongside it
 
 This is the core difference from the original project. Peakweb Agency Agents is not just a bigger roster of personas; it is trying to generate the **right operating layer for each project**.

--- a/docs/builder-inventory-workflow.md
+++ b/docs/builder-inventory-workflow.md
@@ -51,6 +51,7 @@ Inspect the repository and its immediate execution context for durable clues suc
 - docs and contribution guides
 - existing local agent, skill, or workflow files
 - package-manager and workspace manifests
+- user-supplied entry context such as a task reference or direct bootstrap brief
 
 The builder should prefer local evidence over assumptions and prefer durable config over incidental text.
 
@@ -60,6 +61,8 @@ Convert raw findings into a stable signal vocabulary that fragments and later bu
 
 Example normalized signals:
 
+- `input.task_reference`
+- `input.direct_brief`
 - `forge.github`
 - `task_tracker.github_issues`
 - `task_tracker.jira`
@@ -76,7 +79,8 @@ Signals are the bridge between repository inspection and fragment selection.
 
 Use one or more signals to infer builder decisions such as:
 
-- primary task tracker
+- work intake mode
+- primary task tracker, if tracker-backed intake is in scope
 - review loop shape
 - whether team-sizing guidance is needed
 - whether runtime/model-routing guidance is needed
@@ -138,6 +142,24 @@ Recommended signal fields:
 
 The builder should prioritize signal categories that materially affect fragment selection and questionnaire behavior.
 
+### Intake Mode Signals
+
+These determine whether generated skills should expect work to arrive from a tracked task, a direct brief, or both.
+
+Common signals:
+
+- `input.task_reference`
+- `input.direct_brief`
+- `workflow.bootstrap_greenfield_likely`
+- `workflow.task_tracker_optional`
+
+Typical evidence sources:
+
+- explicit CLI or slash-command design such as `/agent-task <ticket-or-prompt>`
+- starter-repo or greenfield language in docs
+- absence of authoritative task-tracker evidence in an otherwise active repo
+- user-provided brief at builder runtime
+
 ### Forge And Code Host Signals
 
 These help identify the primary hosting environment and likely PR workflow.
@@ -159,7 +181,7 @@ Typical evidence sources:
 
 ### Task Tracker Signals
 
-These drive provider-fragment selection for project-management behavior.
+These drive provider-fragment selection when the generated skill should integrate with an external task system.
 
 Common signals:
 
@@ -379,7 +401,8 @@ The builder should ask a follow-up question when all three of the following are 
 
 In practice, the builder should usually ask when deciding:
 
-- the primary task tracker
+- the work intake mode
+- the primary task tracker, if tracked-task intake is enabled
 - the primary PR/review loop
 - whether Jira or GitHub Issues is authoritative
 - whether review automation such as CodeRabbit is actually active
@@ -429,6 +452,14 @@ inventory:
         path: CONTRIBUTING.md
         detail: review mentions automation generally but no CodeRabbit config was found
   decisions:
+    work_intake_mode:
+      value: both
+      confidence: medium
+      supported_by:
+        - forge.github
+        - workflow.pull_requests
+      conflicts_with: []
+      assumption: The repository looks delivery-oriented, but no authoritative tracker was detected, so direct-brief intake remains available.
     primary_task_tracker:
       value: github-issues
       confidence: medium
@@ -446,6 +477,9 @@ inventory:
         - workflow.review_checklist_present
       conflicts_with: []
   unresolved_questions:
+    - id: work-intake-mode
+      prompt: Should the generated skill start from tracked tasks, direct briefs, or both?
+      why: The repository shows delivery workflow signals, but does not make the intake mode explicit.
     - id: task-tracker-authority
       prompt: Is GitHub Issues the primary tracker, or is another system authoritative?
       why: The repository shows GitHub delivery flow, but issue authority is not explicit.
@@ -476,6 +510,7 @@ Below is a sample Markdown-form inventory summary suitable for an MVP builder ha
 ### Inferred Decisions
 
 - Primary forge: GitHub (`high`)
+- Work intake mode: both tracked-task and direct-brief (`medium`)
 - Primary task tracker: GitHub Issues (`medium`)
 - Delivery model: PR-based review (`high`)
 - Team sizing guidance needed: yes (`high`)
@@ -483,11 +518,13 @@ Below is a sample Markdown-form inventory summary suitable for an MVP builder ha
 
 ### Assumptions
 
+- Direct-brief intake remains available because no authoritative tracker policy was found.
 - GitHub Issues is assumed to be the primary tracker until contradicted.
 - No review automation provider is assumed because none was directly detected.
 
 ### Follow-Up Questions
 
+- Confirm whether the generated skill should start from tracked tasks, direct briefs, or both.
 - Confirm whether GitHub Issues is the authoritative tracker or just a mirror for another system.
 ```
 

--- a/docs/builder-questionnaire-flow.md
+++ b/docs/builder-questionnaire-flow.md
@@ -289,6 +289,19 @@ Avoid:
 
 Builder output should preserve both the question and the resulting decision state.
 
+Canonical ID rule:
+
+- `questions[].id` should use kebab-case.
+- `decisions` keys should use snake_case.
+- The normalization rule is: lowercase the question id and convert hyphens to underscores.
+- Implementations and parsers should apply that mapping consistently when relating question records to decision records.
+
+Examples:
+
+- `work-intake-mode` -> `work_intake_mode`
+- `review-path` -> `review_path`
+- `primary-task-tracker` -> `primary_task_tracker`
+
 Recommended conceptual shape:
 
 ```yaml

--- a/docs/builder-questionnaire-flow.md
+++ b/docs/builder-questionnaire-flow.md
@@ -75,6 +75,7 @@ Use `confirmed` when either:
 Examples:
 
 - GitHub Issues is selected because direct repo evidence makes it clearly primary
+- the user confirms that direct-brief bootstrap should remain available even without an authoritative tracker
 - the user confirms that CodeRabbit is part of the review loop
 
 ### `assumed`
@@ -109,6 +110,7 @@ Use `unresolved` when:
 Examples:
 
 - both GitHub Issues and Jira appear active, but primary authority is unclear
+- the repository shows no authoritative tracker, but it is unclear whether the generated skill should be direct-brief-first or tracker-optional
 - review automation is referenced, but it is unclear whether it is required or legacy
 
 An unresolved decision should usually create a follow-up question.
@@ -130,21 +132,24 @@ The builder should ask questions in priority order, not all at once.
 
 The initial MVP questionnaire should focus on the smallest set of decisions that most strongly affect fragment selection.
 
-### Priority 1: Primary Task Tracker
+### Priority 1: Work Intake Mode
 
 Question goal:
 
-- determine which system is authoritative for task intake and status tracking
+- determine whether generated skills should start from a tracked task, a direct brief, or support both
 
 Ask when:
 
-- multiple task systems are suggested by the repo, or
+- multiple task systems are suggested by the repo
 - the repo clearly uses a forge but issue authority is still unclear
+- the repo appears greenfield, light-process, or likely to benefit from direct-brief bootstrap
+- the intended UX wants a dual entry path such as `/agent-task <ticket-or-prompt>`
 
 Examples:
 
-- Is GitHub Issues the primary task tracker, or is another system authoritative?
-- If both GitHub Issues and Jira are used, which one should the builder treat as the source of truth?
+- Should the generated skill expect work to begin from a tracked task, a direct brief, or both?
+- If both GitHub Issues and Jira are used, which one should the builder treat as the source of truth for tracked-task intake?
+- Should a greenfield repo support a direct-brief bootstrap mode even if GitHub Issues exists?
 
 ### Priority 2: Review Path
 
@@ -272,7 +277,7 @@ Good pattern:
 
 Good example:
 
-- Which system should the builder treat as the primary task tracker: GitHub Issues or Jira? This changes the generated project-management fragment.
+- Should the generated skill start from tracked tasks, direct briefs, or both? This changes the intake and project-management fragments.
 
 Avoid:
 
@@ -288,18 +293,19 @@ Recommended conceptual shape:
 
 ```yaml
 questions:
-  - id: primary-task-tracker
+  - id: work-intake-mode
     status: asked
-    prompt: Which system should the builder treat as the primary task tracker?
+    prompt: Should the generated skill start from tracked tasks, direct briefs, or both?
     options:
-      - github-issues
-      - jira
-    why: This changes the project-management fragment and issue-handling guidance.
-    answer: jira
+      - tracked-task
+      - direct-brief
+      - both
+    why: This changes the intake and project-management fragments.
+    answer: both
 decisions:
-  primary_task_tracker:
+  work_intake_mode:
     state: confirmed
-    value: jira
+    value: both
     source: user-answer
 ```
 
@@ -334,8 +340,14 @@ Recommended shape:
 
 ```yaml
 unresolved_decisions:
+  - id: work-intake-mode
+    topic: work intake mode
+    why_unresolved: The repository suggests GitHub-based delivery, but it is unclear whether direct-brief bootstrap should remain available.
+    impact: high
+    recommended_question: Should the generated skill start from tracked tasks only, direct briefs only, or both?
+    safe_to_proceed: false
   - id: task-tracker-authority
-    topic: primary task tracker
+    topic: primary task tracker for tracked-task intake
     why_unresolved: GitHub Issues and Jira are both referenced, but authority is not explicit.
     impact: high
     recommended_question: Which system should the builder treat as authoritative for task intake and status updates?
@@ -369,6 +381,12 @@ inventory:
         path: CONTRIBUTING.md
         detail: Jira ticket keys appear in workflow examples
 decisions:
+  work_intake_mode:
+    state: assumed
+    value: both
+    confidence: medium
+    source: builder-default
+    assumption: The repository appears to support delivery work but does not show a clearly authoritative tracker, so the builder kept both tracked-task and direct-brief intake available.
   primary_forge:
     state: confirmed
     value: github
@@ -389,11 +407,11 @@ decisions:
 questions:
   - id: primary-task-tracker
     status: pending
-    prompt: Which system should the builder treat as the primary task tracker?
+    prompt: Which system should the builder treat as the primary task tracker for tracked-task intake?
     why: This changes the generated project-management fragment.
 unresolved_decisions:
   - id: task-tracker-authority
-    topic: primary task tracker
+    topic: primary task tracker for tracked-task intake
     why_unresolved: GitHub Issues and Jira both appear active, but authority is unclear.
     impact: high
     recommended_question: Which system should the builder treat as authoritative?

--- a/docs/fragment-schema.md
+++ b/docs/fragment-schema.md
@@ -112,6 +112,7 @@ Every fragment must define the following fields.
 - Type: enum string
 - Required: yes
 - Initial values:
+  - `task-intake`
   - `project-management`
   - `delivery`
   - `orchestration`
@@ -130,6 +131,7 @@ Every fragment must define the following fields.
 - Required: yes
 - Purpose: describe the workflow capability this fragment adds
 - Example values:
+  - `task-intake.direct-brief`
   - `task-tracker.read`
   - `task-tracker.update`
   - `delivery.pr-review`
@@ -378,6 +380,37 @@ Why it is generic:
 - it supports Peakweb's adaptive-team model directly
 - it can pair with GitHub, Jira, or future task-system fragments
 
+### Example: Generic Intake Fragment
+
+```md
+---
+schema_version: 1
+id: task-intake/direct-brief
+title: Direct Brief Intake
+fragment_type: generic
+layer: task-intake
+summary: Allow work to begin from a freeform prompt instead of requiring an external ticket.
+capabilities:
+  - task-intake.direct-brief
+selection:
+  evidence_any:
+    - input.direct_brief
+    - workflow.task_tracker_optional
+  preference: 70
+composition:
+  suggests:
+    - orchestration/team-sizing
+    - runtime/context-and-model-routing
+  order: 10
+---
+```
+
+Why it is generic:
+
+- it models how work enters the system without naming a vendor
+- it supports greenfield and vibe-coding flows directly
+- it can coexist with or replace tracker-backed intake depending on project needs
+
 ### Example: Provider Fragment
 
 ```md
@@ -387,7 +420,7 @@ id: project-management/github-issues
 title: GitHub Issues
 fragment_type: provider
 layer: project-management
-summary: Use GitHub Issues as the primary task tracker for delivery work.
+summary: Use GitHub Issues as the tracked-task system of record for delivery work.
 provider: github
 capabilities:
   - task-tracker.read

--- a/skills/fragments/README.md
+++ b/skills/fragments/README.md
@@ -16,6 +16,8 @@ In v1, each fragment is:
 
 ## Current Layers
 
+- `task-intake/`
+  - direct-brief and other work-entry fragments
 - `project-management/`
   - task-system and workflow-of-record fragments
 - `delivery/`

--- a/skills/fragments/project-management/github-issues.md
+++ b/skills/fragments/project-management/github-issues.md
@@ -4,7 +4,7 @@ id: project-management/github-issues
 title: GitHub Issues
 fragment_type: provider
 layer: project-management
-summary: Use GitHub Issues as the system of record for task intake, progress logging, and traceability.
+summary: Use GitHub Issues as the tracked-task system of record when the project actually manages work there.
 provider: github
 capabilities:
   - task-tracker.read
@@ -38,17 +38,17 @@ composition:
 
 ## Purpose
 
-Use GitHub Issues as the system of record for task intake, progress logging, and traceability.
+Use GitHub Issues as the tracked-task system of record when the project manages implementation work there.
 
 ## Include When
 
 - The repository uses GitHub as its primary forge.
 - Issues are actively referenced in branches, commits, or PRs.
-- The team wants implementation agents to read and update issue context directly.
+- The team wants issue-backed work to be read from and summarized back to GitHub.
 
 ## Expected Behaviors
 
-- Read the issue before planning or implementation starts.
+- Read the issue before planning or implementation starts for issue-backed work.
 - Extract acceptance criteria into an explicit checklist.
 - Post meaningful status updates when the workflow spans multiple phases or agents.
 - Link PRs, validation evidence, and follow-up work back to the issue.
@@ -57,4 +57,4 @@ Use GitHub Issues as the system of record for task intake, progress logging, and
 
 - Pair well with `orchestration/team-sizing.md`.
 - Pair well with `delivery/pull-request-review.md`.
-- If GitHub is present but issues are not used, omit this fragment and prefer a lighter PR-only workflow.
+- If GitHub is present but issues are not authoritative, omit this fragment and prefer direct-brief or lighter PR-only workflow guidance.

--- a/skills/fragments/project-management/jira.md
+++ b/skills/fragments/project-management/jira.md
@@ -4,7 +4,7 @@ id: project-management/jira
 title: Jira
 fragment_type: provider
 layer: project-management
-summary: Use Jira as the planning and delivery source of truth while keeping implementation behavior aligned with ticket discipline.
+summary: Use Jira as the tracked-task source of truth when the project manages delivery through Jira.
 provider: jira
 capabilities:
   - task-tracker.read
@@ -38,7 +38,7 @@ composition:
 
 ## Purpose
 
-Use Jira as the planning and delivery source of truth while keeping implementation behavior aligned with ticket discipline.
+Use Jira as the tracked-task source of truth when the project manages delivery through Jira.
 
 ## Include When
 
@@ -48,12 +48,12 @@ Use Jira as the planning and delivery source of truth while keeping implementati
 
 ## Expected Behaviors
 
-- Resolve the active Jira issue before making implementation decisions.
+- Resolve the active Jira issue before making implementation decisions for tracked-task work.
 - Preserve ticket keys in branch and PR metadata.
 - Translate Jira acceptance criteria into an implementation checklist.
 - Report blockers, status changes, and review readiness in Jira-compatible language.
 
 ## Builder Notes
 
-- Prefer this over the GitHub Issues fragment when Jira is the authoritative tracker.
+- Prefer this over the GitHub Issues fragment when Jira is the authoritative tracker for tracked-task intake.
 - If both Jira and GitHub Issues are used, define one as primary and the other as reference-only.

--- a/skills/fragments/task-intake/direct-brief.md
+++ b/skills/fragments/task-intake/direct-brief.md
@@ -1,0 +1,55 @@
+---
+schema_version: 1
+id: task-intake/direct-brief
+title: Direct Brief Intake
+fragment_type: generic
+layer: task-intake
+summary: Allow work to begin from a freeform prompt or bootstrap brief instead of requiring an external ticket.
+capabilities:
+  - task-intake.direct-brief
+selection:
+  evidence_any:
+    - input.direct_brief
+    - workflow.bootstrap_greenfield_likely
+    - workflow.task_tracker_optional
+  evidence_all: []
+  evidence_none: []
+  preference: 70
+composition:
+  requires: []
+  suggests:
+    - orchestration/team-sizing
+    - runtime/context-and-model-routing
+  conflicts: []
+  exclusive_within:
+    - primary-intake-mode
+  emits:
+    - task-intake
+    - assumption-capture
+  order: 10
+---
+
+# Fragment: Direct Brief Intake
+
+## Purpose
+
+Allow work to begin from a freeform prompt or bootstrap brief instead of requiring an external ticket.
+
+## Include When
+
+- The project is greenfield, exploratory, or intentionally light-process.
+- The team wants to support vibe-coding or bootstrap flows alongside tracked-task delivery.
+- No authoritative external task tracker is present, or tracker usage is optional.
+
+## Expected Behaviors
+
+- Turn the incoming brief into a concrete checklist, assumptions list, and proposed delivery slice.
+- Record notable assumptions and unresolved decisions explicitly so humans can review them later.
+- Prefer lightweight local coordination unless and until the work merits durable human-facing tracking.
+- Escalate into tracker-backed workflow only when the team or repository conventions require it.
+
+## Builder Notes
+
+- Pair well with `orchestration/team-sizing.md`.
+- Pair well with `runtime/context-and-model-routing.md`.
+- This fragment is a first-class alternative to task-system provider fragments, not just a fallback.


### PR DESCRIPTION
## Summary

This updates the builder/spec direction so Peakweb can start work from either a tracked task or a direct brief.

## What changed

- add a new generic `task-intake/direct-brief` fragment for vibe/bootstrap flows
- update builder inventory and questionnaire docs to treat work intake mode as a first-class decision
- clarify that GitHub/Jira fragments are optional tracked-task companions, not universal prerequisites
- refresh top-level docs to mention direct-brief bootstrap alongside task-system-backed delivery
- align GitHub issues `#5`, `#13`, `#20`, and `#28` with the same model

## Why

We want the builder to support both:

- structured delivery against GitHub Issues/Jira/etc.
- greenfield or light-process work that begins from a freeform brief

That gives us a cleaner path toward commands like `/agent-task <ticket-or-prompt>` and matches the broader Kiro-style vibe/spec split the product is moving toward.

## Testing

- docs/spec change only; no runtime tests needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added direct-brief intake as a first-class work-entry option alongside tracked-task systems.

* **Documentation**
  * Introduced “work intake mode” decision framing and updated questionnaire/examples to reflect tracked-task vs direct-brief.
  * Added guidance, examples, and fragments for direct-brief intake and task-intake layer.
  * Clarified when to prefer GitHub Issues or Jira for tracked-task scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->