### PR TITLE
Docs: add missing Roadmap link for install/packaging contract

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -172,6 +172,10 @@ Non-goals:
 
 Make the new skills layer installable, understandable, and usable alongside the existing agent roster.
 
+Canonical install/packaging contract:
+
+- [`docs/install-packaging-skill-fragments-contract.md`](./docs/install-packaging-skill-fragments-contract.md)
+
 Goals:
 
 - ship the base agents and reusable skill fragments together


### PR DESCRIPTION
## Summary
- add the missing Epic 7 roadmap backlink to the install/packaging contract doc
- align `ROADMAP.md` with the already-merged contract documentation for installation/packaging behavior

## Why
This appears to have been omitted during earlier docs updates; this PR restores the expected roadmap-to-contract linkage without changing implementation behavior.

## Scope
- `ROADMAP.md` only


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated roadmap to include a reference to the canonical install/packaging contract documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->