### PR TITLE
Define unavailable-capability fallback behavior

### DIFF
--- a/docs/builder-inventory-workflow.md
+++ b/docs/builder-inventory-workflow.md
@@ -11,6 +11,7 @@ It builds directly on:
 - the generated-skill layout contract from issue `#12`
 - the external capability model from issue `#13`
 - the project integration declaration format from issue `#18`
+- the capability fallback contract from issue `#19`
 - the roadmap goal of turning Peakweb into a workflow operating layer instead of a loose prompt library
 
 ## Why This Exists
@@ -92,6 +93,7 @@ Use one or more signals to infer builder decisions such as:
 - whether a repo-local generated skill is likely to need multiple companion fragments
 - whether existing repo-local Claude or Peakweb files should be reviewed before regeneration
 - which capability families are likely available, optional, or unsupported for this repository
+- whether degraded capability support likely implies continue, warn, manual, or fail fallback behavior
 
 The builder should infer choices only when the evidence reaches the confidence threshold defined below.
 

--- a/docs/builder-questionnaire-flow.md
+++ b/docs/builder-questionnaire-flow.md
@@ -12,6 +12,7 @@ It builds on:
 - the generated-skill layout contract from issue `#12`
 - the external capability model from issue `#13`
 - the project integration declaration format from issue `#18`
+- the capability fallback contract from issue `#19`
 
 ## Why This Exists
 
@@ -36,6 +37,7 @@ This document defines the MVP answer so the builder can stay minimal, explicit, 
 - define the builder decision states
 - define how unresolved decisions are recorded in output
 - resolve workflow choices that materially change which capability families the generated skill should rely on
+- surface when degraded integrations should continue, warn, switch to manual mode, or fail
 
 ## Non-Goals
 
@@ -83,6 +85,7 @@ Examples:
 - the user confirms that direct-brief bootstrap should remain available even without an authoritative tracker
 - the user confirms that CodeRabbit is part of the review loop
 - the user confirms that tracked-task updates are required even though direct briefs remain allowed
+- the user confirms that a missing task-tracker update path should be treated as manual mode rather than a blocker
 
 ### `assumed`
 
@@ -119,6 +122,7 @@ Examples:
 - the repository shows no authoritative tracker, but it is unclear whether the generated skill should be direct-brief-first or tracker-optional
 - review automation is referenced, but it is unclear whether it is required or legacy
 - the project clearly needs PR delivery, but it is unclear whether hosted delivery-status signals are required for completion
+- the project may proceed without automated ticket updates, but it is unclear whether that should warn, require manual completion steps, or block the workflow
 
 An unresolved decision should usually create a follow-up question.
 

--- a/docs/capability-fallback-behavior.md
+++ b/docs/capability-fallback-behavior.md
@@ -1,0 +1,393 @@
+# Capability Fallback Behavior
+
+This document defines the proposed contract for issue `#19`:
+
+- [#19 Define unavailable-capability fallback behavior](https://github.com/peakweb-team/pw-agency-agents/issues/19)
+
+It builds on:
+
+- the external capability model in [`docs/external-capability-model.md`](./external-capability-model.md)
+- the project integration declaration format in [`docs/project-integration-declaration-format.md`](./project-integration-declaration-format.md)
+- the builder inventory workflow in [`docs/builder-inventory-workflow.md`](./builder-inventory-workflow.md)
+- the builder questionnaire flow in [`docs/builder-questionnaire-flow.md`](./builder-questionnaire-flow.md)
+- the generated-skill layout contract in [`docs/generated-skill-layout.md`](./generated-skill-layout.md)
+
+## Why This Exists
+
+The capability model defines what generated skills may rely on.
+
+The integration declaration format defines which provider is expected to satisfy each capability.
+
+That still leaves one important question:
+
+What should Peakweb do when the capability is:
+
+- unavailable
+- only partially available
+- or only realistically reachable through a human/manual workflow
+
+This document defines that fallback contract for MVP.
+
+## Goals
+
+- define explicit fallback modes
+- define when the builder should continue, warn, enter manual mode, or fail
+- document how manual-mode expectations should appear in generated output
+- keep generated skills honest about what is and is not automated
+
+## Non-Goals
+
+- implementing provider adapters
+- auto-configuring missing integrations
+- removing human approval from authorization-sensitive workflows
+- defining every provider-specific exception in detail
+
+## Core Principle
+
+Generated skills must degrade explicitly, not silently.
+
+If an expected capability is missing or partial, the generated output should make one of four states clear:
+
+- safe to continue automatically
+- continue, but warn the operator
+- continue only in manual mode
+- do not continue as if the capability exists
+
+## Fallback Modes
+
+The MVP fallback contract uses four modes.
+
+### `continue`
+
+Use when:
+
+- the capability is optional for the current workflow
+- or the missing automation does not materially change correctness
+
+Behavior:
+
+- proceed normally
+- do not block workflow generation
+- note the lower-confidence behavior only if it materially affects review
+
+Example:
+
+- `delivery-status.read` is absent in a repo where hosted delivery signals are informative but not required for completion
+
+### `warn`
+
+Use when:
+
+- the workflow can still proceed safely
+- but the missing or partial capability materially reduces visibility, convenience, or confidence
+
+Behavior:
+
+- continue generating the workflow
+- record the warning in builder output
+- make the generated skill call out the limitation where the operator needs to compensate
+
+Example:
+
+- `review-feedback.read` is partial, so the workflow can proceed with human PR review, but bot-review coverage may be incomplete
+
+### `manual`
+
+Use when:
+
+- the workflow can still proceed
+- but a meaningful step must be performed or verified by a human outside Peakweb automation
+
+Behavior:
+
+- continue generating the workflow
+- mark the capability as manual-mode dependent
+- include explicit manual expectations and handoff language
+
+Example:
+
+- `task-tracker.update` is only reachable through a human-managed Jira workflow outside the current toolchain
+
+### `fail`
+
+Use when:
+
+- the workflow depends on the capability for correctness or truthfulness
+- and no safe automatic or manual fallback has been established
+
+Behavior:
+
+- do not generate misleading instructions that assume the capability exists
+- leave the relevant decision unresolved
+- surface the blocking condition in builder output
+
+Example:
+
+- a tracked-task-only workflow without any usable `task-tracker.read`
+
+## Decision Factors
+
+Fallback mode should be chosen using three inputs together.
+
+### 1. Capability Support Level
+
+From `integrations.yaml`:
+
+- `full`
+- `partial`
+- `unavailable`
+
+### 2. Workflow Dependency Level
+
+The builder should treat each capability as one of:
+
+- `required`
+- `important-but-optional`
+- `optional`
+
+This dependency level is determined by the selected intake mode, fragments, and workflow expectations.
+
+### 3. Alternate Path Type
+
+The builder should check whether a safe alternate path exists:
+
+- `automatic`
+- `manual`
+- `none`
+
+## Recommended Fallback Matrix
+
+### Rule 1: Full Support Normally Continues
+
+If support is `full`, fallback mode should normally be:
+
+- `continue`
+
+Unless:
+
+- the workflow still depends on a human approval boundary that must be called out separately
+
+### Rule 2: Partial Support Usually Warns Or Goes Manual
+
+If support is `partial`:
+
+- use `warn` when the missing surface reduces convenience or confidence but not core correctness
+- use `manual` when the missing surface requires a human to complete or verify a workflow step
+- use `fail` only when the unsupported portion makes the workflow misleading or unsafe
+
+### Rule 3: Unavailable Support Requires Alternate Path Evaluation
+
+If support is `unavailable`:
+
+- use `continue` only when the capability is genuinely optional
+- use `warn` when a safe automatic alternate path exists
+- use `manual` when a safe human path exists and should be made explicit
+- use `fail` when no safe path exists
+
+## Warning vs Fail vs Continue Guidance
+
+### Continue
+
+Choose `continue` when:
+
+- the workflow still means the same thing
+- the capability is supplemental rather than foundational
+- omission does not create a false claim about what Peakweb can do
+
+### Warn
+
+Choose `warn` when:
+
+- the operator should know the workflow is degraded
+- but the next safe step is still obvious
+- the system can still produce honest instructions
+
+Warnings should be visible in:
+
+- `integrations.yaml`
+- `decisions.yaml`
+- `review.md`
+
+### Manual
+
+Choose `manual` when:
+
+- a human must take a real action
+- or a human must verify the outcome of an action that Peakweb cannot perform directly
+
+Manual mode is not failure.
+
+It is an explicit handoff state.
+
+### Fail
+
+Choose `fail` when:
+
+- the generated workflow would otherwise claim unsupported behavior
+- the workflow would lose its system of record or review-of-record truth
+- or the operator would not know how to proceed safely
+
+## Manual-Mode Expectations
+
+Manual mode must be concrete enough that a human reviewer or operator knows what Peakweb did not do.
+
+When a capability falls into manual mode, the generated output should include:
+
+### 1. Clear Manual Boundary
+
+State plainly that the capability is not automated in the current project configuration.
+
+Example:
+
+- `task-tracker.update` is manual for this project; post the final status update in Jira yourself.
+
+### 2. Required Human Action
+
+Describe the specific manual step.
+
+Examples:
+
+- post the ticket update
+- request the reviewer manually
+- verify hosted checks in the code host UI
+
+### 3. Completion Semantics
+
+State whether Peakweb may still proceed with the rest of the workflow before that manual step is complete.
+
+Examples:
+
+- continue implementation, but do not mark the task complete until the human update is posted
+- continue PR preparation, but do not claim review has been requested automatically
+
+### 4. Review Visibility
+
+Manual-mode steps should appear in:
+
+- `integrations.yaml`
+- `review.md`
+- generated skill instructions if the step is likely to recur in normal use
+
+## Recommended Binding Fields In `integrations.yaml`
+
+To support fallback reviewability, capability bindings may include:
+
+### `fallback_mode`
+
+- Type: enum string
+- Allowed values:
+  - `continue`
+  - `warn`
+  - `manual`
+  - `fail`
+- Purpose: record the selected fallback behavior for that capability in the current project
+
+### `manual_steps`
+
+- Type: array of strings
+- Purpose: list concrete human actions required when `fallback_mode: manual`
+
+### `warning`
+
+- Type: string
+- Purpose: short operator-facing warning when `fallback_mode: warn`
+
+These fields extend the declaration format without changing its basic provider-binding structure.
+
+## Family-Specific MVP Guidance
+
+### Task Intake
+
+- Missing `task-intake.direct-brief` in a tracked-task-only workflow may still be `continue`
+- Missing `task-tracker.read` in a tracked-task-only workflow should usually be `fail`
+- Missing tracked-task support in a dual-intake workflow may be `manual` or `warn` if direct-brief remains safe
+
+### Task Tracker
+
+- Missing `task-tracker.lookup` or `task-tracker.read` in a tracked-task-first workflow should usually be `fail`
+- Missing `task-tracker.update` often becomes `manual` rather than `fail` if the rest of the tracked-task workflow is still usable
+
+### Code Host / PR
+
+- Missing `code-host.pr.open` in a PR-based workflow is usually `manual` if a human can open the PR safely
+- Missing `code-host.pr.update` is often `warn` or `manual`
+- Missing `code-host.pr.review-request` is often `manual`
+
+### Review Feedback
+
+- Partial `review-feedback.read` usually becomes `warn`
+- Missing `review-feedback.respond` is often `manual`
+- Completely missing review feedback in a review-driven workflow may become `fail` if no human-visible review queue remains
+
+### Delivery And Validation
+
+- Missing `delivery-status.read` is often `warn` unless hosted gates are mandatory
+- Missing `validation-signal.read` is often `manual` when humans can still inspect CI or local validation output directly
+
+## Builder Output Expectations
+
+When fallback behavior matters, the builder should record it in multiple places.
+
+### `integrations.yaml`
+
+Record:
+
+- support level
+- fallback mode
+- manual steps or warnings when applicable
+
+### `decisions.yaml`
+
+Record:
+
+- why the fallback mode was chosen
+- whether it was confirmed, assumed, or unresolved
+
+### `review.md`
+
+Highlight:
+
+- degraded integrations
+- manual steps required before completion
+- any capabilities that block full workflow automation
+
+## Example
+
+```yaml
+capability_bindings:
+  task-tracker.update:
+    provider_ref: jira
+    support: unavailable
+    decision_state: confirmed
+    fallback_mode: manual
+    manual_steps:
+      - Post the final delivery update in Jira manually before marking the work complete.
+
+  review-feedback.read:
+    provider_ref: github
+    support: partial
+    decision_state: assumed
+    fallback_mode: warn
+    warning: Bot-review coverage is partial; confirm unresolved human PR feedback before closing the loop.
+
+  task-tracker.read:
+    provider_ref: jira
+    support: unavailable
+    decision_state: unresolved
+    fallback_mode: fail
+```
+
+## MVP Boundary
+
+This contract defines:
+
+- fallback modes
+- warning vs manual vs fail vs continue behavior
+- manual-mode expectations
+- how fallback state should surface in builder metadata
+
+It does not define:
+
+- provider-specific implementation details
+- a full automation policy for every future workflow
+- human authorization policy outside the capability scope itself

--- a/docs/external-capability-model.md
+++ b/docs/external-capability-model.md
@@ -11,6 +11,7 @@ It builds on:
 - the fragment metadata contract in [`docs/fragment-schema.md`](./fragment-schema.md)
 - the builder inventory workflow in [`docs/builder-inventory-workflow.md`](./builder-inventory-workflow.md)
 - the builder questionnaire flow in [`docs/builder-questionnaire-flow.md`](./builder-questionnaire-flow.md)
+- the capability fallback contract in [`docs/capability-fallback-behavior.md`](./capability-fallback-behavior.md)
 - the roadmap direction toward capability-oriented workflow behavior instead of vendor-bound prompts
 
 ## Why This Exists
@@ -375,11 +376,11 @@ Examples:
 - a tracked-task-only workflow without `task-tracker.read`
 - a review-driven PR workflow without any usable review-feedback path
 
-### 5. Leave Detailed Fallback Policy To Follow-On Work
+### 5. Use The Shared Fallback Contract
 
 This document defines the baseline behavior only.
 
-The more detailed fallback matrix belongs to issue `#19`.
+The detailed fallback matrix now lives in [`docs/capability-fallback-behavior.md`](./capability-fallback-behavior.md).
 
 ## Recommended Capability Vocabulary For Fragments
 

--- a/docs/generated-skill-layout.md
+++ b/docs/generated-skill-layout.md
@@ -11,6 +11,7 @@ It builds on:
 - the builder inventory workflow in [`docs/builder-inventory-workflow.md`](./builder-inventory-workflow.md)
 - the builder questionnaire flow in [`docs/builder-questionnaire-flow.md`](./builder-questionnaire-flow.md)
 - the project integration declaration format in [`docs/project-integration-declaration-format.md`](./project-integration-declaration-format.md)
+- the capability fallback contract in [`docs/capability-fallback-behavior.md`](./capability-fallback-behavior.md)
 - the roadmap direction toward a workflow operating system instead of a loose prompt library
 
 ## Why This Exists
@@ -177,6 +178,8 @@ The MVP metadata bundle should include:
   - human-readable summary of why the skills were generated this way and what should be reviewed manually
 
 These files make generated output reviewable, diffable, and regenerable.
+
+When integrations are degraded, the metadata bundle should make fallback mode, warnings, and manual steps reviewable rather than burying them in prose.
 
 ## Precedence Rules
 

--- a/docs/project-integration-declaration-format.md
+++ b/docs/project-integration-declaration-format.md
@@ -11,6 +11,7 @@ It builds on:
 - the builder inventory workflow in [`docs/builder-inventory-workflow.md`](./builder-inventory-workflow.md)
 - the builder questionnaire flow in [`docs/builder-questionnaire-flow.md`](./builder-questionnaire-flow.md)
 - the external capability model in [`docs/external-capability-model.md`](./external-capability-model.md)
+- the capability fallback contract in [`docs/capability-fallback-behavior.md`](./capability-fallback-behavior.md)
 
 ## Why This Exists
 
@@ -118,6 +119,7 @@ capability_bindings:
     provider_ref: github
     support: partial
     decision_state: assumed
+    fallback_mode: warn
     notes: Human review is confirmed, but bot-review coverage is still assumed.
 ```
 
@@ -273,6 +275,26 @@ Optional fields:
 
 - Type: string
 - Purpose: short description of the safe alternate path if support is partial or unavailable
+
+### `fallback_mode`
+
+- Type: enum string
+- Purpose: record the selected fallback behavior for that capability
+- Allowed values:
+  - `continue`
+  - `warn`
+  - `manual`
+  - `fail`
+
+### `warning`
+
+- Type: string
+- Purpose: short operator-facing warning when degraded support should remain visible but not block execution
+
+### `manual_steps`
+
+- Type: array of strings
+- Purpose: list concrete human actions required when the capability falls back to manual mode
 
 ### `source`
 
@@ -441,6 +463,7 @@ capability_bindings:
     provider_ref: coderabbit
     support: partial
     decision_state: assumed
+    fallback_mode: warn
     fallback: Fall back to human PR review comments when CodeRabbit is unavailable.
 ```
 
@@ -452,9 +475,10 @@ For MVP:
 
 - if a capability is unavailable, it may still appear in `capability_bindings` with `support: unavailable`
 - if a workflow decision remains unresolved, the binding may use `decision_state: unresolved`
+- fallback handling should be expressed with `fallback_mode` and optional `warning` or `manual_steps` fields
 - the builder should not silently omit a required capability that materially affects workflow behavior
 
-That explicit behavior keeps the declaration honest and prepares the ground for issue `#19`.
+That explicit behavior keeps the declaration honest and aligns it with [`docs/capability-fallback-behavior.md`](./capability-fallback-behavior.md).
 
 ## Recommended Builder Behavior
 
@@ -473,7 +497,7 @@ This contract intentionally does not define:
 - secrets or credentials storage
 - how a provider is authenticated
 - automatic installation or provisioning
-- the complete fallback policy for every missing capability
+- the complete provider-specific fallback policy for every missing capability
 
 It does define:
 

--- a/skills/README.md
+++ b/skills/README.md
@@ -43,6 +43,8 @@ The external capability vocabulary that fragments and generated skills should re
 
 The repo-local provider and capability binding format now lives in [`docs/project-integration-declaration-format.md`](../docs/project-integration-declaration-format.md).
 
+The fallback rules for unavailable, partial, or manual-only capabilities now live in [`docs/capability-fallback-behavior.md`](../docs/capability-fallback-behavior.md).
+
 ## Intended Flow
 
 1. Peakweb Agency Agents is installed into the user's home directory with the base agent roster and reusable skill fragments.

--- a/skills/skill-builder/SKILL.md
+++ b/skills/skill-builder/SKILL.md
@@ -38,6 +38,8 @@ Use those findings to infer which capability families are available for this pro
 
 Use the resulting decisions to declare repo-local provider and capability bindings under `docs/project-integration-declaration-format.md`.
 
+Use `docs/capability-fallback-behavior.md` to decide whether degraded capability support should continue, warn, switch to manual mode, or fail.
+
 Summarize what was detected and what is still unknown.
 
 ### Phase 2: Targeted Questionnaire
@@ -87,6 +89,8 @@ Each generated skill must:
 The builder metadata bundle must include the inventory record, decision record, fragment lock information, and a human-readable review summary.
 
 When integrations are in scope, the metadata bundle must also include `integrations.yaml` so provider mappings are reviewable and versioned with the project.
+
+If a capability is degraded or unavailable, the metadata bundle must make the fallback mode and any manual steps visible.
 
 ### Phase 5: Handoff
 


### PR DESCRIPTION
## Summary
- add the fallback behavior contract for issue #19
- define continue, warn, manual, and fail modes for degraded capability support
- update the capability, integration declaration, builder, and generated-skill docs so fallback behavior is recorded in repo-local metadata

## Testing
- not run (docs-only changes)

Closes #19

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Added comprehensive capability fallback behavior specification defining four configurable modes—continue, warn, manual, and fail—for handling unavailable or partially available external capabilities.
  * Updated builder workflows and integration configuration format to incorporate fallback planning and explicitly declare fallback behavior and manual steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->