### PR TITLE
Document builder usage flow and repo-local precedence

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,9 @@ The intended flow looks like this:
 2. Run the `skill-builder` skill inside a target repository.
 3. Let it inspect the repo and confirm only the missing workflow details.
 4. Generate project-local skills from reusable fragments.
-5. Commit those generated skills with the project so the team can review and evolve them over time.
+5. Commit generated output roots (`.claude/skills/peakweb/` and `.agency/skills/peakweb/`) with the project so the team can review and evolve them over time.
+
+For a step-by-step usage runbook and deterministic precedence rules, see [`docs/builder-usage-and-repo-local-precedence-contract.md`](docs/builder-usage-and-repo-local-precedence-contract.md).
 
 That gives teams a practical path from generic specialist agents to a repeatable delivery system tailored to how they actually work.
 
@@ -104,6 +106,8 @@ Browse the agents below and copy/adapt the ones you need!
 Project-specific skills are starting to live in [`skills/`](skills/README.md). The long-term direction is for a builder skill to assemble repo-specific skills from reusable fragments and place the generated result inside the target project.
 
 The fragment metadata contract for that builder is documented in [`docs/fragment-schema.md`](docs/fragment-schema.md).
+
+Builder usage flow, repo-local precedence, and review/versioning expectations are documented in [`docs/builder-usage-and-repo-local-precedence-contract.md`](docs/builder-usage-and-repo-local-precedence-contract.md).
 
 ### Option 3: Use with Other Tools (GitHub Copilot, Antigravity, Gemini CLI, OpenCode, OpenClaw, Cursor, Aider, Windsurf, Kimi Code)
 

--- a/docs/builder-usage-and-repo-local-precedence-contract.md
+++ b/docs/builder-usage-and-repo-local-precedence-contract.md
@@ -1,0 +1,153 @@
+# Builder Usage And Repo-Local Precedence Contract
+
+This document defines the canonical user-facing contract for issue `#27`:
+
+- [#27 Document builder usage and repo-local skill precedence](https://github.com/peakweb-team/pw-agency-agents/issues/27)
+
+It aligns with:
+
+- the generated-skill layout and precedence rules in [`docs/generated-skill-layout.md`](./generated-skill-layout.md)
+- the install/packaging contract for reusable fragments in [`docs/install-packaging-skill-fragments-contract.md`](./install-packaging-skill-fragments-contract.md)
+- the release versioning and generated-skill upgrade contract in [`docs/release-versioning-and-upgrade-contract.md`](./release-versioning-and-upgrade-contract.md)
+- the Phase 3 packaging/adoption milestone in [`ROADMAP.md`](../ROADMAP.md)
+
+## Why This Exists
+
+After installation, teams need a single, practical answer to three questions:
+
+1. How do we run the builder inside a target repository?
+2. Which skill wins when user-level and repo-local skills both exist?
+3. How should generated repo-local output be reviewed, versioned, and regenerated?
+
+This contract answers those questions without changing existing install, layout, or release semantics.
+
+## Scope
+
+This contract covers:
+
+- builder usage flow inside a target repository
+- precedence between user-level reusable skills and repo-local generated skills
+- review/versioning guidance for generated repo-local output
+
+This contract does not cover:
+
+- automatic integration provisioning
+- provider-specific credential setup
+- changes to generated output roots or schema
+
+## Preconditions
+
+Before running the builder in a repository:
+
+1. Install Peakweb at user level with:
+   - `./scripts/install.sh --tool claude-code`
+2. Confirm reusable builder source material exists at:
+   - `~/.claude/skills/peakweb-skill-builder/SKILL.md`
+   - `~/.claude/skills/peakweb-skill-builder/fragments/**/*.md`
+3. Ensure any external tools you expect to use are already configured by your team.
+
+The builder consumes configured capabilities. It does not auto-provision integrations.
+
+## Builder Usage Flow In A Target Repository
+
+Run the builder from the repository root that should receive generated skills.
+
+### Step 1: Start In The Target Repository
+
+- `cd /path/to/target-repo`
+
+Builder output is repository-local, so running in the correct root is required.
+
+### Step 2: Invoke The Installed Builder Skill
+
+In your coding assistant session, invoke the installed `peakweb-skill-builder` skill and ask it to generate Peakweb project-local skills for the current repository.
+
+The builder should:
+
+- inventory repo signals
+- ask focused follow-up questions when confidence is insufficient
+- choose applicable fragments
+- assemble generated project-local skills and metadata
+
+### Step 3: Confirm Generated Output Roots
+
+After generation, confirm both repo-local roots exist:
+
+- execution-facing generated skills:
+  - `.claude/skills/peakweb/`
+- builder metadata bundle:
+  - `.agency/skills/peakweb/`
+
+If only one root exists, treat the run as incomplete and regenerate.
+
+### Step 4: Review Before Commit
+
+Review generated artifacts as normal project files, including:
+
+- generated `SKILL.md` and `skill.json` files under `.claude/skills/peakweb/`
+- metadata files under `.agency/skills/peakweb/`
+- `review.md` for assumptions, unresolved decisions, compatibility notes, and warnings
+
+### Step 5: Commit Generated Output Together
+
+Commit both roots in the same change:
+
+- `.claude/skills/peakweb/**`
+- `.agency/skills/peakweb/**`
+
+Committing both preserves what will execute and why it was assembled that way.
+
+## Precedence Rules (User-Level Vs Repo-Local)
+
+Precedence is repository-scoped and deterministic.
+
+1. Repo-local generated Peakweb skills are authoritative for that repository.
+2. User-level installed skills are reusable defaults and source material for generation.
+3. If names overlap, the repo-local generated skill is the active one in that repository.
+4. The `peakweb-` namespace prevents accidental override of unrelated third-party skills.
+
+Practical meaning:
+
+- install updates improve reusable source material
+- execution in a repo follows the generated files committed in that repo
+- user-level installs do not silently overwrite repo-local generated files
+
+## Repo-Local Review And Versioning Guidance
+
+Generated skills are reviewable configuration, not disposable cache.
+
+### Review Expectations Per Builder Run
+
+Every generation or regeneration should include review of:
+
+- the generated skill text (`SKILL.md`) and any behavior shifts
+- `fragments.lock.yaml` changes (selected fragments and suppression/conflict outcomes)
+- `decisions.yaml` updates (confirmed, assumed, unresolved)
+- `review.md` warnings and manual follow-ups
+
+### Versioning Expectations
+
+- Keep generated artifacts in normal repository history.
+- Use pull requests for generated output changes.
+- Treat hand-edited generated files as valid local changes that require diff review on regeneration.
+
+### Regeneration Triggers
+
+Regenerate when:
+
+- framework release notes mark regeneration as recommended or required
+- project workflow/tooling choices materially change
+- integration capability mappings change
+- generated output is missing required metadata or compatibility context
+
+Regeneration behavior and compatibility classification continue to follow [`docs/release-versioning-and-upgrade-contract.md`](./release-versioning-and-upgrade-contract.md).
+
+## Relationship To Existing Contracts
+
+This document is user-facing glue across existing contracts.
+
+- Install and packaging define how reusable source material is delivered.
+- Generated-skill layout defines output roots, naming, and metadata shape.
+- Release/upgrade defines compatibility posture and regeneration expectations.
+
+This contract does not replace those documents; it consolidates how teams should apply them in day-to-day repository usage.

--- a/docs/builder-usage-and-repo-local-precedence-contract.md
+++ b/docs/builder-usage-and-repo-local-precedence-contract.md
@@ -86,7 +86,7 @@ Review generated artifacts as normal project files, including:
 
 - generated `SKILL.md` and `skill.json` files under `.claude/skills/peakweb/`
 - metadata files under `.agency/skills/peakweb/`
-- `review.md` for assumptions, unresolved decisions, compatibility notes, and warnings
+- `.agency/skills/peakweb/review.md` for assumptions, unresolved decisions, compatibility notes, and warnings
 
 ### Step 5: Commit Generated Output Together
 

--- a/docs/generated-skill-layout.md
+++ b/docs/generated-skill-layout.md
@@ -18,6 +18,7 @@ It builds on:
 - the capability fallback contract in [`docs/capability-fallback-behavior.md`](./capability-fallback-behavior.md)
 - the release versioning and upgrade contract in [`docs/release-versioning-and-upgrade-contract.md`](./release-versioning-and-upgrade-contract.md)
 - the user-level install and packaging contract for reusable fragments in [`docs/install-packaging-skill-fragments-contract.md`](./install-packaging-skill-fragments-contract.md)
+- the user-facing builder usage and precedence contract in [`docs/builder-usage-and-repo-local-precedence-contract.md`](./builder-usage-and-repo-local-precedence-contract.md)
 - the roadmap direction toward a workflow operating system instead of a loose prompt library
 
 ## Why This Exists

--- a/docs/install-packaging-skill-fragments-contract.md
+++ b/docs/install-packaging-skill-fragments-contract.md
@@ -7,6 +7,7 @@ This document defines the canonical install/packaging contract for issue `#26`:
 It aligns with:
 
 - the generated-skill layout and precedence rules in [`docs/generated-skill-layout.md`](./generated-skill-layout.md)
+- the builder usage and repo-local precedence contract in [`docs/builder-usage-and-repo-local-precedence-contract.md`](./builder-usage-and-repo-local-precedence-contract.md)
 - the release and upgrade contract in [`docs/release-versioning-and-upgrade-contract.md`](./release-versioning-and-upgrade-contract.md)
 - the Phase 3 packaging/adoption milestone in [`ROADMAP.md`](../ROADMAP.md)
 

--- a/docs/release-versioning-and-upgrade-contract.md
+++ b/docs/release-versioning-and-upgrade-contract.md
@@ -8,6 +8,7 @@ It builds on:
 
 - the generated output contract in [`docs/generated-skill-layout.md`](./generated-skill-layout.md)
 - the install/packaging contract for reusable fragments in [`docs/install-packaging-skill-fragments-contract.md`](./install-packaging-skill-fragments-contract.md)
+- the builder usage and repo-local precedence contract in [`docs/builder-usage-and-repo-local-precedence-contract.md`](./builder-usage-and-repo-local-precedence-contract.md)
 - the fragment metadata contract in [`docs/fragment-schema.md`](./fragment-schema.md)
 - the fragment assembly contract in [`docs/fragment-assembly-rules.md`](./fragment-assembly-rules.md)
 - the project integration declaration format in [`docs/project-integration-declaration-format.md`](./project-integration-declaration-format.md)

--- a/integrations/README.md
+++ b/integrations/README.md
@@ -79,6 +79,9 @@ Reusable fragment bundle path:
 Migration and packaging expectations are defined in
 [`docs/install-packaging-skill-fragments-contract.md`](../docs/install-packaging-skill-fragments-contract.md).
 
+Builder usage flow, repo-local precedence rules, and generated-skill review/versioning guidance are defined in
+[`docs/builder-usage-and-repo-local-precedence-contract.md`](../docs/builder-usage-and-repo-local-precedence-contract.md).
+
 See [claude-code/README.md](claude-code/README.md) for details.
 
 ---

--- a/integrations/claude-code/README.md
+++ b/integrations/claude-code/README.md
@@ -42,3 +42,7 @@ Reusable skill bundle path:
 Install/packaging and migration contract:
 
 - [`docs/install-packaging-skill-fragments-contract.md`](../../docs/install-packaging-skill-fragments-contract.md)
+
+Builder usage flow, repo-local precedence rules, and generated-skill review/versioning guidance:
+
+- [`docs/builder-usage-and-repo-local-precedence-contract.md`](../../docs/builder-usage-and-repo-local-precedence-contract.md)

--- a/skills/README.md
+++ b/skills/README.md
@@ -39,6 +39,8 @@ The questionnaire and unresolved-decision contract now lives in [`docs/builder-q
 
 The generated-skill output, naming, and precedence contract now lives in [`docs/generated-skill-layout.md`](../docs/generated-skill-layout.md).
 
+The user-facing builder usage flow, repo-local precedence behavior, and review/versioning guidance now live in [`docs/builder-usage-and-repo-local-precedence-contract.md`](../docs/builder-usage-and-repo-local-precedence-contract.md).
+
 The user-level installation and packaging contract for reusable fragments now lives in [`docs/install-packaging-skill-fragments-contract.md`](../docs/install-packaging-skill-fragments-contract.md).
 
 The external capability vocabulary that fragments and generated skills should rely on now lives in [`docs/external-capability-model.md`](../docs/external-capability-model.md).
@@ -53,6 +55,7 @@ The fallback rules for unavailable, partial, or manual-only capabilities now liv
 2. The user runs the `skill-builder` skill inside a target project.
 3. The builder inspects the repo, confirms any missing details through a short questionnaire, and selects the relevant fragments.
 4. The builder assembles one primary skill and any needed companion skills under `.claude/skills/peakweb/`, then writes reviewable builder metadata under `.agency/skills/peakweb/`.
+5. The repo commits both generated roots together and treats repo-local generated output as authoritative over user-level defaults for that repository.
 
 User-level installation for the reusable fragment source bundle is now deterministic via `./scripts/install.sh --tool claude-code`:
 


### PR DESCRIPTION
## Summary
- add a canonical issue-27 contract doc for builder usage inside target repos
- document deterministic precedence for repo-local generated skills vs user-level installed defaults
- include repo-local review/versioning and regeneration guidance, then link this guidance from README, skills, integrations, and related contracts

## Testing
- docs consistency review across referenced contracts and entry points

Closes #27

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a canonical guide for the skill builder with step‑by‑step usage and validation.
  * Specifies committing generated output roots (.claude/skills/peakweb/ and .agency/skills/peakweb/) and post‑run checks.
  * Clarified deterministic repo‑local precedence (repo‑local generated skills override installed ones) and review/versioning expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->