### PR TITLE
Define external capability model for integrations

### DIFF
--- a/docs/builder-inventory-workflow.md
+++ b/docs/builder-inventory-workflow.md
@@ -9,6 +9,7 @@ It builds directly on:
 - the Claude-first MVP stance from issue `#29`
 - the fragment schema from issue `#11`
 - the generated-skill layout contract from issue `#12`
+- the external capability model from issue `#13`
 - the roadmap goal of turning Peakweb into a workflow operating layer instead of a loose prompt library
 
 ## Why This Exists
@@ -29,6 +30,7 @@ This document defines the MVP answer.
 - define a confidence model for inferred choices
 - define the threshold for follow-up questions
 - define what evidence the builder should record in its output
+- make it possible to infer which capability families a generated skill can rely on
 
 ## Non-Goals
 
@@ -75,6 +77,8 @@ Example normalized signals:
 
 Signals are the bridge between repository inspection and fragment selection.
 
+They are also the bridge between repository inspection and later capability-mapping decisions defined in [`docs/external-capability-model.md`](./external-capability-model.md).
+
 ### 3. Infer Project Choices
 
 Use one or more signals to infer builder decisions such as:
@@ -86,6 +90,7 @@ Use one or more signals to infer builder decisions such as:
 - whether runtime/model-routing guidance is needed
 - whether a repo-local generated skill is likely to need multiple companion fragments
 - whether existing repo-local Claude or Peakweb files should be reviewed before regeneration
+- which capability families are likely available, optional, or unsupported for this repository
 
 The builder should infer choices only when the evidence reaches the confidence threshold defined below.
 

--- a/docs/builder-questionnaire-flow.md
+++ b/docs/builder-questionnaire-flow.md
@@ -10,6 +10,7 @@ It builds on:
 - the fragment schema from issue `#11`
 - the builder inventory and confidence model from issue `#14`
 - the generated-skill layout contract from issue `#12`
+- the external capability model from issue `#13`
 
 ## Why This Exists
 
@@ -33,6 +34,7 @@ This document defines the MVP answer so the builder can stay minimal, explicit, 
 - define when a question should be skipped
 - define the builder decision states
 - define how unresolved decisions are recorded in output
+- resolve workflow choices that materially change which capability families the generated skill should rely on
 
 ## Non-Goals
 
@@ -77,6 +79,7 @@ Examples:
 - GitHub Issues is selected because direct repo evidence makes it clearly primary
 - the user confirms that direct-brief bootstrap should remain available even without an authoritative tracker
 - the user confirms that CodeRabbit is part of the review loop
+- the user confirms that tracked-task updates are required even though direct briefs remain allowed
 
 ### `assumed`
 
@@ -112,6 +115,7 @@ Examples:
 - both GitHub Issues and Jira appear active, but primary authority is unclear
 - the repository shows no authoritative tracker, but it is unclear whether the generated skill should be direct-brief-first or tracker-optional
 - review automation is referenced, but it is unclear whether it is required or legacy
+- the project clearly needs PR delivery, but it is unclear whether hosted delivery-status signals are required for completion
 
 An unresolved decision should usually create a follow-up question.
 

--- a/docs/external-capability-model.md
+++ b/docs/external-capability-model.md
@@ -1,0 +1,416 @@
+# External Capability Model For Integrations
+
+This document defines the proposed contract for issue `#13`:
+
+- [#13 Define external capability model for integrations](https://github.com/peakweb-team/pw-agency-agents/issues/13)
+
+It builds on:
+
+- the Claude-first MVP direction from issue `#29`
+- the workflow-pattern lessons from issue `#31`
+- the fragment metadata contract in [`docs/fragment-schema.md`](./fragment-schema.md)
+- the builder inventory workflow in [`docs/builder-inventory-workflow.md`](./builder-inventory-workflow.md)
+- the builder questionnaire flow in [`docs/builder-questionnaire-flow.md`](./builder-questionnaire-flow.md)
+- the roadmap direction toward capability-oriented workflow behavior instead of vendor-bound prompts
+
+## Why This Exists
+
+Peakweb fragments need a stable way to express what they expect from external systems without hardcoding every workflow to one provider.
+
+That is the purpose of the capability model.
+
+It gives generated skills and fragments a shared vocabulary for:
+
+- direct local intake when work starts from a freeform brief
+- tracked-task intake when work starts from an external issue or ticket
+- code-host and PR behavior
+- review feedback handling
+- delivery and validation signal retrieval
+
+This keeps the builder capability-oriented while still leaving room for provider-specific mappings later.
+
+## Goals
+
+- define the MVP capability vocabulary for generated skills
+- distinguish direct-brief intake from tracked-task intake explicitly
+- describe capability semantics clearly enough for later provider mapping
+- call out known provider variability so generated skills do not assume a false uniform API
+- establish the minimum unsupported-capability behavior for MVP
+
+## Non-Goals
+
+- defining the project declaration file or configuration shape for choosing providers
+- implementing provider adapters or MCP servers
+- promising that every provider supports every capability equally
+- replacing future issue work on fallback matrices or provider-specific coverage
+
+## Core Principles
+
+### Capabilities Describe Workflow Intent, Not Vendor APIs
+
+A capability should name what the generated skill needs to accomplish.
+
+It should not name how a specific provider exposes that behavior.
+
+Good:
+
+- `task-tracker.read`
+- `code-host.pr.open`
+- `review-feedback.read`
+
+Bad:
+
+- `github.issue.get`
+- `jira.transition-ticket`
+- `coderabbit.fetch-review`
+
+### Direct-Brief Intake Is First-Class
+
+Generated skills must be allowed to start from a freeform prompt or bootstrap brief without requiring an external task system.
+
+The capability model must therefore distinguish:
+
+- local/direct intake capabilities
+- external tracked-task capabilities
+
+This is not a fallback hack. It is a primary supported workflow mode for MVP.
+
+### Provider Mapping May Be Partial
+
+Later provider declarations may map only part of the capability set.
+
+The generated skill should therefore know:
+
+- which capabilities are required for its chosen workflow
+- which capabilities are optional refinements
+- what to do when a capability is unavailable
+
+### Local Evidence Still Matters
+
+Not every useful workflow signal comes from an external API.
+
+For MVP, local or repo-derived signals remain valid inputs alongside provider-backed capabilities.
+
+Examples:
+
+- local test results
+- CI config in the repository
+- branch and PR conventions in docs
+- a direct brief supplied at builder runtime
+
+## Capability Families
+
+The MVP capability set is organized into five families.
+
+### 1. Task Intake Capabilities
+
+These determine how work begins.
+
+#### `task-intake.direct-brief`
+
+- Purpose: allow work to begin from a freeform prompt, bootstrap brief, or greenfield request
+- Required for:
+  - direct-brief-first workflows
+  - dual-intake workflows that allow both briefs and tracked tasks
+- Semantics:
+  - accept a human-provided brief as the initial work object
+  - treat the brief as authoritative enough to start planning
+  - do not require an external task id before work can begin
+- Notes:
+  - this is usually satisfied by local prompt input, not a third-party system
+  - this capability should pair naturally with explicit assumption capture
+
+#### `task-intake.assumption-capture`
+
+- Purpose: record assumptions, missing facts, and unresolved decisions when work starts without a fully structured ticket
+- Required for:
+  - direct-brief-first workflows
+  - tracker-optional workflows where the initial brief may be incomplete
+- Semantics:
+  - turn implicit assumptions into explicit reviewable output
+  - preserve unresolved questions for later human or system follow-up
+- Notes:
+  - this is commonly satisfied by generated-skill behavior and metadata output rather than by an external provider
+
+### 2. Tracked-Task Capabilities
+
+These apply when work begins from or must sync back to an external issue system.
+
+#### `task-tracker.lookup`
+
+- Purpose: resolve a task reference into the canonical tracked work item
+- Required for:
+  - tracked-task-first workflows
+  - dual-intake workflows when the entry point is a task reference
+- Semantics:
+  - accept a task key, issue number, URL, or equivalent reference
+  - return the canonical task record to drive later reads and updates
+- Known variability:
+  - some providers support multiple reference formats
+  - some require exact ids or project-scoped keys
+  - some can resolve URLs but not plain-language references
+
+#### `task-tracker.read`
+
+- Purpose: read the task record and its delivery-relevant context
+- Required for:
+  - tracked-task-first workflows
+- Semantics:
+  - retrieve title, description, acceptance criteria, status, and related links when available
+  - make the task readable enough to produce an implementation plan
+- Known variability:
+  - some providers expose structured fields for status, assignee, and acceptance criteria
+  - others expose mostly freeform text plus comments
+
+#### `task-tracker.update`
+
+- Purpose: write meaningful progress or completion updates back to the tracked task
+- Required for:
+  - tracked-task workflows that expect durable system-of-record updates
+- Semantics:
+  - post status notes, links, or summary updates back to the task system
+  - keep the tracked task aligned with meaningful workflow milestones
+- Known variability:
+  - some providers support rich field transitions
+  - some only support comments or lightweight status mutation
+  - permissions may allow reading but not updating
+
+### 3. Code-Host And Pull Request Capabilities
+
+These govern how implementation work is published for review.
+
+#### `code-host.pr.open`
+
+- Purpose: create a pull request or merge request for the current implementation slice
+- Required for:
+  - PR-based delivery workflows
+- Semantics:
+  - open the review artifact in the primary code host
+  - include enough summary information for reviewers to evaluate the change
+- Known variability:
+  - some systems require a branch on the same remote
+  - some allow draft PRs or merge requests while others differ in terminology and available states
+
+#### `code-host.pr.update`
+
+- Purpose: keep the PR description and metadata aligned with the current state of the work
+- Required for:
+  - PR-based delivery workflows that expect living PR summaries
+- Semantics:
+  - update title, description, labels, or linked references when the workflow requires it
+- Known variability:
+  - editable metadata differs across providers
+  - some workflows depend heavily on templates or labels, others do not
+
+#### `code-host.pr.review-request`
+
+- Purpose: route a PR into the expected reviewer path
+- Required for:
+  - workflows with explicit human or automated review routing
+- Semantics:
+  - request the relevant review path for the project, such as maintainers, a team, or reviewer automation
+- Known variability:
+  - some providers support explicit reviewer assignment
+  - some automation is triggered through labels, comments, or branch rules instead
+
+#### `code-host.pr.status-read`
+
+- Purpose: read PR-level status and check outcomes
+- Required for:
+  - PR workflows that gate completion on checks, approvals, or mergeability
+- Semantics:
+  - retrieve review state, check state, and merge-readiness signals when available
+- Known variability:
+  - the available status surface differs significantly across providers
+  - some systems separate CI, approvals, and branch protection into different APIs
+
+### 4. Review Feedback Capabilities
+
+These govern how generated skills consume and act on review comments.
+
+#### `review-feedback.read`
+
+- Purpose: read human and automated review feedback on implementation work
+- Required for:
+  - review-driven workflows
+- Semantics:
+  - retrieve unresolved review comments, approval state, and notable automated review findings
+  - normalize them into a work queue the generated skill can act on
+- Known variability:
+  - review comments may be inline, summary-level, or bot-generated
+  - some providers expose threaded resolution state, others do not
+
+#### `review-feedback.respond`
+
+- Purpose: update the review conversation after follow-up changes
+- Required for:
+  - workflows that expect visible reviewer follow-through
+- Semantics:
+  - acknowledge or resolve feedback in the review system when appropriate
+  - keep the review loop legible after changes are made
+- Known variability:
+  - some systems support formal review replies and resolution markers
+  - others only support generic comments
+
+### 5. Delivery And Validation Capabilities
+
+These let generated skills inspect whether the work is ready to hand off or complete.
+
+#### `delivery-status.read`
+
+- Purpose: read delivery-state signals tied to the change
+- Required for:
+  - workflows that rely on hosted checks, deploy previews, or release gates
+- Semantics:
+  - retrieve the status of downstream delivery signals that materially affect completion
+- Known variability:
+  - signals may come from the code host, CI provider, deployment platform, or release tooling
+  - some projects treat this as mandatory, others as optional context
+
+#### `validation-signal.read`
+
+- Purpose: retrieve validation evidence relevant to the task
+- Required for:
+  - workflows where tests, lint, static analysis, or similar evidence affect completion
+- Semantics:
+  - make validation outcomes visible to the generated skill for planning, PR preparation, or completion checks
+- Known variability:
+  - validation may be local-only, CI-only, or both
+  - some providers expose rich structured results, others only expose pass/fail summaries
+
+## Intake Modes And Required Capability Sets
+
+The builder should treat work intake mode as a top-level workflow decision.
+
+### Direct-Brief-First
+
+Required capabilities:
+
+- `task-intake.direct-brief`
+- `task-intake.assumption-capture`
+
+Not required:
+
+- any `task-tracker.*` capability
+
+This mode explicitly allows generated skills to operate without an external task system.
+
+### Tracked-Task-First
+
+Required capabilities:
+
+- `task-tracker.lookup`
+- `task-tracker.read`
+
+Usually required:
+
+- `task-tracker.update`
+
+This mode assumes the tracked task is the system of record for work intake.
+
+### Dual Intake
+
+Required capabilities:
+
+- `task-intake.direct-brief`
+- `task-intake.assumption-capture`
+- `task-tracker.lookup`
+- `task-tracker.read`
+
+This mode allows the generated skill to start from either a direct brief or a tracked task depending on the request.
+
+## Provider Mapping Expectations
+
+Provider mapping work should translate a concrete system into one or more of the canonical capabilities above.
+
+That later mapping should answer:
+
+- which capabilities the provider satisfies
+- whether support is full, partial, or unavailable
+- any provider-specific restrictions worth surfacing to the generated skill
+
+Examples:
+
+- GitHub Issues may satisfy `task-tracker.lookup`, `task-tracker.read`, and `task-tracker.update`
+- Jira may satisfy the same tracked-task capabilities with different field semantics
+- GitHub Pull Requests may satisfy `code-host.pr.open`, `code-host.pr.update`, `code-host.pr.review-request`, `code-host.pr.status-read`, `review-feedback.read`, and `review-feedback.respond`
+- local prompt input satisfies `task-intake.direct-brief` without any external provider at all
+
+This document defines the capability semantics, not the declaration format for those mappings. The declaration shape belongs to issue `#18`.
+
+## Unsupported-Capability Behavior
+
+Generated skills must not pretend a capability exists when it has not been mapped or confirmed.
+
+For MVP:
+
+### 1. Do Not Invent Support
+
+If a capability is unavailable, generated instructions should not fabricate a provider-specific step.
+
+### 2. Prefer A Safe Alternate Path
+
+If the missing capability has a safe local or direct-brief alternative, the builder may prefer that path.
+
+Example:
+
+- if no authoritative task-tracker capability is available, prefer direct-brief-first workflow when that remains compatible with the project
+
+### 3. Record The Gap Explicitly
+
+If a missing capability materially affects workflow behavior, record it in builder output rather than hiding it.
+
+This should surface in:
+
+- `decisions.yaml`
+- `review.md`
+- generated-skill instructions where the limitation changes operator behavior
+
+### 4. Escalate When No Safe Path Exists
+
+If the workflow requires a capability and no safe fallback exists, the builder should leave the related decision unresolved instead of generating misleading behavior.
+
+Examples:
+
+- a tracked-task-only workflow without `task-tracker.read`
+- a review-driven PR workflow without any usable review-feedback path
+
+### 5. Leave Detailed Fallback Policy To Follow-On Work
+
+This document defines the baseline behavior only.
+
+The more detailed fallback matrix belongs to issue `#19`.
+
+## Recommended Capability Vocabulary For Fragments
+
+Fragments should prefer the canonical capability ids in this document when declaring behavior.
+
+That keeps:
+
+- provider fragments comparable to each other
+- generic fragments independent from vendor names
+- builder output ready for later provider-mapping work
+
+This does not require every fragment to enumerate every possible capability immediately.
+
+For MVP, fragments should declare:
+
+- the smallest set of capabilities they genuinely depend on or contribute
+- in canonical capability language
+
+## MVP Boundary
+
+This contract is intentionally modest.
+
+It defines:
+
+- the shared capability vocabulary
+- the distinction between direct/local intake and external tracked-task intake
+- the baseline semantics needed for later provider mapping
+- the minimum unsupported-capability behavior
+
+It does not define:
+
+- the config file or declaration syntax for selecting providers
+- provider-specific adapter implementations
+- the full fallback matrix for every missing capability combination

--- a/docs/fragment-schema.md
+++ b/docs/fragment-schema.md
@@ -7,6 +7,7 @@ This document defines the canonical fragment contract for issue `#11`:
 It is intentionally shaped by:
 
 - the Claude-first MVP stance from issue `#29`
+- the external capability model from issue `#13`
 - the workflow-discipline lessons from issue `#31`
 - the product direction in [`ROADMAP.md`](../ROADMAP.md)
 
@@ -132,13 +133,21 @@ Every fragment must define the following fields.
 - Purpose: describe the workflow capability this fragment adds
 - Example values:
   - `task-intake.direct-brief`
+  - `task-intake.assumption-capture`
+  - `task-tracker.lookup`
   - `task-tracker.read`
   - `task-tracker.update`
+  - `code-host.pr.open`
+  - `code-host.pr.review-request`
+  - `review-feedback.read`
+  - `validation-signal.read`
   - `delivery.pr-review`
   - `orchestration.team-sizing`
   - `runtime.context-routing`
 
 This is the main place where Peakweb stays capability-oriented instead of hardcoding vendor logic everywhere.
+
+The canonical capability semantics live in [`docs/external-capability-model.md`](./external-capability-model.md).
 
 ### `selection`
 

--- a/skills/README.md
+++ b/skills/README.md
@@ -12,6 +12,8 @@ This directory is the starting point for the Peakweb skills layer.
 
 - `skill-builder/`
   - Interactive builder skill that inventories a repo, asks a targeted questionnaire, and assembles project-specific skills.
+- `fragments/task-intake/`
+  - Work-entry fragments for direct-brief and other intake modes.
 - `fragments/project-management/`
   - Strategy fragments for issue systems such as GitHub Issues and Jira.
 - `fragments/orchestration/`
@@ -36,6 +38,8 @@ That document defines which repo signals the builder should look for, how it sho
 The questionnaire and unresolved-decision contract now lives in [`docs/builder-questionnaire-flow.md`](../docs/builder-questionnaire-flow.md).
 
 The generated-skill output, naming, and precedence contract now lives in [`docs/generated-skill-layout.md`](../docs/generated-skill-layout.md).
+
+The external capability vocabulary that fragments and generated skills should rely on now lives in [`docs/external-capability-model.md`](../docs/external-capability-model.md).
 
 ## Intended Flow
 

--- a/skills/fragments/README.md
+++ b/skills/fragments/README.md
@@ -7,6 +7,7 @@ This directory contains the reusable fragment source material that the Peakweb b
 Fragments now follow a canonical metadata contract documented here:
 
 - [docs/fragment-schema.md](../../docs/fragment-schema.md)
+- [docs/external-capability-model.md](../../docs/external-capability-model.md)
 
 In v1, each fragment is:
 
@@ -38,6 +39,8 @@ That means fragment metadata should help the builder answer:
 - what it conflicts with
 - what it commonly pairs with
 - where it belongs in assembled output
+
+Capability names should use the canonical vocabulary from `docs/external-capability-model.md` so provider fragments stay comparable and direct-brief workflows remain first-class.
 
 ## MVP Bias
 

--- a/skills/skill-builder/SKILL.md
+++ b/skills/skill-builder/SKILL.md
@@ -34,13 +34,16 @@ Inspect the repository for signals such as:
 
 Normalize those findings into explicit builder signals and assign confidence to the resulting project choices. Follow the contract in `docs/builder-inventory-workflow.md`.
 
+Use those findings to infer which capability families are available for this project under `docs/external-capability-model.md`.
+
 Summarize what was detected and what is still unknown.
 
 ### Phase 2: Targeted Questionnaire
 
 Ask only the unresolved questions that materially affect skill composition. Prioritize:
 
-- Project management system: GitHub Issues, Jira, Linear, or other
+- Work intake mode: direct brief, tracked task, or both
+- Project management system when tracked-task intake is in scope: GitHub Issues, Jira, Linear, or other
 - Review tooling: CodeRabbit, human-only review, custom CI gates
 - Whether tasks should default to solo execution or team orchestration
 - Any budget or model constraints
@@ -49,6 +52,8 @@ Ask only the unresolved questions that materially affect skill composition. Prio
 If the repository already answers a question with high confidence, do not ask it again.
 If a high-impact workflow decision remains below high confidence, ask a focused follow-up question instead of guessing silently.
 Record each resulting decision as confirmed, assumed, unresolved, or not-applicable. Follow `docs/builder-questionnaire-flow.md` for questionnaire priority and unresolved-decision handling.
+
+Be explicit about whether the generated skill should rely on direct-brief intake, tracked-task capabilities, or both.
 
 ### Phase 3: Fragment Selection
 
@@ -59,6 +64,8 @@ Choose the smallest useful set of fragments from `skills/fragments/`. For each s
 - any assumptions or unresolved risks
 
 Follow the generated output contract in `docs/generated-skill-layout.md` for naming, folder layout, precedence, and required review artifacts.
+
+When describing selected fragments, use the canonical capability vocabulary from `docs/external-capability-model.md` instead of provider-specific API language.
 
 ### Phase 4: Skill Assembly
 


### PR DESCRIPTION
## Summary
- add the external capability contract for issue #13
- distinguish direct-brief intake from tracked-task capabilities and define code-host, review-feedback, delivery, and validation capability families
- update fragment and builder docs so they reference the shared capability vocabulary

## Testing
- not run (docs-only changes)

Closes #13

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Introduced an external capability model defining standard capabilities across task intake, code hosting, and review workflows.
  * Enhanced builder workflow to determine work intake mode (direct brief, tracked task, or both).
  * Updated fragment vocabulary to use standardized capability names for consistency.
  * Added capability family inference based on project repository findings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->