### PR TITLE
Define context-budgeting and repo-reading rules

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -151,6 +151,10 @@ Non-goals:
 
 Add shared rules for context use, task scoping, and model selection across generated skills.
 
+Canonical contract:
+
+- [`docs/runtime-context-budgeting-and-repo-reading.md`](./docs/runtime-context-budgeting-and-repo-reading.md)
+
 Goals:
 
 - define efficient file-reading and context-loading behavior

--- a/docs/builder-inventory-workflow.md
+++ b/docs/builder-inventory-workflow.md
@@ -12,6 +12,7 @@ It builds directly on:
 - the generated-skill layout contract from issue `#12`
 - the external capability model from issue `#13`
 - the orchestration tiering rubric in [`docs/orchestration-execution-rubric.md`](./orchestration-execution-rubric.md)
+- the runtime context-budgeting and repo-reading contract in [`docs/runtime-context-budgeting-and-repo-reading.md`](./runtime-context-budgeting-and-repo-reading.md)
 - the project integration declaration format from issue `#18`
 - the capability fallback contract from issue `#19`
 - the first-wave task-system provider fragment set in [`docs/task-system-provider-fragment-set.md`](./task-system-provider-fragment-set.md)
@@ -283,6 +284,8 @@ Typical evidence sources:
 ### Team And Runtime Signals
 
 These matter for adaptive specialist-team selection and efficient execution rules.
+
+Runtime signals should feed context-budget defaults using the canonical rules in [`docs/runtime-context-budgeting-and-repo-reading.md`](./runtime-context-budgeting-and-repo-reading.md).
 
 Common signals:
 

--- a/docs/builder-questionnaire-flow.md
+++ b/docs/builder-questionnaire-flow.md
@@ -14,6 +14,7 @@ It builds on:
 - the external capability model from issue `#13`
 - the orchestration tiering rubric in [`docs/orchestration-execution-rubric.md`](./orchestration-execution-rubric.md)
 - the role and handoff contract in [`docs/orchestration-role-handoff-contract.md`](./orchestration-role-handoff-contract.md)
+- the runtime context-budgeting and repo-reading contract in [`docs/runtime-context-budgeting-and-repo-reading.md`](./runtime-context-budgeting-and-repo-reading.md)
 - the project integration declaration format from issue `#18`
 - the capability fallback contract from issue `#19`
 - the first-wave task-system provider fragment set in [`docs/task-system-provider-fragment-set.md`](./task-system-provider-fragment-set.md)
@@ -206,6 +207,8 @@ Examples:
 Question goal:
 
 - capture constraints that materially change runtime/model-routing guidance
+
+These answers should shape runtime behavior using the canonical context-budgeting and repo-reading contract in [`docs/runtime-context-budgeting-and-repo-reading.md`](./runtime-context-budgeting-and-repo-reading.md).
 
 Ask when:
 

--- a/docs/fragment-assembly-rules.md
+++ b/docs/fragment-assembly-rules.md
@@ -11,6 +11,7 @@ It builds on:
 - the builder inventory workflow in [`docs/builder-inventory-workflow.md`](./builder-inventory-workflow.md)
 - the builder questionnaire flow in [`docs/builder-questionnaire-flow.md`](./builder-questionnaire-flow.md)
 - the orchestration tiering rubric in [`docs/orchestration-execution-rubric.md`](./orchestration-execution-rubric.md)
+- the runtime context-budgeting and repo-reading contract in [`docs/runtime-context-budgeting-and-repo-reading.md`](./runtime-context-budgeting-and-repo-reading.md)
 - the project integration declaration format in [`docs/project-integration-declaration-format.md`](./project-integration-declaration-format.md)
 - the capability fallback contract in [`docs/capability-fallback-behavior.md`](./capability-fallback-behavior.md)
 - the first-wave task-system provider fragment set in [`docs/task-system-provider-fragment-set.md`](./task-system-provider-fragment-set.md)
@@ -538,6 +539,8 @@ Final emitted block order:
 4. `review-loop`
 5. `context-budgeting`
 6. `model-routing-rules`
+
+The meaning of `context-budgeting` should follow the canonical runtime contract in [`docs/runtime-context-budgeting-and-repo-reading.md`](./runtime-context-budgeting-and-repo-reading.md) rather than ad hoc file-reading guidance.
 
 Outcome:
 

--- a/docs/fragment-schema.md
+++ b/docs/fragment-schema.md
@@ -11,6 +11,7 @@ It is intentionally shaped by:
 - the workflow-discipline lessons from issue `#31`
 - the product direction in [`ROADMAP.md`](../ROADMAP.md)
 - the orchestration tiering rubric in [`docs/orchestration-execution-rubric.md`](./orchestration-execution-rubric.md)
+- the runtime context-budgeting and repo-reading contract in [`docs/runtime-context-budgeting-and-repo-reading.md`](./runtime-context-budgeting-and-repo-reading.md)
 - the assembly contract in [`docs/fragment-assembly-rules.md`](./fragment-assembly-rules.md)
 - the first-wave task-system provider fragment set in [`docs/task-system-provider-fragment-set.md`](./task-system-provider-fragment-set.md)
 - the first-wave code-host/review provider fragment set in [`docs/code-host-review-provider-fragment-set.md`](./code-host-review-provider-fragment-set.md)

--- a/docs/generated-skill-layout.md
+++ b/docs/generated-skill-layout.md
@@ -13,6 +13,7 @@ It builds on:
 - the builder questionnaire flow in [`docs/builder-questionnaire-flow.md`](./builder-questionnaire-flow.md)
 - the orchestration tiering rubric in [`docs/orchestration-execution-rubric.md`](./orchestration-execution-rubric.md)
 - the role and handoff contract in [`docs/orchestration-role-handoff-contract.md`](./orchestration-role-handoff-contract.md)
+- the runtime context-budgeting and repo-reading contract in [`docs/runtime-context-budgeting-and-repo-reading.md`](./runtime-context-budgeting-and-repo-reading.md)
 - the project integration declaration format in [`docs/project-integration-declaration-format.md`](./project-integration-declaration-format.md)
 - the capability fallback contract in [`docs/capability-fallback-behavior.md`](./capability-fallback-behavior.md)
 - the release versioning and upgrade contract in [`docs/release-versioning-and-upgrade-contract.md`](./release-versioning-and-upgrade-contract.md)
@@ -253,6 +254,7 @@ Every builder run should produce a `review.md` file that highlights:
 - any warnings introduced by degraded or fallback-aware assembly
 - the chosen orchestration tier (`solo`, `sub-agent`, or `agent-team`) and why that sizing was selected
 - any handoff contract exceptions, blocked handoffs, or unresolved role-ownership questions that require manual follow-up
+- any context-budget escalations (for example `narrow` -> `medium` or `wide`) and the trigger for each escalation
 
 This review file should make doc-only PR review practical.
 

--- a/docs/orchestration-execution-rubric.md
+++ b/docs/orchestration-execution-rubric.md
@@ -13,6 +13,7 @@ It builds on:
 - the builder questionnaire flow in [`docs/builder-questionnaire-flow.md`](./builder-questionnaire-flow.md)
 - the generated-skill layout contract in [`docs/generated-skill-layout.md`](./generated-skill-layout.md)
 - the role and handoff contract in [`docs/orchestration-role-handoff-contract.md`](./orchestration-role-handoff-contract.md)
+- the runtime context-budgeting and repo-reading contract in [`docs/runtime-context-budgeting-and-repo-reading.md`](./runtime-context-budgeting-and-repo-reading.md)
 - the Claude-first MVP constraints and implementation reality in [`docs/claude-first-mvp-strategy.md`](./claude-first-mvp-strategy.md)
 
 ## Why This Exists
@@ -149,6 +150,7 @@ Generated skills should:
 - treat `sub-agent` as the default middle tier for bounded parallel work
 - require explicit rationale before `agent-team` selection
 - preserve the model-assignment caveat for `agent-team`
+- apply context budgets progressively using the runtime contract instead of front-loading full-repo reads
 
 Generated skills should not:
 

--- a/docs/orchestration-role-handoff-contract.md
+++ b/docs/orchestration-role-handoff-contract.md
@@ -8,6 +8,7 @@ It builds on:
 
 - the roadmap orchestration direction in [`ROADMAP.md`](../ROADMAP.md)
 - the tiering rubric in [`docs/orchestration-execution-rubric.md`](./orchestration-execution-rubric.md)
+- the runtime context-budgeting and repo-reading contract in [`docs/runtime-context-budgeting-and-repo-reading.md`](./runtime-context-budgeting-and-repo-reading.md)
 - task-system external update boundaries in [`docs/task-system-provider-fragment-set.md`](./task-system-provider-fragment-set.md)
 - code-host/review external update boundaries in [`docs/code-host-review-provider-fragment-set.md`](./code-host-review-provider-fragment-set.md)
 - builder output and review metadata expectations in [`docs/generated-skill-layout.md`](./generated-skill-layout.md)
@@ -126,6 +127,7 @@ Every handoff should include:
 - `requested_action`: expected receiver action (`implement`, `review`, `validate`, `integrate`, or `decide`)
 - `acceptance_criteria`: concrete completion bar for this handoff
 - `status`: `proposed`, `accepted`, `needs-clarification`, `blocked`, or `complete`
+- `context_scope`: optional but recommended summary of what was read, what was intentionally not read, and whether broader context escalation is requested
 
 Suggested minimal shape:
 
@@ -154,6 +156,13 @@ requested_action: integrate
 acceptance_criteria:
   - "Lead confirms fallback behavior alignment."
 status: proposed
+context_scope:
+  read:
+    - apps/api/src/issues/normalize.ts
+    - apps/api/test/issues/normalize.test.ts
+  intentionally_not_read:
+    - apps/web/**
+  escalation_requested: false
 ```
 
 ### Ownership Transfer Rules

--- a/docs/runtime-context-budgeting-and-repo-reading.md
+++ b/docs/runtime-context-budgeting-and-repo-reading.md
@@ -1,0 +1,244 @@
+# Runtime Context-Budgeting And Repo-Reading Rules
+
+This document defines the proposed contract for issue `#24`:
+
+- [#24 Define context-budgeting and repo-reading rules](https://github.com/peakweb-team/pw-agency-agents/issues/24)
+
+It builds on:
+
+- the runtime-efficiency direction in [`ROADMAP.md`](../ROADMAP.md)
+- the orchestration tiering rubric in [`docs/orchestration-execution-rubric.md`](./orchestration-execution-rubric.md)
+- the role and handoff contract in [`docs/orchestration-role-handoff-contract.md`](./orchestration-role-handoff-contract.md)
+- the builder inventory contract in [`docs/builder-inventory-workflow.md`](./builder-inventory-workflow.md)
+- the builder questionnaire contract in [`docs/builder-questionnaire-flow.md`](./builder-questionnaire-flow.md)
+- the fragment assembly contract in [`docs/fragment-assembly-rules.md`](./fragment-assembly-rules.md)
+
+## Why This Exists
+
+Generated skills need one provider-neutral runtime policy for how much context to load, how to read repositories efficiently, and when to expand scope.
+
+Without this contract, large repos risk wasteful full-repo reading while small tasks risk unnecessary orchestration overhead.
+
+## Goals
+
+- define context-budgeting guidance that works across `solo`, `sub-agent`, and `agent-team`
+- define repo-reading heuristics for small tasks and large multi-package repositories
+- define file-discovery and selective-reading behavior before deep file ingestion
+- define progressive context-expansion rules that are deterministic and reviewable
+- include concrete examples and anti-patterns for generated execution behavior
+
+## Non-Goals
+
+- prescribing provider-specific model APIs or token limits
+- requiring one static budget number for every runtime/provider
+- replacing tier-selection or handoff contracts
+
+## Core Policy
+
+### Progressive Context First
+
+Generated execution should load context in stages instead of front-loading full repositories.
+
+Default sequence:
+
+1. discover
+2. select
+3. deepen
+4. execute
+5. verify
+
+### Smallest Useful Read Wins
+
+Agents should read the minimum material required to make the next correct decision.
+
+When uncertainty remains high after selective reading, widen scope deliberately and record why.
+
+### Provider-Neutral Budgeting
+
+Budgets should be expressed as behavior constraints, not provider-specific token promises.
+
+Examples of acceptable constraints:
+
+- number of files deeply read before first implementation attempt
+- number of directories scanned before escalating to broader discovery
+- maximum re-read loops before requesting clarification
+
+## Context Budget Levels
+
+Generated skills should use these qualitative budget levels:
+
+- `narrow`
+  - single-scope changes, low ambiguity, one primary subsystem
+- `medium`
+  - bounded multi-file or cross-layer changes with moderate ambiguity
+- `wide`
+  - multi-package, multi-domain, or high-ambiguity work requiring broader synthesis
+
+Budget selection should align with the orchestration tier:
+
+- `solo`: start `narrow`, escalate to `medium` only with explicit trigger
+- `sub-agent`: lead may use `medium`; specialists should usually start `narrow`
+- `agent-team`: allow `medium` to `wide`, but require explicit ownership boundaries and scoped handoff payloads
+
+## Repo-Reading Heuristics
+
+### Discovery Phase
+
+Before opening many files, gather structural signals:
+
+- top-level directory map
+- workspace/package manifests
+- build/test/tooling entry points
+- task-relevant docs and ownership hints
+- recent files touched in the current task context when available
+
+Discovery should prefer fast listing/search operations over broad file-body reads.
+
+### Selective-Reading Phase
+
+After discovery, select a bounded candidate set.
+
+Selection priorities:
+
+1. files directly named by issue/task acceptance criteria
+2. files referenced by tests failing for the target behavior
+3. files imported or called by candidate implementation entry points
+4. contract docs that define constraints for the target area
+
+Avoid deep-reading unrelated sibling packages during this phase.
+
+### Deep-Reading Phase
+
+Perform full-content reads only for files in the current candidate set and immediate dependencies.
+
+Escalate to broader reading only when one of the following occurs:
+
+- repeated ambiguity after two focused passes
+- evidence of cross-package coupling that can affect correctness
+- risk signals indicate high blast radius
+
+When escalating, record what triggered broader reading and which new areas were added.
+
+## Small Task Vs Large Repo Behavior
+
+### Small Task Behavior
+
+Expected shape:
+
+- start in `solo` with `narrow` budget
+- discover at repo root and target package only
+- deeply read only task-local files plus nearest tests
+- implement and verify before expanding scope
+
+Example:
+
+- issue asks to clarify one contract section in `docs/orchestration-role-handoff-contract.md`
+- discovery finds no code coupling requirements
+- read target doc and directly linked contracts only
+- produce focused edit and coherence check
+
+### Large Repo / Multi-Package Behavior
+
+Expected shape:
+
+- start with `medium` budget and explicit discovery boundaries
+- map packages/apps before selecting candidate files
+- route independent slices to `sub-agent` specialists when bounded decomposition is clear
+- keep each specialist on a narrow file subset; lead integrates and resolves cross-slice risk
+
+Example:
+
+- issue requires API contract change plus CLI integration plus docs updates in a monorepo
+- lead maps impacted packages (`apps/api`, `apps/cli`, `docs`)
+- specialists own disjoint slices with explicit acceptance criteria
+- lead escalates to wider reading only when integration tests reveal cross-package assumptions
+
+## File-Discovery And Selective-Reading Rules
+
+Generated skills should include these explicit runtime rules:
+
+1. Start with path discovery (`rg --files`, workspace manifests, top-level docs) before content-heavy reads.
+2. Use targeted search (`rg`) to locate symbols/phrases before opening whole files.
+3. Read headings/sections first for long docs; deep-read only relevant sections unless contradiction appears.
+4. For code, read call sites and tests nearest to the change before reading transitive dependencies.
+5. Stop broad discovery once enough evidence exists to pick a bounded execution slice.
+6. Re-open previously read files only when new evidence invalidates earlier assumptions.
+
+## Progressive-Context Escalation Triggers
+
+Escalate from `narrow` to `medium` or `wide` only when at least one trigger is true:
+
+- unresolved ambiguity blocks safe implementation
+- validation evidence conflicts with current assumptions
+- ownership boundaries reveal hidden cross-domain dependency
+- reviewer/validator finds a correctness risk requiring broader synthesis
+
+Generated review metadata should summarize these escalations in human-readable form.
+
+## Good Patterns
+
+### Good Pattern: Bounded Discovery Before Editing
+
+- list repo structure and search for target symbols
+- select 3-8 candidate files
+- deep-read only selected files
+- implement, verify, and stop
+
+Why this is good:
+
+- minimizes context waste
+- keeps reasoning traceable
+- scales to large repos
+
+### Good Pattern: Lead-Wide, Specialist-Narrow
+
+- lead reads medium-scope architecture context
+- specialists receive scoped handoffs with explicit file boundaries
+- specialists avoid full-repo rereads
+
+Why this is good:
+
+- preserves coherence without redundant context loading
+- aligns with `sub-agent` and `agent-team` handoff contracts
+
+## Anti-Patterns
+
+### Anti-Pattern: Full Repo Slurp Up Front
+
+- agent reads broad directory trees and dozens of full files before identifying target slice
+
+Why this is bad:
+
+- high cost and latency
+- increases stale-context risk
+- obscures which evidence actually mattered
+
+### Anti-Pattern: Blind Narrowness
+
+- agent refuses to widen context even after repeated validation failures
+
+Why this is bad:
+
+- creates false confidence
+- misses cross-package coupling
+- can produce regressions in large repositories
+
+### Anti-Pattern: Duplicate Multi-Agent Reading
+
+- each specialist independently re-discovers the whole repo
+
+Why this is bad:
+
+- multiplies context cost with little quality gain
+- undermines lead ownership and structured handoffs
+
+## Integration With Existing Contracts
+
+This document is the canonical runtime context-budgeting and repo-reading contract for generated execution.
+
+Related docs should reference it rather than redefining these rules:
+
+- builder inventory/questionnaire contracts for runtime signal and decision capture
+- fragment assembly for deterministic runtime block composition
+- orchestration tiering and handoff contracts for tier-compatible execution behavior
+- generated-skill layout/review metadata for documenting escalation and assumptions

--- a/docs/runtime-context-budgeting-and-repo-reading.md
+++ b/docs/runtime-context-budgeting-and-repo-reading.md
@@ -127,7 +127,7 @@ Expected shape:
 
 - start in `solo` with `narrow` budget
 - discover at repo root and target package only
-- deeply read only task-local files plus nearest tests
+- deeply read task-local files and nearest tests
 - implement and verify before expanding scope
 
 Example:


### PR DESCRIPTION
## Summary\n- add a canonical runtime contract doc for context budgeting and repo-reading heuristics\n- define progressive context expansion, selective-reading rules, and escalation triggers\n- include concrete examples for small tasks vs large multi-package repos plus good patterns and anti-patterns\n- cross-link runtime guidance into roadmap, builder, fragment, orchestration, and generated-skill contracts\n\n## Testing\n- docs-only change; verified link/reference consistency via repo search\n\nCloses #24

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Established a canonical runtime contract for context budgeting and repo-reading, with staged execution flow, budget levels, heuristics, and escalation triggers.
  * Added and aligned multiple docs (flows, assembly, schema, orchestration rubric, builder guides) to reference the new contract.
  * Extended role handoff examples to include an optional context_scope field and required review reporting for context-budget escalations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->