### PR TITLE
Define solo/sub-agent/agent-team orchestration rubric

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -136,7 +136,7 @@ Teach the system to choose the smallest capable team and coordinate work across 
 
 Goals:
 
-- define solo vs small-team vs expanded-team heuristics
+- define canonical `solo`, `sub-agent`, and `agent-team` heuristics (see [`docs/orchestration-execution-rubric.md`](./docs/orchestration-execution-rubric.md))
 - map task characteristics to likely agent roles and specialist needs
 - define handoff expectations between implementers, reviewers, and validators
 - keep team formation proportionate to task scope and risk

--- a/docs/builder-inventory-workflow.md
+++ b/docs/builder-inventory-workflow.md
@@ -11,6 +11,7 @@ It builds directly on:
 - the fragment assembly contract from issue `#16`
 - the generated-skill layout contract from issue `#12`
 - the external capability model from issue `#13`
+- the orchestration tiering rubric in [`docs/orchestration-execution-rubric.md`](./orchestration-execution-rubric.md)
 - the project integration declaration format from issue `#18`
 - the capability fallback contract from issue `#19`
 - the first-wave task-system provider fragment set in [`docs/task-system-provider-fragment-set.md`](./task-system-provider-fragment-set.md)
@@ -76,6 +77,8 @@ Example normalized signals:
 - `repo.monorepo`
 - `workflow.pull_requests`
 - `workflow.parallel_agents`
+- `workflow.parallel_work_bounded`
+- `workflow.peer_coordination_required`
 - `workflow.model_budget_matters`
 - `review.coderabbit`
 - `docs.references_jira_workflows`
@@ -245,6 +248,8 @@ Common signals:
 - `repo.multi_package`
 - `repo.multi_language`
 - `repo.cross_functional_changes_likely`
+- `workflow.parallel_work_bounded`
+- `workflow.peer_coordination_required`
 - `repo.local_skills_present`
 
 Typical evidence sources:

--- a/docs/builder-questionnaire-flow.md
+++ b/docs/builder-questionnaire-flow.md
@@ -12,6 +12,7 @@ It builds on:
 - the fragment assembly contract from issue `#16`
 - the generated-skill layout contract from issue `#12`
 - the external capability model from issue `#13`
+- the orchestration tiering rubric in [`docs/orchestration-execution-rubric.md`](./orchestration-execution-rubric.md)
 - the project integration declaration format from issue `#18`
 - the capability fallback contract from issue `#19`
 - the first-wave task-system provider fragment set in [`docs/task-system-provider-fragment-set.md`](./task-system-provider-fragment-set.md)
@@ -187,16 +188,16 @@ Examples:
 
 Question goal:
 
-- determine whether the generated skill should bias toward solo execution or explicit specialist-team coordination
+- determine whether the generated skill should default to `solo`, escalate to `sub-agent` for bounded parallel work, or reserve `agent-team` for richer peer coordination cases
 
 Ask when:
 
-- the repository shape suggests cross-functional work, but the default execution mode is unclear
+- repository evidence suggests parallel or cross-functional work, but it is unclear whether bounded decomposition is enough or richer peer coordination is required
 
 Examples:
 
-- Should the generated skill default to solo execution for most tasks, or to a small specialist team?
-- Are implementation, review, and validation typically handled by separate roles here?
+- Should bounded parallel implementation default to `sub-agent` before `agent-team`?
+- Are there recurring tasks in this repo where active peer-to-peer coordination materially improves outcomes?
 
 ### Priority 4: Runtime / Budget Constraints
 

--- a/docs/external-capability-model.md
+++ b/docs/external-capability-model.md
@@ -11,6 +11,7 @@ It builds on:
 - the fragment metadata contract in [`docs/fragment-schema.md`](./fragment-schema.md)
 - the builder inventory workflow in [`docs/builder-inventory-workflow.md`](./builder-inventory-workflow.md)
 - the builder questionnaire flow in [`docs/builder-questionnaire-flow.md`](./builder-questionnaire-flow.md)
+- the orchestration execution rubric in [`docs/orchestration-execution-rubric.md`](./orchestration-execution-rubric.md)
 - the capability fallback contract in [`docs/capability-fallback-behavior.md`](./capability-fallback-behavior.md)
 - the first-wave task-system fragment set in [`docs/task-system-provider-fragment-set.md`](./task-system-provider-fragment-set.md)
 - the first-wave code-host/review fragment set in [`docs/code-host-review-provider-fragment-set.md`](./code-host-review-provider-fragment-set.md)
@@ -31,6 +32,8 @@ It gives generated skills and fragments a shared vocabulary for:
 - delivery and validation signal retrieval
 
 This keeps the builder capability-oriented while still leaving room for provider-specific mappings later.
+
+Execution-tier sizing (`solo`, `sub-agent`, `agent-team`) is a separate internal orchestration concern and is defined in [`docs/orchestration-execution-rubric.md`](./orchestration-execution-rubric.md).
 
 ## Goals
 

--- a/docs/fragment-assembly-rules.md
+++ b/docs/fragment-assembly-rules.md
@@ -10,6 +10,7 @@ It builds on:
 - the generated-skill layout contract in [`docs/generated-skill-layout.md`](./generated-skill-layout.md)
 - the builder inventory workflow in [`docs/builder-inventory-workflow.md`](./builder-inventory-workflow.md)
 - the builder questionnaire flow in [`docs/builder-questionnaire-flow.md`](./builder-questionnaire-flow.md)
+- the orchestration tiering rubric in [`docs/orchestration-execution-rubric.md`](./orchestration-execution-rubric.md)
 - the project integration declaration format in [`docs/project-integration-declaration-format.md`](./project-integration-declaration-format.md)
 - the capability fallback contract in [`docs/capability-fallback-behavior.md`](./capability-fallback-behavior.md)
 - the first-wave task-system provider fragment set in [`docs/task-system-provider-fragment-set.md`](./task-system-provider-fragment-set.md)
@@ -333,6 +334,8 @@ A typical generated `SKILL.md` may therefore read like:
 3. PR and review loop
 4. team-sizing heuristics
 5. context and model-routing rules
+
+Team-sizing block content should apply the canonical `solo` -> `sub-agent` -> `agent-team` escalation rules from [`docs/orchestration-execution-rubric.md`](./orchestration-execution-rubric.md).
 
 Companion skills may project a subset of the same assembled fragment plan, but they should inherit the same conflict-resolution results rather than rerunning selection independently.
 

--- a/docs/fragment-schema.md
+++ b/docs/fragment-schema.md
@@ -10,6 +10,7 @@ It is intentionally shaped by:
 - the external capability model from issue `#13`
 - the workflow-discipline lessons from issue `#31`
 - the product direction in [`ROADMAP.md`](../ROADMAP.md)
+- the orchestration tiering rubric in [`docs/orchestration-execution-rubric.md`](./orchestration-execution-rubric.md)
 - the assembly contract in [`docs/fragment-assembly-rules.md`](./fragment-assembly-rules.md)
 - the first-wave task-system provider fragment set in [`docs/task-system-provider-fragment-set.md`](./task-system-provider-fragment-set.md)
 - the first-wave code-host/review provider fragment set in [`docs/code-host-review-provider-fragment-set.md`](./code-host-review-provider-fragment-set.md)
@@ -300,6 +301,7 @@ Generic fragments should:
 
 - express capabilities in neutral workflow language
 - describe heuristics, sequencing, and operating rules
+- keep execution-tier guidance aligned with [`docs/orchestration-execution-rubric.md`](./orchestration-execution-rubric.md)
 - avoid assuming a specific vendor surface unless the body is explicitly calling out an optional example
 
 Generic fragments should not:

--- a/docs/generated-skill-layout.md
+++ b/docs/generated-skill-layout.md
@@ -11,6 +11,7 @@ It builds on:
 - the fragment assembly contract in [`docs/fragment-assembly-rules.md`](./fragment-assembly-rules.md)
 - the builder inventory workflow in [`docs/builder-inventory-workflow.md`](./builder-inventory-workflow.md)
 - the builder questionnaire flow in [`docs/builder-questionnaire-flow.md`](./builder-questionnaire-flow.md)
+- the orchestration tiering rubric in [`docs/orchestration-execution-rubric.md`](./orchestration-execution-rubric.md)
 - the project integration declaration format in [`docs/project-integration-declaration-format.md`](./project-integration-declaration-format.md)
 - the capability fallback contract in [`docs/capability-fallback-behavior.md`](./capability-fallback-behavior.md)
 - the release versioning and upgrade contract in [`docs/release-versioning-and-upgrade-contract.md`](./release-versioning-and-upgrade-contract.md)
@@ -249,6 +250,7 @@ Every builder run should produce a `review.md` file that highlights:
 - fragments that were added, removed, or replaced
 - fragments that were suppressed by exclusivity or explicit conflicts
 - any warnings introduced by degraded or fallback-aware assembly
+- the chosen orchestration tier (`solo`, `sub-agent`, or `agent-team`) and why that sizing was selected
 
 This review file should make doc-only PR review practical.
 

--- a/docs/orchestration-execution-rubric.md
+++ b/docs/orchestration-execution-rubric.md
@@ -1,0 +1,155 @@
+# Orchestration Execution Rubric: Solo, Sub-Agent, And Agent-Team
+
+This document defines the proposed contract for issue `#22`:
+
+- [#22 Define solo, sub-agent, and agent-team heuristics](https://github.com/peakweb-team/pw-agency-agents/issues/22)
+
+It builds on:
+
+- the roadmap orchestration direction in [`ROADMAP.md`](../ROADMAP.md)
+- the fragment schema contract in [`docs/fragment-schema.md`](./fragment-schema.md)
+- the assembly contract in [`docs/fragment-assembly-rules.md`](./fragment-assembly-rules.md)
+- the builder inventory and confidence model in [`docs/builder-inventory-workflow.md`](./builder-inventory-workflow.md)
+- the builder questionnaire flow in [`docs/builder-questionnaire-flow.md`](./builder-questionnaire-flow.md)
+- the generated-skill layout contract in [`docs/generated-skill-layout.md`](./generated-skill-layout.md)
+- the Claude-first MVP constraints and implementation reality in [`docs/claude-first-mvp-strategy.md`](./claude-first-mvp-strategy.md)
+
+## Why This Exists
+
+The current contracts reference team sizing, but they do not yet define one canonical three-tier rubric for generated skills.
+
+This document fills that gap and sets one consistent policy:
+
+- prefer the smallest capable execution mode
+- keep `sub-agent` as the default middle-tier escalation path for bounded parallel work
+- reserve `agent-team` for cases where richer peer coordination materially improves outcomes
+
+## Three-Tier Execution Model
+
+Generated skills should classify task execution into exactly one of:
+
+1. `solo`
+2. `sub-agent`
+3. `agent-team`
+
+### `solo`
+
+Use one primary agent end-to-end when the task is narrow and coordination overhead would exceed any parallelism benefit.
+
+### `sub-agent`
+
+Use one lead agent plus bounded delegated sub-agents for mostly independent slices.
+
+This is the default escalation path once work no longer fits cleanly in `solo`.
+
+### `agent-team`
+
+Use a coordinated team pattern only when outcomes improve because agents must actively collaborate, share evolving state, or iterate jointly across boundaries.
+
+This tier has the highest overhead and should be explicitly justified.
+
+## Trigger Dimensions
+
+Sizing decisions should evaluate five dimensions together:
+
+1. scope
+2. risk
+3. ambiguity
+4. domain breadth
+5. coordination cost
+
+The default move is upward only when one or more dimensions cross the next tier boundary and expected delivery quality improves.
+
+## Tier Triggers
+
+### `solo` Triggers
+
+Default to `solo` when most of the following are true:
+
+- scope: one bounded deliverable or a single linear implementation path
+- risk: low blast radius and easy rollback/recovery
+- ambiguity: requirements and acceptance criteria are mostly clear
+- domain breadth: one primary domain (for example, one service or one doc contract)
+- coordination cost: introducing multiple agents would create more overhead than value
+
+### `sub-agent` Triggers (Default Middle Tier)
+
+Escalate from `solo` to `sub-agent` when bounded parallel work is available and most of the following are true:
+
+- scope: multiple work slices can progress in parallel with clear ownership boundaries
+- risk: moderate risk that benefits from focused verification or specialist checks
+- ambiguity: manageable uncertainty that can be isolated per slice
+- domain breadth: two or more adjacent domains, but weak coupling between slices
+- coordination cost: handoffs are lightweight and can be coordinated by a lead agent without persistent peer-to-peer discussion
+
+Default rule:
+
+- if the task is too large for `solo` but can still be decomposed into bounded, mostly independent subtasks, use `sub-agent` before considering `agent-team`
+
+### `agent-team` Triggers (Constrained Use)
+
+Escalate from `sub-agent` to `agent-team` only when richer peer coordination is materially beneficial and at least one of the following is true:
+
+- scope: multiple slices require continuous co-design, not just parallel execution
+- risk: high-impact changes where cross-checking and iterative peer review are part of correctness
+- ambiguity: requirements are materially unclear and need multi-perspective synthesis while executing
+- domain breadth: broad multi-domain coupling where local optimizations can conflict without active peer alignment
+- coordination cost: higher coordination overhead is justified by lower rework risk or better final quality
+
+`agent-team` should not be selected just because a task is "large." If bounded decomposition is viable, prefer `sub-agent`.
+
+## Model-Assignment Caveat
+
+When generated guidance references per-agent model assignment in `agent-team` setups, it must be framed as:
+
+- best-effort
+- forward-compatible guidance
+- not guaranteed behavior in current implementations
+
+Generated skills should avoid promising strict static per-agent model enforcement for `agent-team` execution.
+
+## Example Task Classifications
+
+### `solo` Examples
+
+- update one contract document section with clear acceptance criteria
+- implement a small bug fix in one service with localized tests
+- adjust a single CI check message or script behavior without workflow redesign
+
+### `sub-agent` Examples
+
+- implement a feature with independent backend and frontend slices plus a bounded test/update slice
+- update multiple docs/contracts where each file has distinct ownership and low coupling
+- run parallel review/remediation passes for separate PR feedback clusters with one lead integrator
+
+### `agent-team` Examples
+
+- redesign a cross-cutting architecture that requires iterative tradeoffs across runtime, delivery, and integration contracts
+- resolve a high-risk migration with intertwined data, API, and workflow changes requiring ongoing peer challenge
+- coordinate a complex incident-response hardening effort where findings in one area continuously reshape work in others
+
+## Integration With Existing Contracts
+
+This rubric is the canonical sizing source for:
+
+- orchestration fragment behavior (`orchestration/team-sizing`)
+- builder decisions about execution defaults
+- generated review metadata that explains why a tier was chosen
+
+Related contracts should reference this document rather than redefining tier boundaries independently.
+
+## Contract Expectations For Generated Skills
+
+Generated skills should:
+
+- document the selected tier and short rationale in human-readable output
+- keep escalation incremental (`solo` -> `sub-agent` -> `agent-team`)
+- treat `sub-agent` as the default middle tier for bounded parallel work
+- require explicit rationale before `agent-team` selection
+- preserve the model-assignment caveat for `agent-team`
+
+Generated skills should not:
+
+- default to `agent-team` for generic "complexity" labels alone
+- imply that higher agent count is always better
+- promise guaranteed per-agent model pinning in team mode

--- a/docs/provider-matrix.md
+++ b/docs/provider-matrix.md
@@ -7,6 +7,7 @@ This document defines the proposed contract for issue `#17`:
 It builds on:
 
 - the canonical capability model in [`docs/external-capability-model.md`](./external-capability-model.md)
+- the orchestration execution rubric in [`docs/orchestration-execution-rubric.md`](./orchestration-execution-rubric.md)
 - fallback behavior in [`docs/capability-fallback-behavior.md`](./capability-fallback-behavior.md)
 - the project integration declaration contract in [`docs/project-integration-declaration-format.md`](./project-integration-declaration-format.md)
 - the first-wave task-system fragment contract in [`docs/task-system-provider-fragment-set.md`](./task-system-provider-fragment-set.md)
@@ -24,6 +25,8 @@ This matrix is intentionally capability-oriented:
 - rows are providers or review patterns
 - columns are canonical capability ids from `docs/external-capability-model.md`
 - support is marked as `full`, `partial`, or `unavailable`
+
+Execution-tier choices (`solo`, `sub-agent`, `agent-team`) are intentionally out of scope for this matrix and are defined in [`docs/orchestration-execution-rubric.md`](./orchestration-execution-rubric.md).
 
 ## Canonical Capability Subset Used In This Matrix
 


### PR DESCRIPTION
## Summary
- add a canonical orchestration execution rubric doc for issue #22
- define explicit 3-tier sizing heuristics: solo, sub-agent, agent-team
- make sub-agent the default middle-tier escalation path for bounded parallel work
- constrain agent-team usage to cases where richer peer coordination materially improves outcomes
- include trigger dimensions (scope, risk, ambiguity, domain breadth, coordination cost), model-assignment caveats, and concrete task classifications
- cross-link Phase 1/2 contracts so team-sizing guidance remains coherent

## Validation
- doc consistency pass across updated contracts

Closes #22

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Introduced a standardized orchestration execution framework with three canonical team-sizing tiers and escalation rules.
  * Added new workflow signals to improve orchestration guidance for parallel work and peer coordination scenarios.
  * Updated questionnaire flow to reflect the new three-tier escalation logic based on workload characteristics.
  * Enhanced builder guidance documents to reference and enforce consistent team-sizing definitions across the ecosystem.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->