### PR TITLE
Define project integration declaration format

### DIFF
--- a/docs/builder-inventory-workflow.md
+++ b/docs/builder-inventory-workflow.md
@@ -10,6 +10,7 @@ It builds directly on:
 - the fragment schema from issue `#11`
 - the generated-skill layout contract from issue `#12`
 - the external capability model from issue `#13`
+- the project integration declaration format from issue `#18`
 - the roadmap goal of turning Peakweb into a workflow operating layer instead of a loose prompt library
 
 ## Why This Exists
@@ -107,6 +108,8 @@ Every inferred choice should retain:
 This keeps generated behavior reviewable and gives the questionnaire phase a clean starting point.
 
 The recorded evidence should ultimately feed the metadata bundle defined in [`docs/generated-skill-layout.md`](./generated-skill-layout.md), especially `inventory.yaml`, `decisions.yaml`, and `review.md`.
+
+That same evidence should also feed the provider and capability bindings recorded in [`docs/project-integration-declaration-format.md`](./project-integration-declaration-format.md).
 
 ### 5. Ask Only The Necessary Follow-Up Questions
 

--- a/docs/builder-questionnaire-flow.md
+++ b/docs/builder-questionnaire-flow.md
@@ -11,6 +11,7 @@ It builds on:
 - the builder inventory and confidence model from issue `#14`
 - the generated-skill layout contract from issue `#12`
 - the external capability model from issue `#13`
+- the project integration declaration format from issue `#18`
 
 ## Why This Exists
 
@@ -55,6 +56,8 @@ That means:
 - record uncertainty explicitly
 
 That recorded uncertainty should appear in the builder metadata bundle and review handoff defined in [`docs/generated-skill-layout.md`](./generated-skill-layout.md).
+
+It should also be reflected in provider and capability mapping state inside [`docs/project-integration-declaration-format.md`](./project-integration-declaration-format.md).
 
 In a Claude-first MVP, the builder should prefer safe defaults when the impact is low, but it should not guess silently on high-impact workflow choices.
 

--- a/docs/external-capability-model.md
+++ b/docs/external-capability-model.md
@@ -336,7 +336,7 @@ Examples:
 - GitHub Pull Requests may satisfy `code-host.pr.open`, `code-host.pr.update`, `code-host.pr.review-request`, `code-host.pr.status-read`, `review-feedback.read`, and `review-feedback.respond`
 - local prompt input satisfies `task-intake.direct-brief` without any external provider at all
 
-This document defines the capability semantics, not the declaration format for those mappings. The declaration shape belongs to issue `#18`.
+This document defines the capability semantics, not the declaration format for those mappings. The declaration shape now lives in [`docs/project-integration-declaration-format.md`](./project-integration-declaration-format.md).
 
 ## Unsupported-Capability Behavior
 

--- a/docs/generated-skill-layout.md
+++ b/docs/generated-skill-layout.md
@@ -10,6 +10,7 @@ It builds on:
 - the fragment metadata contract in [`docs/fragment-schema.md`](./fragment-schema.md)
 - the builder inventory workflow in [`docs/builder-inventory-workflow.md`](./builder-inventory-workflow.md)
 - the builder questionnaire flow in [`docs/builder-questionnaire-flow.md`](./builder-questionnaire-flow.md)
+- the project integration declaration format in [`docs/project-integration-declaration-format.md`](./project-integration-declaration-format.md)
 - the roadmap direction toward a workflow operating system instead of a loose prompt library
 
 ## Why This Exists
@@ -164,6 +165,8 @@ The MVP metadata bundle should include:
 
 - `manifest.yaml`
   - top-level summary of the builder run, generated skills, and schema versions
+- `integrations.yaml`
+  - repo-local declaration of which configured integration satisfies each external capability
 - `inventory.yaml`
   - normalized signals, evidence sources, and confidence levels from the inventory phase
 - `decisions.yaml`
@@ -271,6 +274,7 @@ However:
   skills/
     peakweb/
       manifest.yaml
+      integrations.yaml
       inventory.yaml
       decisions.yaml
       fragments.lock.yaml

--- a/docs/project-integration-declaration-format.md
+++ b/docs/project-integration-declaration-format.md
@@ -1,0 +1,484 @@
+# Project Integration Declaration Format
+
+This document defines the proposed contract for issue `#18`:
+
+- [#18 Define project integration declaration format](https://github.com/peakweb-team/pw-agency-agents/issues/18)
+
+It builds on:
+
+- the Claude-first MVP direction from issue `#29`
+- the generated-skill layout contract in [`docs/generated-skill-layout.md`](./generated-skill-layout.md)
+- the builder inventory workflow in [`docs/builder-inventory-workflow.md`](./builder-inventory-workflow.md)
+- the builder questionnaire flow in [`docs/builder-questionnaire-flow.md`](./builder-questionnaire-flow.md)
+- the external capability model in [`docs/external-capability-model.md`](./external-capability-model.md)
+
+## Why This Exists
+
+The external capability model defines *what* a generated skill may need.
+
+This document defines how a project declares *which configured integration* satisfies those capabilities.
+
+That declaration needs to be:
+
+- repo-local
+- human-reviewable
+- compatible with builder output
+- explicit about what is confirmed versus what is only assumed
+
+Without this layer, generated skills would know the capability vocabulary but would still lack a stable project-level record of how those capabilities are satisfied.
+
+## Design Goals
+
+- keep the declaration close to the generated-skill metadata bundle
+- separate capability semantics from provider selection
+- support both external systems and local/direct workflow paths
+- distinguish confirmed mappings from assumptions or unresolved gaps
+- preserve enough detail for later regeneration and review
+
+## Output Location
+
+The project integration declaration should live at:
+
+- `.agency/skills/peakweb/integrations.yaml`
+
+This keeps it inside the existing Peakweb builder metadata root rather than scattering workflow configuration across unrelated files.
+
+The file should be committed alongside:
+
+- `manifest.yaml`
+- `inventory.yaml`
+- `decisions.yaml`
+- `fragments.lock.yaml`
+- `review.md`
+
+## Core Model
+
+The declaration format has two layers:
+
+### 1. Provider Entries
+
+These define the named integration targets available to the project.
+
+Examples:
+
+- a local direct-brief intake path
+- GitHub Issues
+- Jira
+- GitHub Pull Requests
+- CodeRabbit
+
+### 2. Capability Bindings
+
+These map canonical capabilities to one declared provider entry.
+
+Examples:
+
+- `task-intake.direct-brief` -> local direct-brief input
+- `task-tracker.read` -> Jira
+- `code-host.pr.open` -> GitHub
+- `review-feedback.read` -> GitHub PR reviews
+
+The provider entry says what the integration is.
+
+The capability binding says what workflow job it satisfies.
+
+## Canonical File Shape
+
+The MVP declaration file should use YAML with this top-level shape:
+
+```yaml
+schema_version: 1
+generated_by: skill-builder
+generated_at: 2026-04-15T18:00:00Z
+providers:
+  local-direct-brief:
+    provider: local
+    kind: local
+    decision_state: confirmed
+    notes: Work may begin from a direct brief supplied at runtime.
+
+  github:
+    provider: github
+    kind: external
+    decision_state: confirmed
+    notes: GitHub is the primary code host and issue system.
+
+capability_bindings:
+  task-intake.direct-brief:
+    provider_ref: local-direct-brief
+    support: full
+    decision_state: confirmed
+
+  task-tracker.lookup:
+    provider_ref: github
+    support: full
+    decision_state: confirmed
+
+  review-feedback.read:
+    provider_ref: github
+    support: partial
+    decision_state: assumed
+    notes: Human review is confirmed, but bot-review coverage is still assumed.
+```
+
+This shape is intentionally small.
+
+It should be easy to diff, hand-edit, and regenerate.
+
+## Required Fields
+
+### Top-Level Required Fields
+
+#### `schema_version`
+
+- Type: integer
+- Required: yes
+- MVP value: `1`
+- Purpose: version the declaration contract
+
+#### `generated_by`
+
+- Type: string
+- Required: yes
+- Purpose: identify the builder or process that last wrote the file
+
+#### `generated_at`
+
+- Type: string
+- Required: yes
+- Format: ISO 8601 timestamp
+- Purpose: record when the declaration was last generated
+
+#### `providers`
+
+- Type: object keyed by repo-local provider reference id
+- Required: yes
+- Purpose: define the integration targets available to the project
+
+#### `capability_bindings`
+
+- Type: object keyed by canonical capability id
+- Required: yes
+- Purpose: map each declared capability to a provider entry
+
+## Provider Entry Fields
+
+Each entry in `providers` should use a stable repo-local key such as `github`, `jira`, or `local-direct-brief`.
+
+Required fields:
+
+### `provider`
+
+- Type: string
+- Purpose: canonical provider label
+
+Example values:
+
+- `local`
+- `github`
+- `jira`
+- `gitlab`
+- `coderabbit`
+
+### `kind`
+
+- Type: enum string
+- Allowed values:
+  - `local`
+  - `external`
+- Purpose: distinguish local workflow paths from external configured systems
+
+### `decision_state`
+
+- Type: enum string
+- Allowed values:
+  - `confirmed`
+  - `assumed`
+  - `unresolved`
+- Purpose: record how certain the builder is that this provider entry is valid for the project
+
+### Optional Provider Fields
+
+#### `label`
+
+- Type: string
+- Purpose: human-friendly display label when the provider name alone is too generic
+
+#### `notes`
+
+- Type: string
+- Purpose: short explanation of relevant project-specific constraints
+
+#### `source`
+
+- Type: object
+- Purpose: identify where the provider inference came from
+
+Suggested nested fields:
+
+- `type`
+- `path`
+- `detail`
+
+#### `config_hint`
+
+- Type: string
+- Purpose: short reminder about the expected configured path without attempting auto-setup
+
+Example values:
+
+- `requires gh auth and repository access`
+- `requires Jira MCP or CLI credentials outside Peakweb`
+
+## Capability Binding Fields
+
+Each entry in `capability_bindings` is keyed by the canonical capability id from [`docs/external-capability-model.md`](./external-capability-model.md).
+
+Required fields:
+
+### `provider_ref`
+
+- Type: string
+- Required: yes
+- Purpose: reference one entry from the `providers` map
+
+### `support`
+
+- Type: enum string
+- Required: yes
+- Allowed values:
+  - `full`
+  - `partial`
+  - `unavailable`
+- Purpose: describe the expected support level for that capability in this project
+
+### `decision_state`
+
+- Type: enum string
+- Required: yes
+- Allowed values:
+  - `confirmed`
+  - `assumed`
+  - `unresolved`
+- Purpose: record whether the capability binding is established, inferred, or still uncertain
+
+Optional fields:
+
+### `notes`
+
+- Type: string
+- Purpose: call out project-specific limitations or interpretation details
+
+### `fallback`
+
+- Type: string
+- Purpose: short description of the safe alternate path if support is partial or unavailable
+
+### `source`
+
+- Type: object
+- Purpose: record the evidence or decision that justified the binding
+
+## Confirmed vs Assumed vs Unresolved
+
+The declaration format must make certainty visible, not implicit.
+
+### `confirmed`
+
+Use when:
+
+- repository evidence is strong enough
+- or the user explicitly confirmed the provider mapping
+
+Example:
+
+- `task-tracker.read` is bound to `jira` because repeated Jira keys and workflow docs make it authoritative
+
+### `assumed`
+
+Use when:
+
+- the builder has a reasonable default
+- but the project did not fully confirm the mapping
+
+Example:
+
+- `review-feedback.read` is assumed to be satisfied by GitHub PR review because PR delivery is clear, but the exact review automation path is not
+
+### `unresolved`
+
+Use when:
+
+- the workflow likely needs the capability
+- but no safe provider mapping can yet be confirmed or assumed
+
+Example:
+
+- `delivery-status.read` is needed for completion gates, but no stable delivery-status source is confirmed yet
+
+## Local / Direct Workflow Support
+
+The declaration format must support workflows that do not begin with an external task system.
+
+That means:
+
+- local providers are valid first-class entries in `providers`
+- `task-intake.direct-brief` may bind to a `kind: local` provider
+- `task-intake.assumption-capture` may also bind to a local provider or generated-skill behavior record
+
+Example:
+
+```yaml
+providers:
+  local-direct-brief:
+    provider: local
+    kind: local
+    decision_state: confirmed
+
+capability_bindings:
+  task-intake.direct-brief:
+    provider_ref: local-direct-brief
+    support: full
+    decision_state: confirmed
+```
+
+This is a core MVP requirement, not an edge case.
+
+## Compatibility With Builder Output
+
+The declaration file should align with the existing metadata bundle.
+
+### Relationship To `inventory.yaml`
+
+- `inventory.yaml` records evidence and normalized signals
+- `integrations.yaml` records the resulting provider-and-capability mapping
+
+### Relationship To `decisions.yaml`
+
+- `decisions.yaml` records the reasoning state of builder choices
+- `integrations.yaml` records the concrete declared outcome for integration mapping
+
+### Relationship To `manifest.yaml`
+
+`manifest.yaml` should reference `integrations.yaml` as part of the generated metadata bundle so the declaration becomes part of the reviewable build artifact.
+
+### Relationship To Generated Skills
+
+Generated skills should rely on the declaration semantically, but they do not need to inline the entire mapping into `SKILL.md`.
+
+The declaration file is the durable source of truth for provider-capability mapping inside the repo.
+
+## Example Declaration
+
+```yaml
+schema_version: 1
+generated_by: skill-builder
+generated_at: 2026-04-15T18:00:00Z
+
+providers:
+  local-direct-brief:
+    provider: local
+    kind: local
+    decision_state: confirmed
+    notes: Direct bootstrap briefs are allowed for greenfield or exploratory work.
+    source:
+      type: builder-input
+      detail: /agent-task <ticket-or-prompt>
+
+  github:
+    provider: github
+    kind: external
+    decision_state: confirmed
+    notes: GitHub is the primary forge and issue system for this repository.
+    source:
+      type: repo-evidence
+      path: .git/config
+      detail: origin=github.com:peakweb-team/pw-agency-agents.git
+
+  coderabbit:
+    provider: coderabbit
+    kind: external
+    decision_state: assumed
+    notes: Review automation appears active but the exact required review path still needs human confirmation.
+
+capability_bindings:
+  task-intake.direct-brief:
+    provider_ref: local-direct-brief
+    support: full
+    decision_state: confirmed
+
+  task-intake.assumption-capture:
+    provider_ref: local-direct-brief
+    support: full
+    decision_state: confirmed
+
+  task-tracker.lookup:
+    provider_ref: github
+    support: full
+    decision_state: confirmed
+
+  task-tracker.read:
+    provider_ref: github
+    support: full
+    decision_state: confirmed
+
+  task-tracker.update:
+    provider_ref: github
+    support: full
+    decision_state: confirmed
+
+  code-host.pr.open:
+    provider_ref: github
+    support: full
+    decision_state: confirmed
+
+  code-host.pr.review-request:
+    provider_ref: github
+    support: full
+    decision_state: confirmed
+
+  review-feedback.read:
+    provider_ref: coderabbit
+    support: partial
+    decision_state: assumed
+    fallback: Fall back to human PR review comments when CodeRabbit is unavailable.
+```
+
+## Unsupported Or Missing Bindings
+
+This document defines the declaration shape, not the full fallback matrix.
+
+For MVP:
+
+- if a capability is unavailable, it may still appear in `capability_bindings` with `support: unavailable`
+- if a workflow decision remains unresolved, the binding may use `decision_state: unresolved`
+- the builder should not silently omit a required capability that materially affects workflow behavior
+
+That explicit behavior keeps the declaration honest and prepares the ground for issue `#19`.
+
+## Recommended Builder Behavior
+
+When generating or regenerating `integrations.yaml`, the builder should:
+
+1. infer likely providers from repository evidence and user input
+2. confirm high-impact mappings through the questionnaire when needed
+3. record whether each provider and binding is confirmed, assumed, or unresolved
+4. keep provider reference ids stable across regenerations when the underlying mapping has not changed
+5. produce deterministic YAML ordering to keep diffs reviewable
+
+## MVP Boundary
+
+This contract intentionally does not define:
+
+- secrets or credentials storage
+- how a provider is authenticated
+- automatic installation or provisioning
+- the complete fallback policy for every missing capability
+
+It does define:
+
+- the repo-local file path
+- the YAML shape
+- the difference between provider entries and capability bindings
+- the distinction between confirmed, assumed, and unresolved mappings
+- compatibility with builder metadata and repo-local versioning

--- a/skills/README.md
+++ b/skills/README.md
@@ -41,6 +41,8 @@ The generated-skill output, naming, and precedence contract now lives in [`docs/
 
 The external capability vocabulary that fragments and generated skills should rely on now lives in [`docs/external-capability-model.md`](../docs/external-capability-model.md).
 
+The repo-local provider and capability binding format now lives in [`docs/project-integration-declaration-format.md`](../docs/project-integration-declaration-format.md).
+
 ## Intended Flow
 
 1. Peakweb Agency Agents is installed into the user's home directory with the base agent roster and reusable skill fragments.

--- a/skills/skill-builder/SKILL.md
+++ b/skills/skill-builder/SKILL.md
@@ -36,6 +36,8 @@ Normalize those findings into explicit builder signals and assign confidence to 
 
 Use those findings to infer which capability families are available for this project under `docs/external-capability-model.md`.
 
+Use the resulting decisions to declare repo-local provider and capability bindings under `docs/project-integration-declaration-format.md`.
+
 Summarize what was detected and what is still unknown.
 
 ### Phase 2: Targeted Questionnaire
@@ -83,6 +85,8 @@ Each generated skill must:
 - prefer repo-local conventions over user-level defaults
 
 The builder metadata bundle must include the inventory record, decision record, fragment lock information, and a human-readable review summary.
+
+When integrations are in scope, the metadata bundle must also include `integrations.yaml` so provider mappings are reviewable and versioned with the project.
 
 ### Phase 5: Handoff
 


### PR DESCRIPTION
## Summary
- add the repo-local integration declaration contract for issue #18
- define `.agency/skills/peakweb/integrations.yaml` with provider entries, capability bindings, and confirmed vs assumed vs unresolved mapping state
- update the capability, builder, and generated-skill docs so the declaration file is part of the metadata bundle contract

## Testing
- not run (docs-only changes)

Closes #18

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Added a new standard format for declaring project integrations and mapping external capabilities to providers.
  * Updated documentation to clarify relationships between inventory tracking, decision records, and integration declarations.
  * Enhanced skill builder workflow to include integration declaration as a required step in the build process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->