### PR TITLE
Issue #26: ship reusable skill fragments in install/package flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -602,7 +602,7 @@ The Agency works natively with Claude Code, and ships conversion + install scrip
 
 ### Supported Tools
 
-- **[Claude Code](https://claude.ai/code)** — native `.md` agents, no conversion needed → `~/.claude/agents/`
+- **[Claude Code](https://claude.ai/code)** — native `.md` agents plus Peakweb reusable skill bundle → `~/.claude/agents/` and `~/.claude/skills/peakweb-skill-builder/`
 - **[GitHub Copilot](https://github.com/copilot)** — native `.md` agents, no conversion needed → `~/.github/agents/` + `~/.copilot/agents/`
 - **[Antigravity](https://github.com/google-gemini/antigravity)** — `SKILL.md` per agent → `~/.gemini/antigravity/skills/`
 - **[Gemini CLI](https://github.com/google-gemini/gemini-cli)** — extension + `SKILL.md` files → `~/.gemini/extensions/agency-agents/`
@@ -687,6 +687,11 @@ The installer scans your system for installed tools, shows a checkbox UI, and le
 
 Agents are copied directly from the repo into `~/.claude/agents/` -- no conversion needed.
 
+The same install also ships the reusable Peakweb skill bundle to:
+
+- `~/.claude/skills/peakweb-skill-builder/SKILL.md`
+- `~/.claude/skills/peakweb-skill-builder/fragments/**/*.md`
+
 ```bash
 ./scripts/install.sh --tool claude-code
 ```
@@ -697,6 +702,8 @@ Use the Frontend Developer agent to review this component.
 ```
 
 See [integrations/claude-code/README.md](integrations/claude-code/README.md) for details.
+
+Installation/packaging migration expectations for this reusable fragment bundle are defined in [docs/install-packaging-skill-fragments-contract.md](docs/install-packaging-skill-fragments-contract.md).
 </details>
 
 <details>

--- a/docs/generated-skill-layout.md
+++ b/docs/generated-skill-layout.md
@@ -17,6 +17,7 @@ It builds on:
 - the project integration declaration format in [`docs/project-integration-declaration-format.md`](./project-integration-declaration-format.md)
 - the capability fallback contract in [`docs/capability-fallback-behavior.md`](./capability-fallback-behavior.md)
 - the release versioning and upgrade contract in [`docs/release-versioning-and-upgrade-contract.md`](./release-versioning-and-upgrade-contract.md)
+- the user-level install and packaging contract for reusable fragments in [`docs/install-packaging-skill-fragments-contract.md`](./install-packaging-skill-fragments-contract.md)
 - the roadmap direction toward a workflow operating system instead of a loose prompt library
 
 ## Why This Exists

--- a/docs/install-packaging-skill-fragments-contract.md
+++ b/docs/install-packaging-skill-fragments-contract.md
@@ -1,0 +1,100 @@
+# Installation And Packaging Contract For Reusable Skill Fragments
+
+This document defines the canonical install/packaging contract for issue `#26`:
+
+- [#26 Ship reusable skill fragments in installation and packaging flow](https://github.com/peakweb-team/pw-agency-agents/issues/26)
+
+It aligns with:
+
+- the generated-skill layout and precedence rules in [`docs/generated-skill-layout.md`](./generated-skill-layout.md)
+- the release and upgrade contract in [`docs/release-versioning-and-upgrade-contract.md`](./release-versioning-and-upgrade-contract.md)
+- the Phase 3 packaging/adoption milestone in [`ROADMAP.md`](../ROADMAP.md)
+
+## Why This Exists
+
+Peakweb now has two user-level assets that must ship together:
+
+- the base agent roster
+- the reusable skill-builder and fragment source bundle
+
+Without an explicit install contract, users can end up with agents installed but no fragment library available for project-local generation.
+
+## User-Level Installation Paths (Claude-First MVP)
+
+When users run:
+
+```bash
+./scripts/install.sh --tool claude-code
+```
+
+the installer must place assets at deterministic user-level paths:
+
+- agents:
+  - `~/.claude/agents/*.md`
+- reusable skill bundle:
+  - `~/.claude/skills/peakweb-skill-builder/SKILL.md`
+  - `~/.claude/skills/peakweb-skill-builder/fragments/**/*.md`
+
+The reusable bundle path is intentionally namespaced (`peakweb-`) so it does not collide with unrelated local skills.
+
+## Packaging Behavior
+
+Peakweb framework packaging for install flows must include all of the following source inputs:
+
+- `agents/**`
+- `skills/skill-builder/SKILL.md`
+- `skills/fragments/**/*.md`
+- `scripts/install.sh`
+
+Installer behavior for the reusable skill bundle is deterministic:
+
+1. `SKILL.md` is copied into `~/.claude/skills/peakweb-skill-builder/`.
+2. The target `fragments/` subtree under that bundle is replaced.
+3. Current repository fragments are copied into the rebuilt subtree.
+
+Step 2 ensures removed or renamed fragments do not linger as stale local files across reinstall/upgrade runs.
+
+## Relationship To Repo-Local Generated Output
+
+This contract does not change generated output roots:
+
+- generated project-local skills remain under `.claude/skills/peakweb/`
+- generated metadata remains under `.agency/skills/peakweb/`
+
+User-level reusable fragments are source material for generation. Repo-local generated output remains the project-authoritative execution layer.
+
+## Migration Expectations
+
+### Existing users with agents-only Claude installs
+
+If a user previously installed only `~/.claude/agents`, migration is:
+
+1. pull a release that includes this contract
+2. rerun `./scripts/install.sh --tool claude-code`
+
+Expected result:
+
+- existing agent files are refreshed as before
+- the reusable skill bundle is added at `~/.claude/skills/peakweb-skill-builder/`
+
+No project-local generated files are created or overwritten by this installer step.
+
+### Existing users with repo-local generated skills
+
+No immediate regeneration is required purely because the user-level fragment bundle is now installed.
+
+Regeneration guidance continues to follow [`docs/release-versioning-and-upgrade-contract.md`](./release-versioning-and-upgrade-contract.md).
+
+## MVP Boundary
+
+This contract requires:
+
+- deterministic user-level installation paths for reusable fragments
+- packaging that ships fragments with the roster install flow
+- explicit migration guidance for agents-only installs
+
+This contract does not require:
+
+- automatic project-local generation during installation
+- automatic migration of hand-edited generated skills
+- provider-specific runtime guarantees beyond the existing Claude-first MVP scope

--- a/docs/release-versioning-and-upgrade-contract.md
+++ b/docs/release-versioning-and-upgrade-contract.md
@@ -7,6 +7,7 @@ This document defines the proposed contract for issue `#48`:
 It builds on:
 
 - the generated output contract in [`docs/generated-skill-layout.md`](./generated-skill-layout.md)
+- the install/packaging contract for reusable fragments in [`docs/install-packaging-skill-fragments-contract.md`](./install-packaging-skill-fragments-contract.md)
 - the fragment metadata contract in [`docs/fragment-schema.md`](./fragment-schema.md)
 - the fragment assembly contract in [`docs/fragment-assembly-rules.md`](./fragment-assembly-rules.md)
 - the project integration declaration format in [`docs/project-integration-declaration-format.md`](./project-integration-declaration-format.md)
@@ -55,6 +56,8 @@ Installed Peakweb files and repo-local generated skills are two different upgrad
 The installed framework may update through GitHub releases.
 
 The repo-local generated bundle must be evaluated against that release instead of being silently assumed current.
+
+The installed framework now includes both the agent roster and the reusable skill-fragment bundle described in [`docs/install-packaging-skill-fragments-contract.md`](./install-packaging-skill-fragments-contract.md).
 
 ## Version Layers
 

--- a/integrations/README.md
+++ b/integrations/README.md
@@ -5,7 +5,7 @@ supported agentic coding tools.
 
 ## Supported Tools
 
-- **[Claude Code](#claude-code)** — `.md` agents, use the repo directly
+- **[Claude Code](#claude-code)** — `.md` agents plus reusable Peakweb skill bundle
 - **[GitHub Copilot](#github-copilot)** — `.md` agents, use the repo directly
 - **[Antigravity](#antigravity)** — `SKILL.md` per agent in `antigravity/`
 - **[Gemini CLI](#gemini-cli)** — extension + `SKILL.md` files in `gemini-cli/`
@@ -62,13 +62,22 @@ If you add or modify agents, regenerate all integration files:
 ## Claude Code
 
 The Agency was originally designed for Claude Code. Agents work natively
-without conversion.
+without conversion, and the installer also ships the reusable Peakweb
+skill-builder bundle.
 
 ```bash
 cp -r <category>/*.md ~/.claude/agents/
-# or install everything at once:
+# or install everything at once (agents + reusable fragment bundle):
 ./scripts/install.sh --tool claude-code
 ```
+
+Reusable fragment bundle path:
+
+- `~/.claude/skills/peakweb-skill-builder/SKILL.md`
+- `~/.claude/skills/peakweb-skill-builder/fragments/**/*.md`
+
+Migration and packaging expectations are defined in
+[`docs/install-packaging-skill-fragments-contract.md`](../docs/install-packaging-skill-fragments-contract.md).
 
 See [claude-code/README.md](claude-code/README.md) for details.
 

--- a/integrations/claude-code/README.md
+++ b/integrations/claude-code/README.md
@@ -3,10 +3,14 @@
 The Agency was built for Claude Code. No conversion needed — agents work
 natively with the existing `.md` + YAML frontmatter format.
 
+The Claude install flow now also ships a reusable Peakweb skill bundle
+containing the skill-builder and fragment source library.
+
 ## Install
 
 ```bash
 # Copy all agents to your Claude Code agents directory
+# and install the Peakweb reusable fragment bundle
 ./scripts/install.sh --tool claude-code
 
 # Or manually copy a category
@@ -29,3 +33,12 @@ Use the Reality Checker agent to verify this feature is production-ready.
 
 Agents are organized into divisions. See the [main README](../../README.md) for
 the full Agency roster.
+
+Reusable skill bundle path:
+
+- `~/.claude/skills/peakweb-skill-builder/SKILL.md`
+- `~/.claude/skills/peakweb-skill-builder/fragments/**/*.md`
+
+Install/packaging and migration contract:
+
+- [`docs/install-packaging-skill-fragments-contract.md`](../../docs/install-packaging-skill-fragments-contract.md)

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -313,14 +313,43 @@ interactive_select() {
 
 install_claude_code() {
   local dest="${HOME}/.claude/agents"
+  local skills_parent="${HOME}/.claude/skills"
   local skills_dest="${HOME}/.claude/skills/peakweb-skill-builder"
+  local skills_stage=""
   local builder_src="$SKILLS_ROOT/skill-builder/SKILL.md"
   local fragments_src="$SKILLS_ROOT/fragments"
-  local fragments_stage=""
   local count=0
   local fragment_count=0
+  local dir f first_line rel dest_dir
+
+  [[ -f "$builder_src" ]] || { err "skills/skill-builder/SKILL.md missing."; return 1; }
+  [[ -d "$fragments_src" ]] || { err "skills/fragments missing."; return 1; }
+
+  mkdir -p "$skills_parent"
+  skills_stage="$(mktemp -d "$skills_parent/peakweb-skill-builder.tmp.XXXXXX")"
+  trap '[[ -n "$skills_stage" && -d "$skills_stage" ]] && rm -rf "$skills_stage"' RETURN
+  cp "$builder_src" "$skills_stage/SKILL.md"
+  mkdir -p "$skills_stage/fragments"
+
+  # Stage fragment copies first; only replace the live bundle after a full successful copy.
+  while IFS= read -r -d '' f; do
+    rel="${f#"$fragments_src"/}"
+    dest_dir="$(dirname "$skills_stage/fragments/$rel")"
+    mkdir -p "$dest_dir"
+    cp "$f" "$skills_stage/fragments/$rel"
+    (( fragment_count++ )) || true
+  done < <(find "$fragments_src" -name "*.md" -type f -print0)
+  if (( fragment_count == 0 )); then
+    rm -rf "$skills_stage"
+    err "skills/fragments contains no .md files."
+    return 1
+  fi
+  rm -rf "$skills_dest"
+  mv "$skills_stage" "$skills_dest"
+  skills_stage=""
+  trap - RETURN
+
   mkdir -p "$dest"
-  local dir f first_line
   for dir in "${AGENT_DIRS[@]}"; do
     [[ -d "$AGENTS_ROOT/$dir" ]] || continue
     while IFS= read -r -d '' f; do
@@ -330,29 +359,6 @@ install_claude_code() {
       (( count++ )) || true
     done < <(find "$AGENTS_ROOT/$dir" -name "*.md" -type f -print0)
   done
-  [[ -f "$builder_src" ]] || { err "skills/skill-builder/SKILL.md missing."; return 1; }
-  [[ -d "$fragments_src" ]] || { err "skills/fragments missing."; return 1; }
-
-  mkdir -p "$skills_dest"
-  cp "$builder_src" "$skills_dest/SKILL.md"
-
-  # Stage fragment copies first; only replace the live bundle after a full successful copy.
-  fragments_stage="$(mktemp -d "$skills_dest/fragments.tmp.XXXXXX")"
-  while IFS= read -r -d '' f; do
-    local rel dest_dir
-    rel="${f#"$fragments_src"/}"
-    dest_dir="$(dirname "$fragments_stage/$rel")"
-    mkdir -p "$dest_dir"
-    cp "$f" "$fragments_stage/$rel"
-    (( fragment_count++ )) || true
-  done < <(find "$fragments_src" -name "*.md" -type f -print0)
-  if (( fragment_count == 0 )); then
-    rm -rf "$fragments_stage"
-    err "skills/fragments contains no .md files."
-    return 1
-  fi
-  rm -rf "$skills_dest/fragments"
-  mv "$fragments_stage" "$skills_dest/fragments"
 
   ok "Claude Code: $count agents -> $dest"
   ok "Claude Code: skill-builder + $fragment_count fragments -> $skills_dest"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -137,6 +137,13 @@ check_integrations() {
   fi
 }
 
+tool_requires_integrations() {
+  case "$1" in
+    claude-code|copilot) return 1 ;;
+    *) return 0 ;;
+  esac
+}
+
 # ---------------------------------------------------------------------------
 # Tool detection
 # ---------------------------------------------------------------------------
@@ -581,8 +588,6 @@ main() {
     esac
   done
 
-  check_integrations
-
   # Validate explicit tool
   if [[ "$tool" != "all" ]]; then
     local valid=false t
@@ -630,6 +635,18 @@ main() {
     dim "  Tip: use --tool <name> to force-install a specific tool."
     dim "  Available: ${ALL_TOOLS[*]}"
     exit 0
+  fi
+
+  local needs_integrations=false
+  local t
+  for t in "${SELECTED_TOOLS[@]}"; do
+    if tool_requires_integrations "$t"; then
+      needs_integrations=true
+      break
+    fi
+  done
+  if $needs_integrations; then
+    check_integrations
   fi
 
   # When parent runs install.sh --parallel, it spawns workers with AGENCY_INSTALL_WORKER=1

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -10,7 +10,7 @@
 #   ./scripts/install.sh [--tool <name>] [--interactive] [--no-interactive] [--parallel] [--jobs N] [--help]
 #
 # Tools:
-#   claude-code  -- Copy agents to ~/.claude/agents/
+#   claude-code  -- Copy agents to ~/.claude/agents/ and Peakweb skill bundle to ~/.claude/skills/peakweb-skill-builder/
 #   copilot      -- Copy agents to ~/.github/agents/ and ~/.copilot/agents/
 #   antigravity  -- Copy skills to ~/.gemini/antigravity/skills/
 #   gemini-cli   -- Install extension to ~/.gemini/extensions/agency-agents/
@@ -105,6 +105,7 @@ ALL_TOOLS=(claude-code copilot antigravity gemini-cli opencode openclaw cursor a
 
 # Standard agent category directories under agents/ (keep sorted, sync with convert.sh / lint-agents.sh)
 AGENTS_ROOT="$REPO_ROOT/agents"
+SKILLS_ROOT="$REPO_ROOT/skills"
 AGENT_DIRS=(
   academic design engineering finance game-development marketing paid-media product project-management
   sales spatial-computing specialized strategy support testing
@@ -305,7 +306,11 @@ interactive_select() {
 
 install_claude_code() {
   local dest="${HOME}/.claude/agents"
+  local skills_dest="${HOME}/.claude/skills/peakweb-skill-builder"
+  local builder_src="$SKILLS_ROOT/skill-builder/SKILL.md"
+  local fragments_src="$SKILLS_ROOT/fragments"
   local count=0
+  local fragment_count=0
   mkdir -p "$dest"
   local dir f first_line
   for dir in "${AGENT_DIRS[@]}"; do
@@ -317,7 +322,26 @@ install_claude_code() {
       (( count++ )) || true
     done < <(find "$AGENTS_ROOT/$dir" -name "*.md" -type f -print0)
   done
+  [[ -f "$builder_src" ]] || { err "skills/skill-builder/SKILL.md missing."; return 1; }
+  [[ -d "$fragments_src" ]] || { err "skills/fragments missing."; return 1; }
+
+  mkdir -p "$skills_dest"
+  cp "$builder_src" "$skills_dest/SKILL.md"
+
+  # Rebuild the fragment bundle on each install so removals are reflected deterministically.
+  rm -rf "$skills_dest/fragments"
+  mkdir -p "$skills_dest/fragments"
+  while IFS= read -r -d '' f; do
+    local rel dest_dir
+    rel="${f#"$fragments_src"/}"
+    dest_dir="$(dirname "$skills_dest/fragments/$rel")"
+    mkdir -p "$dest_dir"
+    cp "$f" "$skills_dest/fragments/$rel"
+    (( fragment_count++ )) || true
+  done < <(find "$fragments_src" -name "*.md" -type f -print0)
+
   ok "Claude Code: $count agents -> $dest"
+  ok "Claude Code: skill-builder + $fragment_count fragments -> $skills_dest"
 }
 
 install_copilot() {

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -316,6 +316,7 @@ install_claude_code() {
   local skills_dest="${HOME}/.claude/skills/peakweb-skill-builder"
   local builder_src="$SKILLS_ROOT/skill-builder/SKILL.md"
   local fragments_src="$SKILLS_ROOT/fragments"
+  local fragments_stage=""
   local count=0
   local fragment_count=0
   mkdir -p "$dest"
@@ -335,17 +336,23 @@ install_claude_code() {
   mkdir -p "$skills_dest"
   cp "$builder_src" "$skills_dest/SKILL.md"
 
-  # Rebuild the fragment bundle on each install so removals are reflected deterministically.
-  rm -rf "$skills_dest/fragments"
-  mkdir -p "$skills_dest/fragments"
+  # Stage fragment copies first; only replace the live bundle after a full successful copy.
+  fragments_stage="$(mktemp -d "$skills_dest/fragments.tmp.XXXXXX")"
   while IFS= read -r -d '' f; do
     local rel dest_dir
     rel="${f#"$fragments_src"/}"
-    dest_dir="$(dirname "$skills_dest/fragments/$rel")"
+    dest_dir="$(dirname "$fragments_stage/$rel")"
     mkdir -p "$dest_dir"
-    cp "$f" "$skills_dest/fragments/$rel"
+    cp "$f" "$fragments_stage/$rel"
     (( fragment_count++ )) || true
   done < <(find "$fragments_src" -name "*.md" -type f -print0)
+  if (( fragment_count == 0 )); then
+    rm -rf "$fragments_stage"
+    err "skills/fragments contains no .md files."
+    return 1
+  fi
+  rm -rf "$skills_dest/fragments"
+  mv "$fragments_stage" "$skills_dest/fragments"
 
   ok "Claude Code: $count agents -> $dest"
   ok "Claude Code: skill-builder + $fragment_count fragments -> $skills_dest"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -315,6 +315,7 @@ install_claude_code() {
   local dest="${HOME}/.claude/agents"
   local skills_parent="${HOME}/.claude/skills"
   local skills_dest="${HOME}/.claude/skills/peakweb-skill-builder"
+  local skills_backup="${HOME}/.claude/skills/peakweb-skill-builder.bak"
   local skills_stage=""
   local builder_src="$SKILLS_ROOT/skill-builder/SKILL.md"
   local fragments_src="$SKILLS_ROOT/fragments"
@@ -344,8 +345,19 @@ install_claude_code() {
     err "skills/fragments contains no .md files."
     return 1
   fi
-  rm -rf "$skills_dest"
-  mv "$skills_stage" "$skills_dest"
+  rm -rf "$skills_backup"
+  if [[ -d "$skills_dest" ]]; then
+    mv "$skills_dest" "$skills_backup"
+  fi
+  if ! mv "$skills_stage" "$skills_dest"; then
+    err "failed to activate staged skill bundle at $skills_dest"
+    rm -rf "$skills_dest"
+    if [[ -d "$skills_backup" ]]; then
+      mv "$skills_backup" "$skills_dest"
+    fi
+    return 1
+  fi
+  rm -rf "$skills_backup"
   skills_stage=""
   trap - RETURN
 

--- a/skills/README.md
+++ b/skills/README.md
@@ -39,6 +39,8 @@ The questionnaire and unresolved-decision contract now lives in [`docs/builder-q
 
 The generated-skill output, naming, and precedence contract now lives in [`docs/generated-skill-layout.md`](../docs/generated-skill-layout.md).
 
+The user-level installation and packaging contract for reusable fragments now lives in [`docs/install-packaging-skill-fragments-contract.md`](../docs/install-packaging-skill-fragments-contract.md).
+
 The external capability vocabulary that fragments and generated skills should rely on now lives in [`docs/external-capability-model.md`](../docs/external-capability-model.md).
 
 The repo-local provider and capability binding format now lives in [`docs/project-integration-declaration-format.md`](../docs/project-integration-declaration-format.md).
@@ -52,4 +54,7 @@ The fallback rules for unavailable, partial, or manual-only capabilities now liv
 3. The builder inspects the repo, confirms any missing details through a short questionnaire, and selects the relevant fragments.
 4. The builder assembles one primary skill and any needed companion skills under `.claude/skills/peakweb/`, then writes reviewable builder metadata under `.agency/skills/peakweb/`.
 
-This is scaffolding for the first iteration, not the final packaging or install behavior.
+User-level installation for the reusable fragment source bundle is now deterministic via `./scripts/install.sh --tool claude-code`:
+
+- `~/.claude/skills/peakweb-skill-builder/SKILL.md`
+- `~/.claude/skills/peakweb-skill-builder/fragments/**/*.md`


### PR DESCRIPTION
## Summary
- make `./scripts/install.sh --tool claude-code` install the reusable Peakweb skill bundle (`SKILL.md` + `fragments/**`) under `~/.claude/skills/peakweb-skill-builder/`
- add a dedicated install/packaging contract doc for reusable fragments, including deterministic path, packaging inputs, and migration behavior
- update install-facing docs (root README, integrations docs, skills README) plus contract cross-links for generated-skill/release docs

## Verification
- `bash -n scripts/install.sh`
- `HOME=$(mktemp -d) ./scripts/install.sh --tool claude-code --no-interactive` and verify:
  - `~/.claude/skills/peakweb-skill-builder/SKILL.md` exists
  - fragment markdown files are installed under `~/.claude/skills/peakweb-skill-builder/fragments/`

Closes #26


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Installation and integration docs updated: Claude Code now documents that installs include a reusable Peakweb skill‑fragment bundle and links to a new install/packaging contract with layout and migration guidance for users who previously had agents-only installs.

* **Chores**
  * Installer enhanced to deploy and deterministically manage the reusable skill‑fragment bundle alongside agent installs, with clearer success messaging and migration expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->