### PR TITLE
Define model-routing and subtask-splitting heuristics

### DIFF
--- a/docs/fragment-assembly-rules.md
+++ b/docs/fragment-assembly-rules.md
@@ -542,6 +542,8 @@ Final emitted block order:
 
 The meaning of `context-budgeting` should follow the canonical runtime contract in [`docs/runtime-context-budgeting-and-repo-reading.md`](./runtime-context-budgeting-and-repo-reading.md) rather than ad hoc file-reading guidance.
 
+The meaning of `model-routing-rules` should also follow that runtime contract, including provider-neutral tier semantics, escalation triggers, and bounded subtask-splitting rules.
+
 Outcome:
 
 - the generated workflow starts from a brief

--- a/docs/generated-skill-layout.md
+++ b/docs/generated-skill-layout.md
@@ -255,6 +255,8 @@ Every builder run should produce a `review.md` file that highlights:
 - the chosen orchestration tier (`solo`, `sub-agent`, or `agent-team`) and why that sizing was selected
 - any handoff contract exceptions, blocked handoffs, or unresolved role-ownership questions that require manual follow-up
 - any context-budget escalations (for example `narrow` -> `medium` or `wide`) and the trigger for each escalation
+- any model-tier escalations (for example `economy` -> `balanced` -> `strong`) and why lower tiers were insufficient
+- any delegation boundary choices that affected overlap risk, context reuse, or decision to stay in `solo` vs escalate
 
 This review file should make doc-only PR review practical.
 

--- a/docs/orchestration-execution-rubric.md
+++ b/docs/orchestration-execution-rubric.md
@@ -4,6 +4,10 @@ This document defines the proposed contract for issue `#22`:
 
 - [#22 Define solo, sub-agent, and agent-team heuristics](https://github.com/peakweb-team/pw-agency-agents/issues/22)
 
+Related runtime routing follow-on:
+
+- [#25 Define model-routing and subtask-splitting heuristics](https://github.com/peakweb-team/pw-agency-agents/issues/25)
+
 It builds on:
 
 - the roadmap orchestration direction in [`ROADMAP.md`](../ROADMAP.md)
@@ -138,6 +142,8 @@ This rubric is the canonical sizing source for:
 - builder decisions about execution defaults
 - generated review metadata that explains why a tier was chosen
 - role and handoff behavior that follows the selected tier (see [`docs/orchestration-role-handoff-contract.md`](./orchestration-role-handoff-contract.md))
+
+Model-tier routing and bounded subtask-splitting heuristics are canonical in [`docs/runtime-context-budgeting-and-repo-reading.md`](./runtime-context-budgeting-and-repo-reading.md). This rubric should define tier selection, while runtime guidance defines how work is routed inside the selected tier.
 
 Related contracts should reference this document rather than redefining tier boundaries independently.
 

--- a/docs/orchestration-role-handoff-contract.md
+++ b/docs/orchestration-role-handoff-contract.md
@@ -13,6 +13,8 @@ It builds on:
 - code-host/review external update boundaries in [`docs/code-host-review-provider-fragment-set.md`](./code-host-review-provider-fragment-set.md)
 - builder output and review metadata expectations in [`docs/generated-skill-layout.md`](./generated-skill-layout.md)
 
+Model-routing and bounded subtask-splitting heuristics are defined in the runtime contract above; this document focuses on role ownership and handoff behavior once a tier and routing plan are chosen.
+
 ## Why This Exists
 
 Issue `#22` established *when* to use `solo`, `sub-agent`, or `agent-team`.

--- a/docs/runtime-context-budgeting-and-repo-reading.md
+++ b/docs/runtime-context-budgeting-and-repo-reading.md
@@ -1,8 +1,9 @@
-# Runtime Context-Budgeting And Repo-Reading Rules
+# Runtime Context-Budgeting, Repo-Reading, And Model-Routing Rules
 
-This document defines the proposed contract for issue `#24`:
+This document defines the proposed contracts for issues:
 
 - [#24 Define context-budgeting and repo-reading rules](https://github.com/peakweb-team/pw-agency-agents/issues/24)
+- [#25 Define model-routing and subtask-splitting heuristics](https://github.com/peakweb-team/pw-agency-agents/issues/25)
 
 It builds on:
 
@@ -12,12 +13,13 @@ It builds on:
 - the builder inventory contract in [`docs/builder-inventory-workflow.md`](./builder-inventory-workflow.md)
 - the builder questionnaire contract in [`docs/builder-questionnaire-flow.md`](./builder-questionnaire-flow.md)
 - the fragment assembly contract in [`docs/fragment-assembly-rules.md`](./fragment-assembly-rules.md)
+- the generated-skill layout contract in [`docs/generated-skill-layout.md`](./generated-skill-layout.md)
 
 ## Why This Exists
 
-Generated skills need one provider-neutral runtime policy for how much context to load, how to read repositories efficiently, and when to expand scope.
+Generated skills need one provider-neutral runtime policy for how much context to load, how to read repositories efficiently, how to split subtasks, and how to route model strength.
 
-Without this contract, large repos risk wasteful full-repo reading while small tasks risk unnecessary orchestration overhead.
+Without this contract, large repos risk wasteful full-repo reading, small tasks risk unnecessary orchestration overhead, and model selection becomes inconsistent and costly.
 
 ## Goals
 
@@ -25,13 +27,16 @@ Without this contract, large repos risk wasteful full-repo reading while small t
 - define repo-reading heuristics for small tasks and large multi-package repositories
 - define file-discovery and selective-reading behavior before deep file ingestion
 - define progressive context-expansion rules that are deterministic and reviewable
+- define provider-neutral model-routing heuristics for each collaboration tier
+- define bounded subtask-splitting rules that minimize overlap and duplicate context loading
 - include concrete examples and anti-patterns for generated execution behavior
 
 ## Non-Goals
 
-- prescribing provider-specific model APIs or token limits
+- prescribing provider-specific model APIs, model names, or token limits
 - requiring one static budget number for every runtime/provider
 - replacing tier-selection or handoff contracts
+- assuming static per-agent model pinning is guaranteed in `agent-team`
 
 ## Core Policy
 
@@ -52,6 +57,12 @@ Default sequence:
 Agents should read the minimum material required to make the next correct decision.
 
 When uncertainty remains high after selective reading, widen scope deliberately and record why.
+
+### Cheapest Capable Model Wins
+
+Generated skills should route to the least expensive model tier that can still satisfy correctness and delivery-risk needs for the current step.
+
+Escalate model strength only when explicit triggers fire, and record escalation reasons in review metadata.
 
 ### Provider-Neutral Budgeting
 
@@ -79,6 +90,86 @@ Budget selection should align with the orchestration tier:
 - `solo`: start `narrow`, escalate to `medium` only with explicit trigger
 - `sub-agent`: lead may use `medium`; specialists should usually start `narrow`
 - `agent-team`: allow `medium` to `wide`, but require explicit ownership boundaries and scoped handoff payloads
+
+## Model-Tier Vocabulary
+
+Generated guidance should use provider-neutral model tiers:
+
+- `economy`: lowest-cost reliable tier for routine and low-risk work
+- `balanced`: default tier for most implementation and integration work
+- `strong`: highest-reasoning tier for ambiguity, high risk, and cross-domain synthesis
+
+Generated skills may map local/provider model names onto these tiers, but runtime behavior should reason in terms of these tier semantics.
+
+## Model-Routing Heuristics By Collaboration Tier
+
+### `solo`
+
+Default routing:
+
+- planning for clear tasks: `economy`
+- implementation in one bounded area: `balanced`
+- validation and basic regression checks: `balanced`
+
+Escalate to `strong` only when explicit escalation triggers are met.
+
+### `sub-agent`
+
+Default routing:
+
+- lead planning/integration and ambiguity resolution: `balanced` (or `strong` when high risk)
+- specialist implementation slices: `economy` or `balanced` depending on complexity
+- specialist validation/reviewer slices: `balanced`, escalate to `strong` for contentious findings
+
+Sub-agent routing should prioritize bounded task-type fit over uniform model assignment.
+
+### `agent-team`
+
+Default routing:
+
+- use only when tier triggers in [`docs/orchestration-execution-rubric.md`](./orchestration-execution-rubric.md) justify richer coordination
+- treat per-agent model assignment as advisory metadata, not a correctness guarantee
+- require at least one owner-of-record (typically lead) to run at `strong` when correctness depends on cross-role synthesis
+
+Advisory-only caveat:
+
+- generated skills must not rely on static per-agent model pinning in `agent-team` for correctness-critical behavior
+- if correctness would fail without strict pinning, route through `sub-agent` with explicit bounded handoffs instead
+
+## Subtask-Splitting And Delegation Rules
+
+### Bounded Split Rules
+
+Generated delegation should satisfy all of the following before splitting:
+
+1. each subtask has one owner-of-record and concrete acceptance criteria
+2. in-scope and out-of-scope boundaries are explicit
+3. write targets are disjoint or merge order is explicit
+4. shared dependencies are identified before execution starts
+5. each subtask can be validated without full-repo re-read
+
+If these conditions are not met, keep work in `solo` or reduce split count.
+
+### Duplicate-Context Minimization Rules
+
+To reduce overlap and wasted loading:
+
+1. lead performs shared discovery once and hands off scoped context payloads
+2. specialists should not repeat broad repo discovery unless escalation is requested
+3. each specialist receives a bounded candidate-file set and dependency hints
+4. cross-slice context expansion requires lead approval and trigger evidence
+5. integration synthesis belongs to lead or designated integrator, not every specialist
+
+### Delegation Stop Conditions
+
+Do not split further when any of the following is true:
+
+- subtasks would overlap the same hot files without clear ownership sequencing
+- coordination cost exceeds expected parallelism benefit
+- ambiguity is global rather than slice-local
+- validation requires shared reasoning that cannot be isolated safely
+
+When stop conditions apply, prefer `solo` or a smaller `sub-agent` plan.
 
 ## Repo-Reading Heuristics
 
@@ -119,6 +210,30 @@ Escalate to broader reading only when one of the following occurs:
 
 When escalating, record what triggered broader reading and which new areas were added.
 
+## Escalation Triggers
+
+Escalation should be explicit and incremental across both context and model/tier dimensions.
+
+### Stronger Model Escalation (`economy` -> `balanced` -> `strong`)
+
+Escalate model tier when at least one trigger is true:
+
+- unresolved ambiguity persists after one focused clarification pass
+- implementation attempts fail validation for non-trivial reasoning causes
+- risk is `high` under the handoff contract or correctness impact is broad
+- synthesis requires reconciling conflicting evidence across domains
+- reviewer/validator returns blocking findings that indicate reasoning depth gaps
+
+### Heavier Collaboration Escalation (`solo` -> `sub-agent` -> `agent-team`)
+
+Escalate collaboration tier when at least one trigger is true and lower tiers are insufficient:
+
+- independent bounded slices exist and delivery speed/quality benefits from parallel work (`solo` -> `sub-agent`)
+- correctness requires active ongoing peer coordination across coupled domains (`sub-agent` -> `agent-team`)
+- integration churn shows that bounded hub-and-spoke delegation is no longer stabilizing outcomes
+
+If `sub-agent` remains viable with explicit bounded handoffs, do not escalate to `agent-team`.
+
 ## Small Task Vs Large Repo Behavior
 
 ### Small Task Behavior
@@ -126,6 +241,7 @@ When escalating, record what triggered broader reading and which new areas were 
 Expected shape:
 
 - start in `solo` with `narrow` budget
+- route planning with `economy` and implementation/validation with `balanced`
 - discover at repo root and target package only
 - deeply read task-local files and nearest tests
 - implement and verify before expanding scope
@@ -135,7 +251,7 @@ Example:
 - issue asks to clarify one contract section in `docs/orchestration-role-handoff-contract.md`
 - discovery finds no code coupling requirements
 - read target doc and directly linked contracts only
-- produce focused edit and coherence check
+- no delegation needed; produce focused edit and coherence check
 
 ### Large Repo / Multi-Package Behavior
 
@@ -145,6 +261,7 @@ Expected shape:
 - map packages/apps before selecting candidate files
 - route independent slices to `sub-agent` specialists when bounded decomposition is clear
 - keep each specialist on a narrow file subset; lead integrates and resolves cross-slice risk
+- escalate lead to `strong` only when ambiguity/risk crosses triggers
 
 Example:
 
@@ -152,6 +269,27 @@ Example:
 - lead maps impacted packages (`apps/api`, `apps/cli`, `docs`)
 - specialists own disjoint slices with explicit acceptance criteria
 - lead escalates to wider reading only when integration tests reveal cross-package assumptions
+
+## Sub-Agent Routing By Task Type
+
+Use task type, not only task size, to route model tiers.
+
+- planning
+  - default: `economy` for clear bounded planning
+  - escalate: `balanced` or `strong` when decomposition is high-risk or ambiguous
+- implementation
+  - default: `balanced`
+  - downgrade: `economy` for straightforward refactors with clear acceptance tests
+  - escalate: `strong` for tricky algorithms, migrations, or cross-domain coupling
+- validation
+  - default: `balanced`
+  - escalate: `strong` for flaky/conflicting evidence or high-impact release gates
+- synthesis/integration
+  - default: lead at `balanced`
+  - escalate: lead at `strong` when conflicting slice outputs need deep reconciliation
+- ambiguity/risk triage
+  - default: lead at `balanced`
+  - escalate: `strong` when unresolved ambiguity can affect correctness or safety claims
 
 ## File-Discovery And Selective-Reading Rules
 
@@ -201,6 +339,17 @@ Why this is good:
 - preserves coherence without redundant context loading
 - aligns with `sub-agent` and `agent-team` handoff contracts
 
+### Good Pattern: Cheapest Capable Routing
+
+- use `economy` for routine planning and low-risk setup
+- route implementation/validation to `balanced` by default
+- escalate selected slices to `strong` only on explicit triggers
+
+Why this is good:
+
+- controls cost without reducing correctness discipline
+- keeps escalation evidence reviewable
+
 ## Anti-Patterns
 
 ### Anti-Pattern: Full Repo Slurp Up Front
@@ -232,13 +381,24 @@ Why this is bad:
 - multiplies context cost with little quality gain
 - undermines lead ownership and structured handoffs
 
+### Anti-Pattern: Correctness-Critical Team Pinning
+
+- workflow correctness assumes static per-agent model assignments in `agent-team`
+
+Why this is bad:
+
+- current implementations may ignore static team model assignments
+- creates hidden reliability risk in high-stakes paths
+- violates the advisory-only team assignment caveat
+
 ## Integration With Existing Contracts
 
-This document is the canonical runtime context-budgeting and repo-reading contract for generated execution.
+This document is the canonical runtime contract for context budgeting, repo reading, model routing, and subtask splitting.
 
 Related docs should reference it rather than redefining these rules:
 
+- orchestration tiering for collaboration-tier selection triggers
+- role/handoff contract for ownership, payload shape, and risk escalation semantics
 - builder inventory/questionnaire contracts for runtime signal and decision capture
 - fragment assembly for deterministic runtime block composition
-- orchestration tiering and handoff contracts for tier-compatible execution behavior
 - generated-skill layout/review metadata for documenting escalation and assumptions


### PR DESCRIPTION
## Summary
- extend the runtime contract to include canonical model-routing heuristics for solo, sub-agent, and agent-team
- define bounded subtask-splitting and delegation rules that reduce overlap and duplicate context loading
- add explicit escalation triggers for stronger model tiers and heavier collaboration modes
- add concrete examples for small-task behavior, large-repo behavior, task-type routing, and agent-team advisory caveat
- cross-link related orchestration, assembly, and layout contracts to keep one canonical routing source

## Scope
- docs-only update for issue #25

Closes #25

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded runtime contract documentation with provider-neutral model tier vocabulary and routing heuristics across collaboration modes
  * Added explicit escalation triggers and bounded subtask-splitting rules with guidance on when to escalate tiers
  * Clarified integration boundaries across orchestration contracts, defining which document governs tier selection versus role handoff behavior
  * Enhanced with task-type-specific routing patterns and context-budgeting best practices

<!-- end of auto-generated comment: release notes by coderabbit.ai -->