### PR TITLE
docs: define deterministic context-budgeting and repo-reading rules

### DIFF
--- a/docs/generated-skill-layout.md
+++ b/docs/generated-skill-layout.md
@@ -257,6 +257,8 @@ Every builder run should produce a `review.md` file that highlights:
 - any context-budget escalations (for example `narrow` -> `medium` or `wide`) and the trigger for each escalation
 - whether execution followed the staged runtime sequence (`discover` -> `select` -> `deepen` -> `execute` -> `verify`) and any stage skips with rationale
 - candidate-file budget ranges used per execution slice and reasons for any widened ranges
+  - for `solo`, report one aggregate slice for the full task (or explicitly note no per-slice breakdown)
+  - for `sub-agent` and `agent-team`, report per specialist/role slice
 - any model-tier escalations (for example `economy` -> `balanced` -> `strong`) and why lower tiers were insufficient
 - any delegation boundary choices that affected overlap risk, context reuse, or decision to stay in `solo` vs escalate
 

--- a/docs/generated-skill-layout.md
+++ b/docs/generated-skill-layout.md
@@ -255,6 +255,8 @@ Every builder run should produce a `review.md` file that highlights:
 - the chosen orchestration tier (`solo`, `sub-agent`, or `agent-team`) and why that sizing was selected
 - any handoff contract exceptions, blocked handoffs, or unresolved role-ownership questions that require manual follow-up
 - any context-budget escalations (for example `narrow` -> `medium` or `wide`) and the trigger for each escalation
+- whether execution followed the staged runtime sequence (`discover` -> `select` -> `deepen` -> `execute` -> `verify`) and any stage skips with rationale
+- candidate-file budget ranges used per execution slice and reasons for any widened ranges
 - any model-tier escalations (for example `economy` -> `balanced` -> `strong`) and why lower tiers were insufficient
 - any delegation boundary choices that affected overlap risk, context reuse, or decision to stay in `solo` vs escalate
 

--- a/docs/orchestration-execution-rubric.md
+++ b/docs/orchestration-execution-rubric.md
@@ -143,7 +143,7 @@ This rubric is the canonical sizing source for:
 - generated review metadata that explains why a tier was chosen
 - role and handoff behavior that follows the selected tier (see [`docs/orchestration-role-handoff-contract.md`](./orchestration-role-handoff-contract.md))
 
-Model-tier routing and bounded subtask-splitting heuristics are canonical in [`docs/runtime-context-budgeting-and-repo-reading.md`](./runtime-context-budgeting-and-repo-reading.md). This rubric should define tier selection, while runtime guidance defines how work is routed inside the selected tier.
+Model-tier routing, progressive context loading (`discover` -> `select` -> `deepen` -> `execute` -> `verify`), candidate-file budgeting, and bounded subtask-splitting heuristics are canonical in [`docs/runtime-context-budgeting-and-repo-reading.md`](./runtime-context-budgeting-and-repo-reading.md). This rubric should define tier selection, while runtime guidance defines how work is routed inside the selected tier.
 
 Related contracts should reference this document rather than redefining tier boundaries independently.
 

--- a/docs/orchestration-role-handoff-contract.md
+++ b/docs/orchestration-role-handoff-contract.md
@@ -131,6 +131,18 @@ Every handoff should include:
 - `status`: `proposed`, `accepted`, `needs-clarification`, `blocked`, or `complete`
 - `context_scope`: optional but recommended summary of what was read, what was intentionally not read, and whether broader context escalation is requested (see staged runtime rules in [`docs/runtime-context-budgeting-and-repo-reading.md`](./runtime-context-budgeting-and-repo-reading.md))
 
+When `context_scope` is present, `context_scope.stage` should be present.
+
+`context_scope.stage` validation rules:
+
+- `stage.current`
+  - required enum string
+  - allowed values: `discover`, `select`, `deepen`, `execute`, `verify`
+- `stage.completed`
+  - required array (may be empty)
+  - values must come from the same allowed set as `stage.current`
+  - should list previously completed stages in order, not only the immediately previous stage
+
 Suggested minimal shape:
 
 ```yaml

--- a/docs/orchestration-role-handoff-contract.md
+++ b/docs/orchestration-role-handoff-contract.md
@@ -129,7 +129,7 @@ Every handoff should include:
 - `requested_action`: expected receiver action (`implement`, `review`, `validate`, `integrate`, or `decide`)
 - `acceptance_criteria`: concrete completion bar for this handoff
 - `status`: `proposed`, `accepted`, `needs-clarification`, `blocked`, or `complete`
-- `context_scope`: optional but recommended summary of what was read, what was intentionally not read, and whether broader context escalation is requested
+- `context_scope`: optional but recommended summary of what was read, what was intentionally not read, and whether broader context escalation is requested (see staged runtime rules in [`docs/runtime-context-budgeting-and-repo-reading.md`](./runtime-context-budgeting-and-repo-reading.md))
 
 Suggested minimal shape:
 
@@ -164,6 +164,11 @@ context_scope:
     - apps/api/test/issues/normalize.test.ts
   intentionally_not_read:
     - apps/web/**
+  stage:
+    current: deepen
+    completed:
+      - discover
+      - select
   escalation_requested: false
 ```
 

--- a/docs/runtime-context-budgeting-and-repo-reading.md
+++ b/docs/runtime-context-budgeting-and-repo-reading.md
@@ -63,6 +63,32 @@ Each stage should produce one explicit output before moving to the next:
 Generated skills should treat stage outputs as local checkpoints.
 If a stage output is missing, execution should not silently skip to later stages.
 
+#### Stage Output Recording
+
+Stage outputs should be recorded in a lightweight structured format so checkpoint validation is explicit.
+
+Recommended stage output shapes:
+
+- `discover`
+  - bounded map keyed by directory/package, with likely entry points and short provenance notes
+- `select`
+  - prioritized candidate-file list with include/exclude rationale
+- `deepen`
+  - per-file focused notes, dependency links, and read status
+- `execute`
+  - scoped change payload describing touched files and intended acceptance criteria
+- `verify`
+  - evidence bundle with checks performed plus pass/block outcome
+
+Recommended storage locations:
+
+- local execution logs
+- handoff payloads (required for non-trivial `sub-agent` and `agent-team` transitions)
+- builder metadata artifacts when available
+
+Before advancing stages, one validator (lead, owner-of-record, or equivalent runtime check) should confirm the current stage output is complete enough for the next stage.
+If stage output is missing or incomplete, halt progression and request clarification or escalate explicitly.
+
 ### Smallest Useful Read Wins
 
 Agents should read the minimum material required to make the next correct decision.
@@ -123,14 +149,19 @@ Budget selection should align with the orchestration tier:
 ## Candidate-File Discovery Budgets
 
 Candidate-file budgets keep selective reading bounded and reviewable while staying provider-neutral.
+In this contract, an execution `slice` means one owner-of-record work portion:
+
+- `solo`: one aggregate slice for the task
+- `sub-agent`: one slice per specialist
+- `agent-team`: one slice per owner-of-record role
 
 Default discovery budgets:
 
 - `solo` + `narrow`: start with 3-8 candidate files
 - `solo` + `medium`: start with 8-15 candidate files
 - `sub-agent` lead: 8-20 candidate files across shared context
-- `sub-agent` specialist slice: 3-10 candidate files per slice
-- `agent-team` role slice: 5-15 candidate files per owner-of-record slice
+- `sub-agent` specialist: 3-10 candidate files per specialist slice
+- `agent-team` owner-of-record role: 5-15 candidate files per role slice
 
 Escalation rule:
 
@@ -254,6 +285,13 @@ Candidate-selection stop rule:
 - stop adding files once the current budget range is met unless a defined escalation trigger is already present
 - record intentionally skipped siblings so later reviewers can verify boundary decisions
 
+Example escalation-trigger exception:
+
+- validation uncovers cross-package coupling after the budget limit is reached
+- continue adding only files needed for the coupled package
+- record skipped siblings and the trigger evidence
+- formally escalate and re-run `discover` and `select`
+
 ### Deep-Reading Phase
 
 Perform full-content reads only for files in the current candidate set and immediate dependencies.
@@ -268,7 +306,7 @@ When escalating, record what triggered broader reading and which new areas were 
 
 Re-read limits:
 
-- do not deep-read the same file more than twice in one execution pass unless new evidence changed assumptions
+- do not deep-read the same file more than twice per execution cycle (one complete `discover` -> `select` -> `deepen` -> `execute` -> `verify` cycle) unless new evidence changed assumptions
 - if repeated re-reads are required, escalate and document what new dependency or ambiguity was introduced
 
 ## Escalation Triggers
@@ -378,6 +416,29 @@ Generated skills should include these explicit runtime rules:
 5. Stop broad discovery once enough evidence exists to pick a bounded execution slice.
 6. Re-open previously read files only when new evidence invalidates earlier assumptions.
 7. Keep one candidate-file ledger per execution slice to avoid duplicate broad discovery across specialists.
+
+### Candidate-File Ledger Format
+
+Each execution slice ledger should track:
+
+- `files_in_candidate_set`
+  - all files currently selected for the slice
+- `files_deeply_read`
+  - subset that received full-content reads
+- `budget_range`
+  - active discovery budget for the slice (for example `3-8`)
+- `escalation_count`
+  - number of context-budget escalations for the slice
+
+Ledger flow in collaborative tiers:
+
+- lead shares initial ledger state in delegation handoff payloads
+- specialists update slice ledgers during execution
+- specialists return updated ledgers in completion handoffs
+- lead merges ledgers for integration and review reporting
+
+After escalation, update both `budget_range` and `escalation_count` before adding new files.
+This ledger complements `context_scope.read` from the handoff contract: `context_scope.read` captures what was read, while the ledger captures selection boundaries, deep-read subset, and escalation history.
 
 ## Progressive-Context Escalation Triggers
 

--- a/docs/runtime-context-budgeting-and-repo-reading.md
+++ b/docs/runtime-context-budgeting-and-repo-reading.md
@@ -52,6 +52,17 @@ Default sequence:
 4. execute
 5. verify
 
+Each stage should produce one explicit output before moving to the next:
+
+- `discover`: bounded map of relevant directories/packages and likely entry points
+- `select`: candidate-file list with priorities and exclusions
+- `deepen`: focused notes from full reads of selected files and immediate dependencies
+- `execute`: implementation or doc edits limited to current scope
+- `verify`: evidence summary (tests/checks/manual review) plus pass/block status
+
+Generated skills should treat stage outputs as local checkpoints.
+If a stage output is missing, execution should not silently skip to later stages.
+
 ### Smallest Useful Read Wins
 
 Agents should read the minimum material required to make the next correct decision.
@@ -74,6 +85,24 @@ Examples of acceptable constraints:
 - number of directories scanned before escalating to broader discovery
 - maximum re-read loops before requesting clarification
 
+## Deterministic Progressive-Loading Rules
+
+Generated skills should enforce the following default runtime algorithm:
+
+1. run one discovery pass before any deep file reads
+2. derive a bounded candidate-file set from discovery evidence
+3. deep-read only candidate files and immediate dependencies
+4. execute one scoped implementation pass
+5. verify against explicit acceptance criteria
+6. escalate context only when escalation triggers are met
+
+Deterministic guardrails:
+
+- do not deep-read files outside the candidate set unless escalation is triggered
+- do not add a new package/domain during `execute`; return to `discover` first
+- do not run more than two `select` -> `deepen` loops without either escalating or requesting clarification
+- do not mark `verify` complete when unresolved ambiguity still affects correctness claims
+
 ## Context Budget Levels
 
 Generated skills should use these qualitative budget levels:
@@ -90,6 +119,28 @@ Budget selection should align with the orchestration tier:
 - `solo`: start `narrow`, escalate to `medium` only with explicit trigger
 - `sub-agent`: lead may use `medium`; specialists should usually start `narrow`
 - `agent-team`: allow `medium` to `wide`, but require explicit ownership boundaries and scoped handoff payloads
+
+## Candidate-File Discovery Budgets
+
+Candidate-file budgets keep selective reading bounded and reviewable while staying provider-neutral.
+
+Default discovery budgets:
+
+- `solo` + `narrow`: start with 3-8 candidate files
+- `solo` + `medium`: start with 8-15 candidate files
+- `sub-agent` lead: 8-20 candidate files across shared context
+- `sub-agent` specialist slice: 3-10 candidate files per slice
+- `agent-team` role slice: 5-15 candidate files per owner-of-record slice
+
+Escalation rule:
+
+- if evidence remains insufficient after the current budget is exhausted, escalate one budget level and record:
+  - trigger condition
+  - newly added directories/packages
+  - revised candidate-file ceiling
+
+These ranges are guidance ceilings for first-pass selection, not mandatory deep-read targets.
+Reading fewer files is preferred when confidence is already sufficient.
 
 ## Model-Tier Vocabulary
 
@@ -198,6 +249,11 @@ Selection priorities:
 
 Avoid deep-reading unrelated sibling packages during this phase.
 
+Candidate-selection stop rule:
+
+- stop adding files once the current budget range is met unless a defined escalation trigger is already present
+- record intentionally skipped siblings so later reviewers can verify boundary decisions
+
 ### Deep-Reading Phase
 
 Perform full-content reads only for files in the current candidate set and immediate dependencies.
@@ -209,6 +265,11 @@ Escalate to broader reading only when one of the following occurs:
 - risk signals indicate high blast radius
 
 When escalating, record what triggered broader reading and which new areas were added.
+
+Re-read limits:
+
+- do not deep-read the same file more than twice in one execution pass unless new evidence changed assumptions
+- if repeated re-reads are required, escalate and document what new dependency or ambiguity was introduced
 
 ## Escalation Triggers
 
@@ -233,6 +294,21 @@ Escalate collaboration tier when at least one trigger is true and lower tiers ar
 - integration churn shows that bounded hub-and-spoke delegation is no longer stabilizing outcomes
 
 If `sub-agent` remains viable with explicit bounded handoffs, do not escalate to `agent-team`.
+
+### Wider Context Escalation (`narrow` -> `medium` -> `wide`)
+
+Escalate context budget level only when at least one trigger is true:
+
+- two focused `select` -> `deepen` passes failed to resolve implementation ambiguity
+- verification failed due to missing cross-package or cross-domain evidence
+- reviewer/validator identified a potential correctness issue outside the current scope boundary
+- handoff payloads repeatedly request context outside assigned ownership boundaries
+
+Escalation discipline:
+
+- escalate one level at a time
+- re-run `discover` and `select` after each escalation before further deep reads
+- if `wide` still fails to resolve correctness-critical ambiguity, request explicit clarification instead of continuing blind
 
 ## Small Task Vs Large Repo Behavior
 
@@ -301,6 +377,7 @@ Generated skills should include these explicit runtime rules:
 4. For code, read call sites and tests nearest to the change before reading transitive dependencies.
 5. Stop broad discovery once enough evidence exists to pick a bounded execution slice.
 6. Re-open previously read files only when new evidence invalidates earlier assumptions.
+7. Keep one candidate-file ledger per execution slice to avoid duplicate broad discovery across specialists.
 
 ## Progressive-Context Escalation Triggers
 
@@ -318,7 +395,7 @@ Generated review metadata should summarize these escalations in human-readable f
 ### Good Pattern: Bounded Discovery Before Editing
 
 - list repo structure and search for target symbols
-- select 3-8 candidate files
+- select a bounded candidate set for the current budget level
 - deep-read only selected files
 - implement, verify, and stop
 
@@ -380,6 +457,16 @@ Why this is bad:
 
 - multiplies context cost with little quality gain
 - undermines lead ownership and structured handoffs
+
+### Anti-Pattern: Unbounded Candidate Creep
+
+- candidate-file set keeps growing during execution without explicit escalation
+
+Why this is bad:
+
+- hides scope drift
+- defeats selective-reading guarantees
+- makes evidence and review metadata hard to trust
 
 ### Anti-Pattern: Correctness-Critical Team Pinning
 


### PR DESCRIPTION
## Summary
- tighten runtime context-budgeting and repo-reading into a deterministic staged workflow
- add explicit candidate-file discovery budgets and widening triggers that stay provider-neutral
- cross-link orchestration/handoff/layout contracts to the canonical runtime rules without duplicating logic

## Scope
- issue #24 only

## Testing
- docs consistency review via diff and contract cross-link checks

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded review outputs to report adherence to staged runtime sequencing and per-slice candidate-file budget ranges, noting skipped stages and rationale; reporting format varies by orchestration tier.
  * Clarified execution-stage specifications and progressive context-loading order (discover → select → deepen → execute → verify) with deterministic escalation and re-run rules.
  * Enhanced handoff contract to require explicit staged progress tracking.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->