### PR TITLE
Add first code-host and review provider fragment set

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -119,6 +119,7 @@ Goals:
 - keep task-system provider fragments optional companions to direct-brief intake rather than a hard prerequisite
 - support major code-hosting and PR systems such as GitHub, GitLab, and Bitbucket
 - support common review patterns such as native review, CodeRabbit, and layered review automation
+- keep first-wave provider-fragment guidance split between task-system and code-host/review contracts (see [`docs/task-system-provider-fragment-set.md`](./docs/task-system-provider-fragment-set.md) and [`docs/code-host-review-provider-fragment-set.md`](./docs/code-host-review-provider-fragment-set.md))
 - make provider selection part of builder output rather than hardcoded defaults
 
 Non-goals:

--- a/docs/builder-inventory-workflow.md
+++ b/docs/builder-inventory-workflow.md
@@ -14,6 +14,7 @@ It builds directly on:
 - the project integration declaration format from issue `#18`
 - the capability fallback contract from issue `#19`
 - the first-wave task-system provider fragment set in [`docs/task-system-provider-fragment-set.md`](./task-system-provider-fragment-set.md)
+- the first-wave code-host/review provider fragment set in [`docs/code-host-review-provider-fragment-set.md`](./code-host-review-provider-fragment-set.md)
 - the roadmap goal of turning Peakweb into a workflow operating layer instead of a loose prompt library
 
 ## Why This Exists

--- a/docs/builder-questionnaire-flow.md
+++ b/docs/builder-questionnaire-flow.md
@@ -15,6 +15,7 @@ It builds on:
 - the project integration declaration format from issue `#18`
 - the capability fallback contract from issue `#19`
 - the first-wave task-system provider fragment set in [`docs/task-system-provider-fragment-set.md`](./task-system-provider-fragment-set.md)
+- the first-wave code-host/review provider fragment set in [`docs/code-host-review-provider-fragment-set.md`](./code-host-review-provider-fragment-set.md)
 
 ## Why This Exists
 

--- a/docs/capability-fallback-behavior.md
+++ b/docs/capability-fallback-behavior.md
@@ -11,6 +11,7 @@ It builds on:
 - the builder inventory workflow in [`docs/builder-inventory-workflow.md`](./builder-inventory-workflow.md)
 - the builder questionnaire flow in [`docs/builder-questionnaire-flow.md`](./builder-questionnaire-flow.md)
 - the first-wave task-system fragment set in [`docs/task-system-provider-fragment-set.md`](./task-system-provider-fragment-set.md)
+- the first-wave code-host/review fragment set in [`docs/code-host-review-provider-fragment-set.md`](./code-host-review-provider-fragment-set.md)
 - the generated-skill layout contract in [`docs/generated-skill-layout.md`](./generated-skill-layout.md)
 
 ## Why This Exists

--- a/docs/code-host-review-provider-fragment-set.md
+++ b/docs/code-host-review-provider-fragment-set.md
@@ -1,0 +1,228 @@
+# First Code-Host And Review Provider Fragment Set
+
+This document defines the proposed contract for issue `#21`:
+
+- [#21 Add first code-host and review provider fragment set](https://github.com/peakweb-team/pw-agency-agents/issues/21)
+
+It builds on:
+
+- the canonical capabilities in [`docs/external-capability-model.md`](./external-capability-model.md)
+- fallback behavior in [`docs/capability-fallback-behavior.md`](./capability-fallback-behavior.md)
+- integration declaration mapping in [`docs/project-integration-declaration-format.md`](./project-integration-declaration-format.md)
+- fragment metadata and composition contracts in [`docs/fragment-schema.md`](./fragment-schema.md) and [`docs/fragment-assembly-rules.md`](./fragment-assembly-rules.md)
+- first-wave provider prioritization in [`docs/provider-matrix.md`](./provider-matrix.md)
+- first-wave task-system provider fragments in [`docs/task-system-provider-fragment-set.md`](./task-system-provider-fragment-set.md)
+
+## Why This Exists
+
+Issue `#17` selected the first provider wave.
+
+Issue `#20` defined first-wave task-system fragments.
+
+Issue `#21` defines the matching first-wave code-host and review fragment set so PR creation, review routing, and review-loop behavior are explicit and capability-oriented.
+
+## Scope Boundary
+
+This document defines code-host and review provider fragments for:
+
+- GitHub Pull Requests with native host review as the review system of record
+- CodeRabbit as optional layered review automation on top of native review
+
+It does not redefine task-intake mode selection or task-system source-of-truth behavior.
+
+Those stay governed by [`docs/task-system-provider-fragment-set.md`](./task-system-provider-fragment-set.md), [`docs/external-capability-model.md`](./external-capability-model.md), and [`docs/provider-matrix.md`](./provider-matrix.md).
+
+## Core Rules
+
+### Canonical Capability Mapping Is Required
+
+Code-host and review provider fragments in this first set map behavior to canonical capabilities:
+
+- `code-host.pr.open`
+- `code-host.pr.update`
+- `code-host.pr.review-request`
+- `code-host.pr.status-read`
+- `review-feedback.read`
+- `review-feedback.respond`
+
+They may also declare bounded contribution to:
+
+- `delivery-status.read`
+- `validation-signal.read`
+
+Provider-specific wording may differ, but fragment metadata and generated-skill output should always map behavior back to canonical capability ids.
+
+### Human-Facing Review State Is External; Internal Agent Coordination Is Local
+
+Code-host and review fragments are for durable human-facing review and status updates in external systems of record.
+
+They are not the channel for local multi-agent or sub-agent coordination.
+
+External review/system-of-record updates should include reviewer-visible progress, response-to-feedback outcomes, and final review-ready context.
+
+Internal planning, subtask routing, handoffs between local agents, and execution-level chatter should remain in local runtime coordination.
+
+### Native Review Is Baseline Record; Layered Automation Is Additive
+
+Native code-host review remains the baseline review system of record in this first set.
+
+Layered automation such as CodeRabbit is additive review input.
+
+Do not claim parity where it does not exist:
+
+- CodeRabbit does not replace `code-host.pr.*` ownership.
+- CodeRabbit findings may enrich review queues and validation signals.
+- Final review-of-record state still comes from native host review and host status surfaces.
+
+### Code-Host And Review Fragments Are Optional Companions To Intake Mode
+
+Code-host/review fragments are additive to selected intake and tracker fragments.
+
+Generated skills must still support direct-brief-first and dual-intake paths when those are selected.
+
+No repository should be forced into tracker-first intake as a prerequisite for PR/review guidance.
+
+## First-Wave Code-Host And Review Provider Fragments
+
+| Fragment id | Provider | Fragment type | Layer | Canonical capabilities | Primary role |
+| --- | --- | --- | --- | --- | --- |
+| `delivery/github-pull-requests` | GitHub | `provider` | `delivery` | `code-host.pr.open`, `code-host.pr.update`, `code-host.pr.review-request`, `code-host.pr.status-read`, `review-feedback.read`, `review-feedback.respond` | Open and maintain PRs in GitHub, route review requests, read host-native review and status, and keep visible review follow-through in the PR system of record. |
+| `delivery/coderabbit-layered-review` | CodeRabbit | `provider` | `delivery` | `review-feedback.read`, `review-feedback.respond` (both additive/partial) | Add automated review findings to the review loop while keeping host-native review as authoritative record. |
+
+Recommended composition behavior:
+
+- `delivery/github-pull-requests` should participate in `composition.exclusive_within: primary-code-host-review`.
+- `delivery/coderabbit-layered-review` should not replace the primary code-host/review fragment; it should compose as an optional layered companion.
+
+## Provider Responsibilities By Capability
+
+### GitHub Pull Requests Fragment Responsibilities
+
+- `code-host.pr.open`
+  - Create PRs with reviewer-ready summary context and links to tracked task or direct brief artifacts when available.
+- `code-host.pr.update`
+  - Keep PR title/body/metadata aligned with current implementation and verification state.
+- `code-host.pr.review-request`
+  - Route the PR into the expected reviewer path (maintainers/teams and repo-specific review flow).
+- `code-host.pr.status-read`
+  - Read review state, check outcomes, and merge-readiness state from host-native surfaces.
+- `review-feedback.read`
+  - Read unresolved human review comments and relevant automation comments visible in the PR.
+- `review-feedback.respond`
+  - Post visible follow-up responses in the PR conversation and resolve review threads where host behavior supports it.
+
+### CodeRabbit Layered Review Responsibilities
+
+- `review-feedback.read` (additive)
+  - Surface actionable CodeRabbit findings as layered review input.
+  - Preserve uncertainty when findings are partial or when coverage is unavailable for parts of a change.
+- `review-feedback.respond` (additive)
+  - Support visible follow-up acknowledgments where project policy expects bot-feedback handling.
+  - Do not present bot-response paths as equivalent to host-native reviewer approvals.
+
+Capability boundaries for layered review:
+
+- `code-host.pr.open`, `code-host.pr.update`, `code-host.pr.review-request`, and `code-host.pr.status-read` remain owned by the primary code host fragment.
+- `delivery-status.read` and `validation-signal.read` may receive useful contribution from layered review findings, but should still be sourced from host checks and CI/deploy evidence as primary completion signals.
+
+## Fallback Expectations For This Fragment Set
+
+Fallback outcomes must follow [`docs/capability-fallback-behavior.md`](./capability-fallback-behavior.md).
+
+Recommended behavior for first-wave code-host/review fragments:
+
+| Capability | Support situation | Recommended fallback mode | Builder / generated-skill expectation |
+| --- | --- | --- | --- |
+| `code-host.pr.open` | unavailable from configured automation path but human can open PR | `manual` | Continue implementation, require explicit human PR creation before claiming review-ready delivery path. |
+| `code-host.pr.update` | partial metadata update support | `warn` | Continue with explicit note that some PR metadata updates are manual. |
+| `code-host.pr.review-request` | unavailable or policy-routed outside automation | `manual` | Continue with explicit human review-request step before claiming review-loop handoff is complete. |
+| `code-host.pr.status-read` | partial status/readback visibility | `warn` | Continue with warning and require explicit host-UI verification for missing status surfaces. |
+| `review-feedback.read` | partial layered coverage with native review still available | `warn` | Continue using native review queue as baseline; treat bot findings as additive. |
+| `review-feedback.respond` | unavailable for layered automation while native responses remain available | `manual` | Continue with manual response path for layered findings if project policy requires bot-thread follow-up. |
+| `delivery-status.read` | no dependable external delivery signal source | `warn` | Do not over-claim delivery certainty; require explicit reviewer/operator verification of delivery gates. |
+| `validation-signal.read` | partial validation signal visibility | `warn` | Continue with explicit validation visibility warning and rely on local/CI evidence collection. |
+
+## Integration Declaration Expectations
+
+When a project uses this fragment set, `.agency/skills/peakweb/integrations.yaml` should:
+
+- keep direct-brief intake bindings present when direct-brief mode is selected
+- map `code-host.pr.*` capabilities to one primary code-host provider (`github` in first-wave scope)
+- map `review-feedback.*` either to native host review or to layered provider entries with explicit additive boundaries
+- use `support`, `decision_state`, and `fallback_mode` to avoid parity overclaims for layered automation
+- keep `delivery-status.read` / `validation-signal.read` bound to the best available source, with warnings when coverage is degraded
+
+Example (GitHub primary review-of-record with CodeRabbit layered input):
+
+```yaml
+providers:
+  local-direct-brief:
+    provider: local
+    kind: local
+    decision_state: confirmed
+
+  github:
+    provider: github
+    kind: external
+    decision_state: confirmed
+
+  coderabbit:
+    provider: coderabbit
+    kind: external
+    decision_state: assumed
+    notes: Layered review automation is additive to native GitHub review.
+
+capability_bindings:
+  task-intake.direct-brief:
+    provider_ref: local-direct-brief
+    support: full
+    decision_state: confirmed
+
+  code-host.pr.open:
+    provider_ref: github
+    support: full
+    decision_state: confirmed
+
+  code-host.pr.update:
+    provider_ref: github
+    support: full
+    decision_state: confirmed
+
+  code-host.pr.review-request:
+    provider_ref: github
+    support: full
+    decision_state: confirmed
+
+  code-host.pr.status-read:
+    provider_ref: github
+    support: full
+    decision_state: confirmed
+
+  review-feedback.read:
+    provider_ref: coderabbit
+    support: partial
+    decision_state: assumed
+    fallback_mode: warn
+    warning: Use native GitHub review queue as baseline; CodeRabbit coverage is additive.
+
+  review-feedback.respond:
+    provider_ref: github
+    support: full
+    decision_state: confirmed
+```
+
+## Builder Selection And Questionnaire Alignment
+
+Inventory, questionnaire, and assembly phases should keep these behaviors consistent with existing contracts:
+
+- infer candidate code-host/review fragments from forge, PR, and review-automation signals
+- ask follow-up questions when native-only and layered-review paths are both plausible but policy expectations are unclear
+- preserve unresolved state instead of forcing parity assumptions for layered automation
+- keep direct-brief and task-system intake decisions independent from code-host/review fragment selection
+
+## Non-Goals For This First Set
+
+- full first-wave parity for GitLab or Bitbucket code-host fragments
+- treating CodeRabbit as a standalone system of record for PR state or human approval
+- mirroring local sub-agent coordination into external PR comments as default behavior
+- requiring task-system fragments as a prerequisite for code-host/review fragment inclusion

--- a/docs/external-capability-model.md
+++ b/docs/external-capability-model.md
@@ -13,6 +13,7 @@ It builds on:
 - the builder questionnaire flow in [`docs/builder-questionnaire-flow.md`](./builder-questionnaire-flow.md)
 - the capability fallback contract in [`docs/capability-fallback-behavior.md`](./capability-fallback-behavior.md)
 - the first-wave task-system fragment set in [`docs/task-system-provider-fragment-set.md`](./task-system-provider-fragment-set.md)
+- the first-wave code-host/review fragment set in [`docs/code-host-review-provider-fragment-set.md`](./code-host-review-provider-fragment-set.md)
 - the roadmap direction toward capability-oriented workflow behavior instead of vendor-bound prompts
 
 ## Why This Exists

--- a/docs/fragment-assembly-rules.md
+++ b/docs/fragment-assembly-rules.md
@@ -13,6 +13,7 @@ It builds on:
 - the project integration declaration format in [`docs/project-integration-declaration-format.md`](./project-integration-declaration-format.md)
 - the capability fallback contract in [`docs/capability-fallback-behavior.md`](./capability-fallback-behavior.md)
 - the first-wave task-system provider fragment set in [`docs/task-system-provider-fragment-set.md`](./task-system-provider-fragment-set.md)
+- the first-wave code-host/review provider fragment set in [`docs/code-host-review-provider-fragment-set.md`](./code-host-review-provider-fragment-set.md)
 - the Claude-first MVP direction in [`docs/claude-first-mvp-strategy.md`](./claude-first-mvp-strategy.md)
 
 ## Why This Exists

--- a/docs/fragment-schema.md
+++ b/docs/fragment-schema.md
@@ -12,6 +12,7 @@ It is intentionally shaped by:
 - the product direction in [`ROADMAP.md`](../ROADMAP.md)
 - the assembly contract in [`docs/fragment-assembly-rules.md`](./fragment-assembly-rules.md)
 - the first-wave task-system provider fragment set in [`docs/task-system-provider-fragment-set.md`](./task-system-provider-fragment-set.md)
+- the first-wave code-host/review provider fragment set in [`docs/code-host-review-provider-fragment-set.md`](./code-host-review-provider-fragment-set.md)
 
 The goal is not to make fragments abstract for abstraction's sake. The goal is to give Peakweb a small, deterministic contract that can support:
 
@@ -140,8 +141,11 @@ Every fragment must define the following fields.
   - `task-tracker.read`
   - `task-tracker.update`
   - `code-host.pr.open`
+  - `code-host.pr.update`
   - `code-host.pr.review-request`
+  - `code-host.pr.status-read`
   - `review-feedback.read`
+  - `review-feedback.respond`
   - `validation-signal.read`
   - `delivery.pr-review`
   - `orchestration.team-sizing`

--- a/docs/project-integration-declaration-format.md
+++ b/docs/project-integration-declaration-format.md
@@ -13,6 +13,7 @@ It builds on:
 - the external capability model in [`docs/external-capability-model.md`](./external-capability-model.md)
 - the capability fallback contract in [`docs/capability-fallback-behavior.md`](./capability-fallback-behavior.md)
 - the first-wave task-system fragment set in [`docs/task-system-provider-fragment-set.md`](./task-system-provider-fragment-set.md)
+- the first-wave code-host/review fragment set in [`docs/code-host-review-provider-fragment-set.md`](./code-host-review-provider-fragment-set.md)
 
 ## Why This Exists
 

--- a/docs/provider-matrix.md
+++ b/docs/provider-matrix.md
@@ -10,6 +10,7 @@ It builds on:
 - fallback behavior in [`docs/capability-fallback-behavior.md`](./capability-fallback-behavior.md)
 - the project integration declaration contract in [`docs/project-integration-declaration-format.md`](./project-integration-declaration-format.md)
 - the first-wave task-system fragment contract in [`docs/task-system-provider-fragment-set.md`](./task-system-provider-fragment-set.md)
+- the first-wave code-host/review fragment contract in [`docs/code-host-review-provider-fragment-set.md`](./code-host-review-provider-fragment-set.md)
 - the delivery-platform coverage goals in [`ROADMAP.md`](../ROADMAP.md)
 
 ## Why This Exists
@@ -89,6 +90,11 @@ Use these criteria together:
 2. Jira as additional task-system provider for mixed Jira/GitHub organizations.
 3. CodeRabbit as optional layered review provider on top of native host review.
 4. Local direct-brief intake remains always-on baseline (`task-intake.*`), independent of external systems.
+
+First-wave provider-fragment guidance is split into:
+
+- task-system fragments in [`docs/task-system-provider-fragment-set.md`](./task-system-provider-fragment-set.md)
+- code-host and review fragments in [`docs/code-host-review-provider-fragment-set.md`](./code-host-review-provider-fragment-set.md)
 
 ### Out Of First Wave (Defer)
 

--- a/docs/task-system-provider-fragment-set.md
+++ b/docs/task-system-provider-fragment-set.md
@@ -11,6 +11,7 @@ It builds on:
 - integration declaration mapping in [`docs/project-integration-declaration-format.md`](./project-integration-declaration-format.md)
 - fragment metadata and composition contracts in [`docs/fragment-schema.md`](./fragment-schema.md) and [`docs/fragment-assembly-rules.md`](./fragment-assembly-rules.md)
 - first-wave provider prioritization in [`docs/provider-matrix.md`](./provider-matrix.md)
+- first-wave code-host/review provider fragments in [`docs/code-host-review-provider-fragment-set.md`](./code-host-review-provider-fragment-set.md)
 
 ## Why This Exists
 
@@ -29,7 +30,7 @@ This document defines task-system provider fragments for:
 
 It does not redefine code-host or review-system fragments.
 
-Those remain covered by existing provider-matrix and capability docs.
+Those remain covered by existing provider-matrix and capability docs, plus the first-wave code-host/review fragment set in [`docs/code-host-review-provider-fragment-set.md`](./code-host-review-provider-fragment-set.md).
 
 ## Core Rules
 


### PR DESCRIPTION
## Summary
- add docs/code-host-review-provider-fragment-set.md as the #21 contract for first-wave code-host/review provider fragments
- define canonical capability mapping for code-host.pr.* and review-feedback.* with contribution boundaries for delivery-status.read and validation-signal.read
- clarify external human-facing review/system-of-record updates vs local internal agent/sub-agent coordination
- codify native review as baseline record and CodeRabbit as optional layered additive automation without parity over-claims
- keep task-system fragments optional companions to direct-brief intake and cross-link contract docs for coherence

## Testing
- docs consistency pass (cross-link and capability mapping review)

Closes #21

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive documentation for code-host and review provider fragments, establishing contracts for first-wave provider support including GitHub PR hosting and optional CodeRabbit review automation.
  * Updated related documentation to reference the new provider fragment set specification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->