### PR TITLE
docs: add phase-2 reasoning-effort guidance

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -52,7 +52,7 @@ This is an important boundary. We can help users connect systems, but we are not
 - **Composable over monolithic**: use small fragments that can be assembled into project-specific skills.
 - **Repo-local precedence**: generated skills should live in the project and override user-level defaults.
 - **Smallest capable team**: orchestration should start with the minimum agent team needed for the task.
-- **Efficient by default**: context use, model routing, and subtask boundaries should minimize waste.
+- **Efficient by default**: context use, model routing, reasoning effort, and subtask boundaries should minimize waste.
 - **Human-reviewable output**: generated skills should be easy to understand, edit, and version.
 
 ## Epics
@@ -256,6 +256,7 @@ Non-goals:
 - Epic 4: Delivery Workflow Coverage
 - Epic 5: Team Sizing And Orchestration Strategy
 - Epic 6: Runtime Efficiency And Model Routing
+  - Includes context budgeting, model routing, reasoning-effort tuning, and bounded subtask delegation as separate but related runtime levers.
 
 ### Phase 3
 

--- a/docs/runtime-context-budgeting-and-repo-reading.md
+++ b/docs/runtime-context-budgeting-and-repo-reading.md
@@ -4,6 +4,7 @@ This document defines the proposed contracts for issues:
 
 - [#24 Define context-budgeting and repo-reading rules](https://github.com/peakweb-team/pw-agency-agents/issues/24)
 - [#25 Define model-routing and subtask-splitting heuristics](https://github.com/peakweb-team/pw-agency-agents/issues/25)
+- [#55 Define reasoning-effort and token-budget heuristics](https://github.com/peakweb-team/pw-agency-agents/issues/55)
 
 It builds on:
 
@@ -17,9 +18,9 @@ It builds on:
 
 ## Why This Exists
 
-Generated skills need one provider-neutral runtime policy for how much context to load, how to read repositories efficiently, how to split subtasks, and how to route model strength.
+Generated skills need one provider-neutral runtime policy for how much context to load, how to read repositories efficiently, how to split subtasks, how to route model strength, and how to tune reasoning effort when the runtime exposes that control.
 
-Without this contract, large repos risk wasteful full-repo reading, small tasks risk unnecessary orchestration overhead, and model selection becomes inconsistent and costly.
+Without this contract, large repos risk wasteful full-repo reading, small tasks risk unnecessary orchestration overhead, and model or effort selection becomes inconsistent and costly.
 
 ## Goals
 
@@ -28,6 +29,7 @@ Without this contract, large repos risk wasteful full-repo reading, small tasks 
 - define file-discovery and selective-reading behavior before deep file ingestion
 - define progressive context-expansion rules that are deterministic and reviewable
 - define provider-neutral model-routing heuristics for each collaboration tier
+- define provider-neutral reasoning-effort heuristics that complement model routing without replacing it
 - define bounded subtask-splitting rules that minimize overlap and duplicate context loading
 - include concrete examples and anti-patterns for generated execution behavior
 
@@ -100,6 +102,12 @@ When uncertainty remains high after selective reading, widen scope deliberately 
 Generated skills should route to the least expensive model tier that can still satisfy correctness and delivery-risk needs for the current step.
 
 Escalate model strength only when explicit triggers fire, and record escalation reasons in review metadata.
+
+### Lowest Sufficient Effort Wins
+
+When a provider exposes an explicit reasoning-effort control, generated skills should start with the lowest effort setting likely to satisfy the task and escalate only when task risk, ambiguity, or prior failure signals justify spending more.
+
+Effort selection should complement model-tier routing and context budgeting rather than override them.
 
 ### Provider-Neutral Budgeting
 


### PR DESCRIPTION
## Summary
- update Phase 2 roadmap language to explicitly include reasoning-effort tuning as a runtime efficiency lever
- align the runtime context/model routing contract with new effort-guidance scope
- add a new provider-neutral policy section for effort escalation behavior when runtimes expose explicit effort controls

## Details
- updates the `Efficient by default` principle in `ROADMAP.md`
- adds a Phase 2 sequencing note under the Runtime Efficiency epic in `ROADMAP.md`
- links issue #55 from `docs/runtime-context-budgeting-and-repo-reading.md`
- introduces `Lowest Sufficient Effort Wins` guidance to complement model routing and context budgeting

## Related
- #55
- #8

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced design principles documentation with runtime efficiency mechanisms.
  * Introduced new operational policy guidance for effort-based optimization strategies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->