### PR TITLE
Add generated skill reference scenarios for issue #28

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,8 @@ The intended flow looks like this:
 
 For a step-by-step usage runbook and deterministic precedence rules, see [`docs/builder-usage-and-repo-local-precedence-contract.md`](docs/builder-usage-and-repo-local-precedence-contract.md).
 
+For concrete generated outputs across GitHub-heavy, Jira-heavy/mixed, and direct-brief bootstrap workflows, see [`examples/generated-skills/`](examples/generated-skills/README.md).
+
 That gives teams a practical path from generic specialist agents to a repeatable delivery system tailored to how they actually work.
 
 ---
@@ -108,6 +110,8 @@ Project-specific skills are starting to live in [`skills/`](skills/README.md). T
 The fragment metadata contract for that builder is documented in [`docs/fragment-schema.md`](docs/fragment-schema.md).
 
 Builder usage flow, repo-local precedence, and review/versioning expectations are documented in [`docs/builder-usage-and-repo-local-precedence-contract.md`](docs/builder-usage-and-repo-local-precedence-contract.md).
+
+Reference generated-skill scenarios are available in [`examples/generated-skills/`](examples/generated-skills/README.md).
 
 ### Option 3: Use with Other Tools (GitHub Copilot, Antigravity, Gemini CLI, OpenCode, OpenClaw, Cursor, Aider, Windsurf, Kimi Code)
 

--- a/docs/builder-usage-and-repo-local-precedence-contract.md
+++ b/docs/builder-usage-and-repo-local-precedence-contract.md
@@ -97,6 +97,14 @@ Commit both roots in the same change:
 
 Committing both preserves what will execute and why it was assembled that way.
 
+### Step 6: Compare Against Reference Scenarios When Needed
+
+When reviewing generated output for a new repository or unusual workflow mix, compare against the reference bundles in [`examples/generated-skills/`](../examples/generated-skills/README.md) for:
+
+- GitHub-heavy dual-intake with layered review
+- Jira-heavy mixed delivery with dual intake
+- direct-brief-first bootstrap with explicit fallback/manual boundaries
+
 ## Precedence Rules (User-Level Vs Repo-Local)
 
 Precedence is repository-scoped and deterministic.

--- a/docs/generated-skill-layout.md
+++ b/docs/generated-skill-layout.md
@@ -316,6 +316,14 @@ However:
       review.md
 ```
 
+## Reference Scenarios
+
+For complete, reviewable example bundles that follow this layout contract, see:
+
+- [`examples/generated-skills/github-heavy-dual-intake-coderabbit/`](../examples/generated-skills/github-heavy-dual-intake-coderabbit/)
+- [`examples/generated-skills/jira-heavy-mixed-delivery/`](../examples/generated-skills/jira-heavy-mixed-delivery/)
+- [`examples/generated-skills/direct-brief-vibe-bootstrap/`](../examples/generated-skills/direct-brief-vibe-bootstrap/)
+
 ## MVP Boundary
 
 This contract is intentionally narrow for v1.

--- a/examples/generated-skills/README.md
+++ b/examples/generated-skills/README.md
@@ -1,0 +1,46 @@
+# Generated Skill Reference Scenarios
+
+This directory contains concrete, repo-local generated-skill examples that follow the contracts in [`docs/generated-skill-layout.md`](../../docs/generated-skill-layout.md).
+
+Each scenario includes both required output roots:
+
+- execution-facing generated skills under `.claude/skills/peakweb/`
+- builder metadata under `.agency/skills/peakweb/`
+
+## Scenarios
+
+### 1. GitHub-heavy with layered review and dual intake
+
+Path: [`github-heavy-dual-intake-coderabbit/`](./github-heavy-dual-intake-coderabbit/)
+
+Highlights:
+
+- GitHub Issues as tracked-task system of record
+- GitHub PR workflow with CodeRabbit layered input
+- direct-brief intake kept active alongside tracked-task intake
+
+### 2. Jira-heavy with mixed GitHub delivery and dual intake
+
+Path: [`jira-heavy-mixed-delivery/`](./jira-heavy-mixed-delivery/)
+
+Highlights:
+
+- Jira as primary task tracker
+- GitHub pull requests as code-host review system of record
+- direct-brief bootstrap supported for exploratory work while tracked-task flow remains primary
+
+### 3. Direct-brief vibe bootstrap (tracker optional)
+
+Path: [`direct-brief-vibe-bootstrap/`](./direct-brief-vibe-bootstrap/)
+
+Highlights:
+
+- direct-brief as primary intake mode
+- assumption capture and runtime guardrails emphasized
+- tracked-task bindings intentionally unresolved/optional to keep integration boundary explicit
+
+## Notes
+
+- These artifacts are examples for documentation and review workflows.
+- They are designed to be realistic and diffable, not placeholders.
+- Capability bindings intentionally include warning/manual examples where coverage is partial.

--- a/examples/generated-skills/direct-brief-vibe-bootstrap/.agency/skills/peakweb/decisions.yaml
+++ b/examples/generated-skills/direct-brief-vibe-bootstrap/.agency/skills/peakweb/decisions.yaml
@@ -1,0 +1,24 @@
+schema_version: 1
+generated_at: 2026-04-16T14:47:00Z
+decisions:
+  work_intake_mode:
+    value: direct-brief
+    decision_state: confirmed
+
+  primary_task_tracker:
+    value: none
+    decision_state: confirmed
+    rationale: External tracker intentionally optional for this repository stage.
+
+  tracker_escalation_policy:
+    value: on-demand
+    decision_state: confirmed
+    rationale: Create or link ticket only when team requests durable external traceability.
+
+  primary_code_host_review:
+    value: github-pull-requests
+    decision_state: assumed
+
+  runtime_context_budget:
+    value: narrow
+    decision_state: confirmed

--- a/examples/generated-skills/direct-brief-vibe-bootstrap/.agency/skills/peakweb/fragments.lock.yaml
+++ b/examples/generated-skills/direct-brief-vibe-bootstrap/.agency/skills/peakweb/fragments.lock.yaml
@@ -1,0 +1,26 @@
+schema_version: 1
+generated_at: 2026-04-16T14:47:00Z
+selected:
+  - id: task-intake/direct-brief
+    decision_state: confirmed
+    order: 10
+  - id: orchestration/team-sizing
+    decision_state: confirmed
+    order: 40
+  - id: delivery/pull-request-review
+    decision_state: assumed
+    order: 60
+  - id: runtime/context-and-model-routing
+    decision_state: confirmed
+    order: 80
+suppressed:
+  - id: project-management/github-issues
+    reason: not_applicable
+  - id: project-management/jira
+    reason: not_applicable
+emitted_blocks:
+  - task-intake
+  - assumption-capture
+  - team-sizing-rules
+  - review-loop
+  - context-budgeting

--- a/examples/generated-skills/direct-brief-vibe-bootstrap/.agency/skills/peakweb/integrations.yaml
+++ b/examples/generated-skills/direct-brief-vibe-bootstrap/.agency/skills/peakweb/integrations.yaml
@@ -1,0 +1,83 @@
+schema_version: 1
+generated_by: skill-builder
+generated_at: 2026-04-16T14:47:00Z
+providers:
+  local-direct-brief:
+    provider: local
+    kind: local
+    decision_state: confirmed
+    notes: Direct brief is the primary intake path.
+
+  github:
+    provider: github
+    kind: external
+    decision_state: assumed
+    notes: GitHub PR workflow inferred from repository conventions.
+
+capability_bindings:
+  task-intake.direct-brief:
+    provider_ref: local-direct-brief
+    support: full
+    decision_state: confirmed
+
+  task-intake.assumption-capture:
+    provider_ref: local-direct-brief
+    support: full
+    decision_state: confirmed
+
+  task-tracker.lookup:
+    provider_ref: local-direct-brief
+    support: unavailable
+    decision_state: confirmed
+    fallback_mode: continue
+    notes: Tracker lookup is optional in this direct-brief-first scenario.
+
+  task-tracker.read:
+    provider_ref: local-direct-brief
+    support: unavailable
+    decision_state: confirmed
+    fallback_mode: continue
+    notes: Continue using local brief artifacts as source of truth.
+
+  task-tracker.update:
+    provider_ref: local-direct-brief
+    support: unavailable
+    decision_state: confirmed
+    fallback_mode: manual
+    manual_steps:
+      - If a tracker is introduced later, post milestone summary and evidence manually.
+
+  code-host.pr.open:
+    provider_ref: github
+    support: full
+    decision_state: assumed
+
+  code-host.pr.update:
+    provider_ref: github
+    support: full
+    decision_state: assumed
+
+  code-host.pr.review-request:
+    provider_ref: github
+    support: partial
+    decision_state: assumed
+    fallback_mode: manual
+    manual_steps:
+      - Request reviewer assignment manually when automation is not configured.
+
+  code-host.pr.status-read:
+    provider_ref: github
+    support: partial
+    decision_state: assumed
+    fallback_mode: warn
+    notes: Verify final check state in host UI when status surfaces are incomplete.
+
+  review-feedback.read:
+    provider_ref: github
+    support: full
+    decision_state: assumed
+
+  review-feedback.respond:
+    provider_ref: github
+    support: full
+    decision_state: assumed

--- a/examples/generated-skills/direct-brief-vibe-bootstrap/.agency/skills/peakweb/inventory.yaml
+++ b/examples/generated-skills/direct-brief-vibe-bootstrap/.agency/skills/peakweb/inventory.yaml
@@ -1,0 +1,22 @@
+schema_version: 1
+repository: github.com/example/greenfield-studio
+generated_at: 2026-04-16T14:46:00Z
+signals:
+  input.direct_brief: true
+  workflow.bootstrap_greenfield_likely: true
+  workflow.task_tracker_optional: true
+  workflow.pull_requests: true
+  forge.github: true
+  task_tracker.github_issues: false
+  task_tracker.jira: false
+  repo.multi_step_delivery: true
+  workflow.model_budget_matters: true
+evidence:
+  - source: README.md
+    supports:
+      - workflow.bootstrap_greenfield_likely
+      - workflow.task_tracker_optional
+  - source: .github/pull_request_template.md
+    supports:
+      - workflow.pull_requests
+      - forge.github

--- a/examples/generated-skills/direct-brief-vibe-bootstrap/.agency/skills/peakweb/manifest.yaml
+++ b/examples/generated-skills/direct-brief-vibe-bootstrap/.agency/skills/peakweb/manifest.yaml
@@ -1,0 +1,19 @@
+schema_version: 1
+generated_by: skill-builder
+generated_at: 2026-04-16T14:47:00Z
+framework_release: v1.1.0
+repository: github.com/example/greenfield-studio
+bundle:
+  primary_skill: peakweb-workflow
+  companion_skills:
+    - peakweb-pr-review
+    - peakweb-task-tracking
+    - peakweb-runtime-guardrails
+contract_versions:
+  generated_skill_layout: 1
+  fragment_schema: 1
+  integration_declaration: 1
+compatibility:
+  status: compatible
+  reason: Generated on current framework release.
+  manual_review_required: true

--- a/examples/generated-skills/direct-brief-vibe-bootstrap/.agency/skills/peakweb/review.md
+++ b/examples/generated-skills/direct-brief-vibe-bootstrap/.agency/skills/peakweb/review.md
@@ -1,0 +1,23 @@
+# Builder Review Summary
+
+## Scenario
+
+Direct-brief-first bootstrap repository with tracker-optional policy.
+
+## Why This Shape Was Generated
+
+- Inventory and questionnaire confirmed direct-brief as primary intake mode.
+- No tracker provider was selected as system of record.
+- PR workflow remained active through assumed GitHub host capabilities.
+
+## Warnings And Manual Follow-Up
+
+- `code-host.pr.review-request` is partial and uses manual fallback.
+- `code-host.pr.status-read` is partial and requires host-UI verification.
+- Tracker capabilities are intentionally unavailable and do not block direct-brief flow.
+
+## Reviewer Checklist
+
+- Confirm tracker-optional policy still applies.
+- Confirm manual reviewer-request step is acceptable.
+- Confirm direct-brief assumption capture is visible in PR summaries.

--- a/examples/generated-skills/direct-brief-vibe-bootstrap/.claude/skills/peakweb/peakweb-pr-review/SKILL.md
+++ b/examples/generated-skills/direct-brief-vibe-bootstrap/.claude/skills/peakweb/peakweb-pr-review/SKILL.md
@@ -1,0 +1,11 @@
+# Peakweb PR Review (Direct-brief first)
+
+## Purpose
+
+Keep review handoff strong when work begins from a freeform brief instead of an external ticket.
+
+## Rules
+
+1. Open PR only after checklist and assumption log are current.
+2. Use PR body to summarize scope, acceptance target, and unresolved tradeoffs.
+3. Resolve review feedback as explicit tasks and refresh summary after each response batch.

--- a/examples/generated-skills/direct-brief-vibe-bootstrap/.claude/skills/peakweb/peakweb-pr-review/skill.json
+++ b/examples/generated-skills/direct-brief-vibe-bootstrap/.claude/skills/peakweb/peakweb-pr-review/skill.json
@@ -1,0 +1,19 @@
+{
+  "name": "peakweb-pr-review",
+  "generated_by": "skill-builder",
+  "generated_at": "2026-04-16T14:47:00Z",
+  "framework_release": "v1.1.0",
+  "schema_version": 1,
+  "repository": "github.com/example/greenfield-studio",
+  "role": "delivery review",
+  "selected_fragments": [
+    "delivery/pull-request-review",
+    "task-intake/direct-brief"
+  ],
+  "contract_versions": {
+    "generated_skill_layout": 1,
+    "fragment_schema": 1,
+    "integration_declaration": 1
+  },
+  "source_manifest": ".agency/skills/peakweb/manifest.yaml"
+}

--- a/examples/generated-skills/direct-brief-vibe-bootstrap/.claude/skills/peakweb/peakweb-runtime-guardrails/SKILL.md
+++ b/examples/generated-skills/direct-brief-vibe-bootstrap/.claude/skills/peakweb/peakweb-runtime-guardrails/SKILL.md
@@ -1,0 +1,12 @@
+# Peakweb Runtime Guardrails
+
+## Purpose
+
+Keep direct-brief execution fast and bounded in early-stage repositories.
+
+## Rules
+
+- Default to narrow context slices and expand only when unresolved ambiguity blocks progress.
+- Prefer lower-cost model tiers for framing and scaffolding.
+- Escalate model tier for architecture pivots or risky migrations.
+- Keep validation focused on user-visible outcomes from the brief.

--- a/examples/generated-skills/direct-brief-vibe-bootstrap/.claude/skills/peakweb/peakweb-runtime-guardrails/skill.json
+++ b/examples/generated-skills/direct-brief-vibe-bootstrap/.claude/skills/peakweb/peakweb-runtime-guardrails/skill.json
@@ -1,0 +1,19 @@
+{
+  "name": "peakweb-runtime-guardrails",
+  "generated_by": "skill-builder",
+  "generated_at": "2026-04-16T14:47:00Z",
+  "framework_release": "v1.1.0",
+  "schema_version": 1,
+  "repository": "github.com/example/greenfield-studio",
+  "role": "runtime",
+  "selected_fragments": [
+    "runtime/context-and-model-routing",
+    "orchestration/team-sizing"
+  ],
+  "contract_versions": {
+    "generated_skill_layout": 1,
+    "fragment_schema": 1,
+    "integration_declaration": 1
+  },
+  "source_manifest": ".agency/skills/peakweb/manifest.yaml"
+}

--- a/examples/generated-skills/direct-brief-vibe-bootstrap/.claude/skills/peakweb/peakweb-task-tracking/SKILL.md
+++ b/examples/generated-skills/direct-brief-vibe-bootstrap/.claude/skills/peakweb/peakweb-task-tracking/SKILL.md
@@ -1,0 +1,12 @@
+# Peakweb Task Tracking (Optional escalation)
+
+## Purpose
+
+Define how direct-brief work can be linked to a tracker later without making tracker usage mandatory.
+
+## Behavior
+
+- Keep local task checklist as primary record when no tracker is configured.
+- If the team requests ticket linkage, create or map a tracker reference before merge.
+- Copy key assumptions, risks, and validation evidence into the tracker once linked.
+- Until linkage exists, do not claim tracked-task capabilities are active.

--- a/examples/generated-skills/direct-brief-vibe-bootstrap/.claude/skills/peakweb/peakweb-task-tracking/skill.json
+++ b/examples/generated-skills/direct-brief-vibe-bootstrap/.claude/skills/peakweb/peakweb-task-tracking/skill.json
@@ -1,0 +1,18 @@
+{
+  "name": "peakweb-task-tracking",
+  "generated_by": "skill-builder",
+  "generated_at": "2026-04-16T14:47:00Z",
+  "framework_release": "v1.1.0",
+  "schema_version": 1,
+  "repository": "github.com/example/greenfield-studio",
+  "role": "optional task tracking",
+  "selected_fragments": [
+    "task-intake/direct-brief"
+  ],
+  "contract_versions": {
+    "generated_skill_layout": 1,
+    "fragment_schema": 1,
+    "integration_declaration": 1
+  },
+  "source_manifest": ".agency/skills/peakweb/manifest.yaml"
+}

--- a/examples/generated-skills/direct-brief-vibe-bootstrap/.claude/skills/peakweb/peakweb-workflow/SKILL.md
+++ b/examples/generated-skills/direct-brief-vibe-bootstrap/.claude/skills/peakweb/peakweb-workflow/SKILL.md
@@ -1,0 +1,31 @@
+# Peakweb Workflow (Direct-brief vibe bootstrap)
+
+## Mission
+
+Start from a human brief, shape it into executable slices, and deliver review-ready changes without requiring a task tracker as a precondition.
+
+## Intake Policy
+
+1. Treat the incoming brief as authoritative initial scope.
+2. Produce a checklist, assumptions list, and unresolved questions before coding.
+3. Keep optional escalation path open for later tracked-task linkage if the team asks for durable ticketing.
+
+## Workflow
+
+1. Clarify goals, constraints, and success signals from the brief.
+2. Pick smallest capable team (`solo` by default unless risk is high).
+3. Implement in short slices with tight verification loops.
+4. Open PR and route review in code host.
+5. Capture follow-up work as local action items or optional tracker references.
+
+## Assumption Capture Rules
+
+- Record assumptions in review artifacts before implementation proceeds.
+- Mark unresolved decisions explicitly rather than hiding uncertainty.
+- Reconcile assumptions after feedback or validation failures.
+
+## Guardrails
+
+- Do not claim tracker synchronization happened when no tracker is configured.
+- Do not block implementation solely because external ticketing is absent.
+- Keep handoff notes explicit when humans must complete external updates later.

--- a/examples/generated-skills/direct-brief-vibe-bootstrap/.claude/skills/peakweb/peakweb-workflow/skill.json
+++ b/examples/generated-skills/direct-brief-vibe-bootstrap/.claude/skills/peakweb/peakweb-workflow/skill.json
@@ -1,0 +1,21 @@
+{
+  "name": "peakweb-workflow",
+  "generated_by": "skill-builder",
+  "generated_at": "2026-04-16T14:47:00Z",
+  "framework_release": "v1.1.0",
+  "schema_version": 1,
+  "repository": "github.com/example/greenfield-studio",
+  "role": "primary orchestration",
+  "selected_fragments": [
+    "task-intake/direct-brief",
+    "orchestration/team-sizing",
+    "delivery/pull-request-review",
+    "runtime/context-and-model-routing"
+  ],
+  "contract_versions": {
+    "generated_skill_layout": 1,
+    "fragment_schema": 1,
+    "integration_declaration": 1
+  },
+  "source_manifest": ".agency/skills/peakweb/manifest.yaml"
+}

--- a/examples/generated-skills/github-heavy-dual-intake-coderabbit/.agency/skills/peakweb/decisions.yaml
+++ b/examples/generated-skills/github-heavy-dual-intake-coderabbit/.agency/skills/peakweb/decisions.yaml
@@ -1,0 +1,24 @@
+schema_version: 1
+generated_at: 2026-04-16T14:20:00Z
+decisions:
+  work_intake_mode:
+    value: both
+    decision_state: confirmed
+    rationale: Team accepts GitHub-issue intake and direct briefs for exploratory tasks.
+
+  primary_task_tracker:
+    value: github-issues
+    decision_state: confirmed
+
+  primary_code_host_review:
+    value: github-pull-requests
+    decision_state: confirmed
+
+  layered_review:
+    value: coderabbit
+    decision_state: confirmed
+
+  runtime_context_budget:
+    value: medium
+    decision_state: assumed
+    rationale: Repository size and reviewer loop suggest bounded expansion.

--- a/examples/generated-skills/github-heavy-dual-intake-coderabbit/.agency/skills/peakweb/fragments.lock.yaml
+++ b/examples/generated-skills/github-heavy-dual-intake-coderabbit/.agency/skills/peakweb/fragments.lock.yaml
@@ -1,0 +1,28 @@
+schema_version: 1
+generated_at: 2026-04-16T14:20:00Z
+selected:
+  - id: task-intake/direct-brief
+    decision_state: confirmed
+    order: 10
+  - id: project-management/github-issues
+    decision_state: confirmed
+    order: 20
+  - id: orchestration/team-sizing
+    decision_state: confirmed
+    order: 40
+  - id: delivery/pull-request-review
+    decision_state: confirmed
+    order: 60
+  - id: runtime/context-and-model-routing
+    decision_state: assumed
+    order: 80
+suppressed:
+  - id: project-management/jira
+    reason: suppressed_by_exclusivity
+    bucket: primary-task-tracker
+emitted_blocks:
+  - task-intake
+  - task-status-updates
+  - team-sizing-rules
+  - review-loop
+  - context-budgeting

--- a/examples/generated-skills/github-heavy-dual-intake-coderabbit/.agency/skills/peakweb/integrations.yaml
+++ b/examples/generated-skills/github-heavy-dual-intake-coderabbit/.agency/skills/peakweb/integrations.yaml
@@ -1,0 +1,79 @@
+schema_version: 1
+generated_by: skill-builder
+generated_at: 2026-04-16T14:20:00Z
+providers:
+  local-direct-brief:
+    provider: local
+    kind: local
+    decision_state: confirmed
+    notes: Direct brief is allowed as first-class intake.
+
+  github:
+    provider: github
+    kind: external
+    decision_state: confirmed
+    notes: GitHub is task tracker and code host of record.
+
+  coderabbit:
+    provider: coderabbit
+    kind: external
+    decision_state: confirmed
+    notes: Layered review automation is additive to native GitHub review.
+
+capability_bindings:
+  task-intake.direct-brief:
+    provider_ref: local-direct-brief
+    support: full
+    decision_state: confirmed
+
+  task-intake.assumption-capture:
+    provider_ref: local-direct-brief
+    support: full
+    decision_state: confirmed
+
+  task-tracker.lookup:
+    provider_ref: github
+    support: full
+    decision_state: confirmed
+
+  task-tracker.read:
+    provider_ref: github
+    support: full
+    decision_state: confirmed
+
+  task-tracker.update:
+    provider_ref: github
+    support: full
+    decision_state: confirmed
+
+  code-host.pr.open:
+    provider_ref: github
+    support: full
+    decision_state: confirmed
+
+  code-host.pr.update:
+    provider_ref: github
+    support: full
+    decision_state: confirmed
+
+  code-host.pr.review-request:
+    provider_ref: github
+    support: full
+    decision_state: confirmed
+
+  code-host.pr.status-read:
+    provider_ref: github
+    support: full
+    decision_state: confirmed
+
+  review-feedback.read:
+    provider_ref: coderabbit
+    support: partial
+    decision_state: confirmed
+    fallback_mode: warn
+    notes: Use GitHub human review queue as baseline source of truth.
+
+  review-feedback.respond:
+    provider_ref: github
+    support: full
+    decision_state: confirmed

--- a/examples/generated-skills/github-heavy-dual-intake-coderabbit/.agency/skills/peakweb/inventory.yaml
+++ b/examples/generated-skills/github-heavy-dual-intake-coderabbit/.agency/skills/peakweb/inventory.yaml
@@ -1,0 +1,25 @@
+schema_version: 1
+repository: github.com/example/atlas-portal
+generated_at: 2026-04-16T14:19:00Z
+signals:
+  forge.github: true
+  workflow.pull_requests: true
+  review.coderabbit: true
+  task_tracker.github_issues: true
+  repo.references_issue_numbers: true
+  workflow.task_tracker_optional: true
+  input.direct_brief: true
+  repo.multi_step_delivery: true
+  workflow.model_budget_matters: true
+evidence:
+  - source: .github/workflows/pr.yml
+    supports:
+      - workflow.pull_requests
+      - forge.github
+  - source: docs/contributing.md
+    supports:
+      - repo.references_issue_numbers
+      - task_tracker.github_issues
+  - source: .coderabbit.yaml
+    supports:
+      - review.coderabbit

--- a/examples/generated-skills/github-heavy-dual-intake-coderabbit/.agency/skills/peakweb/manifest.yaml
+++ b/examples/generated-skills/github-heavy-dual-intake-coderabbit/.agency/skills/peakweb/manifest.yaml
@@ -1,0 +1,19 @@
+schema_version: 1
+generated_by: skill-builder
+generated_at: 2026-04-16T14:20:00Z
+framework_release: v1.1.0
+repository: github.com/example/atlas-portal
+bundle:
+  primary_skill: peakweb-workflow
+  companion_skills:
+    - peakweb-pr-review
+    - peakweb-task-tracking
+    - peakweb-runtime-guardrails
+contract_versions:
+  generated_skill_layout: 1
+  fragment_schema: 1
+  integration_declaration: 1
+compatibility:
+  status: compatible
+  reason: Generated on current framework release.
+  manual_review_required: false

--- a/examples/generated-skills/github-heavy-dual-intake-coderabbit/.agency/skills/peakweb/review.md
+++ b/examples/generated-skills/github-heavy-dual-intake-coderabbit/.agency/skills/peakweb/review.md
@@ -1,0 +1,22 @@
+# Builder Review Summary
+
+## Scenario
+
+GitHub-heavy repository with CodeRabbit layered review and dual intake support.
+
+## Why This Shape Was Generated
+
+- GitHub Issues evidence was strong and confirmed as primary tracked-task system.
+- Direct brief remained enabled because the team explicitly allows exploratory work to start without an issue.
+- CodeRabbit was included as additive review input, not review-of-record replacement.
+
+## Warnings And Manual Follow-Up
+
+- `review-feedback.read` is partial for CodeRabbit and marked `warn`; unresolved GitHub review threads remain the baseline queue.
+- No manual-only capability bindings are active in this scenario.
+
+## Reviewer Checklist
+
+- Confirm direct-brief and tracked-task coexistence is still policy.
+- Confirm CodeRabbit usage is additive and does not bypass human approval rules.
+- Confirm runtime budget assumptions remain appropriate for current repo size.

--- a/examples/generated-skills/github-heavy-dual-intake-coderabbit/.claude/skills/peakweb/peakweb-pr-review/SKILL.md
+++ b/examples/generated-skills/github-heavy-dual-intake-coderabbit/.claude/skills/peakweb/peakweb-pr-review/SKILL.md
@@ -1,0 +1,13 @@
+# Peakweb PR Review (GitHub + CodeRabbit)
+
+## Purpose
+
+Keep PR review legible and complete when human GitHub review and CodeRabbit automation both contribute.
+
+## Rules
+
+1. Open PR only after meaningful local validation.
+2. Keep PR body updated with scope, test evidence, and known risks.
+3. Request human review in GitHub even when CodeRabbit is enabled.
+4. Treat unresolved comments as a queue and close the loop visibly.
+5. Summarize what changed after feedback-driven commits.

--- a/examples/generated-skills/github-heavy-dual-intake-coderabbit/.claude/skills/peakweb/peakweb-pr-review/skill.json
+++ b/examples/generated-skills/github-heavy-dual-intake-coderabbit/.claude/skills/peakweb/peakweb-pr-review/skill.json
@@ -1,0 +1,19 @@
+{
+  "name": "peakweb-pr-review",
+  "generated_by": "skill-builder",
+  "generated_at": "2026-04-16T14:20:00Z",
+  "framework_release": "v1.1.0",
+  "schema_version": 1,
+  "repository": "github.com/example/atlas-portal",
+  "role": "delivery review",
+  "selected_fragments": [
+    "delivery/pull-request-review",
+    "runtime/context-and-model-routing"
+  ],
+  "contract_versions": {
+    "generated_skill_layout": 1,
+    "fragment_schema": 1,
+    "integration_declaration": 1
+  },
+  "source_manifest": ".agency/skills/peakweb/manifest.yaml"
+}

--- a/examples/generated-skills/github-heavy-dual-intake-coderabbit/.claude/skills/peakweb/peakweb-runtime-guardrails/SKILL.md
+++ b/examples/generated-skills/github-heavy-dual-intake-coderabbit/.claude/skills/peakweb/peakweb-runtime-guardrails/SKILL.md
@@ -1,0 +1,13 @@
+# Peakweb Runtime Guardrails
+
+## Purpose
+
+Constrain context and model usage so GitHub-heavy delivery loops remain efficient.
+
+## Rules
+
+- Start with narrow context and expand only when blocked.
+- Prefer lower-cost model tiers for discovery and scaffolding.
+- Escalate model strength only for ambiguous architecture or high-risk review.
+- Split work into non-overlapping slices before delegating.
+- Re-check merge readiness before claiming completion.

--- a/examples/generated-skills/github-heavy-dual-intake-coderabbit/.claude/skills/peakweb/peakweb-runtime-guardrails/skill.json
+++ b/examples/generated-skills/github-heavy-dual-intake-coderabbit/.claude/skills/peakweb/peakweb-runtime-guardrails/skill.json
@@ -1,0 +1,19 @@
+{
+  "name": "peakweb-runtime-guardrails",
+  "generated_by": "skill-builder",
+  "generated_at": "2026-04-16T14:20:00Z",
+  "framework_release": "v1.1.0",
+  "schema_version": 1,
+  "repository": "github.com/example/atlas-portal",
+  "role": "runtime",
+  "selected_fragments": [
+    "runtime/context-and-model-routing",
+    "orchestration/team-sizing"
+  ],
+  "contract_versions": {
+    "generated_skill_layout": 1,
+    "fragment_schema": 1,
+    "integration_declaration": 1
+  },
+  "source_manifest": ".agency/skills/peakweb/manifest.yaml"
+}

--- a/examples/generated-skills/github-heavy-dual-intake-coderabbit/.claude/skills/peakweb/peakweb-task-tracking/SKILL.md
+++ b/examples/generated-skills/github-heavy-dual-intake-coderabbit/.claude/skills/peakweb/peakweb-task-tracking/SKILL.md
@@ -1,0 +1,13 @@
+# Peakweb Task Tracking (GitHub Issues)
+
+## Purpose
+
+Manage tracked-task context in GitHub Issues while still allowing direct-brief intake when no issue is provided.
+
+## Behavior
+
+- Normalize issue references before reading or updating.
+- Extract acceptance criteria and convert to execution checklist.
+- Post milestone updates at start, review-ready, and completion points.
+- Include PR link and validation evidence in completion update.
+- If work began from direct brief only, do not fabricate issue updates.

--- a/examples/generated-skills/github-heavy-dual-intake-coderabbit/.claude/skills/peakweb/peakweb-task-tracking/skill.json
+++ b/examples/generated-skills/github-heavy-dual-intake-coderabbit/.claude/skills/peakweb/peakweb-task-tracking/skill.json
@@ -1,0 +1,19 @@
+{
+  "name": "peakweb-task-tracking",
+  "generated_by": "skill-builder",
+  "generated_at": "2026-04-16T14:20:00Z",
+  "framework_release": "v1.1.0",
+  "schema_version": 1,
+  "repository": "github.com/example/atlas-portal",
+  "role": "task tracking",
+  "selected_fragments": [
+    "project-management/github-issues",
+    "task-intake/direct-brief"
+  ],
+  "contract_versions": {
+    "generated_skill_layout": 1,
+    "fragment_schema": 1,
+    "integration_declaration": 1
+  },
+  "source_manifest": ".agency/skills/peakweb/manifest.yaml"
+}

--- a/examples/generated-skills/github-heavy-dual-intake-coderabbit/.claude/skills/peakweb/peakweb-workflow/SKILL.md
+++ b/examples/generated-skills/github-heavy-dual-intake-coderabbit/.claude/skills/peakweb/peakweb-workflow/SKILL.md
@@ -1,0 +1,49 @@
+# Peakweb Workflow (GitHub-heavy dual intake)
+
+## Mission
+
+Run implementation work using the smallest capable team while supporting two valid intake paths:
+
+- tracked-task intake from GitHub Issues
+- direct-brief intake from a freeform operator brief
+
+Choose intake per request and keep the chosen path explicit in updates.
+
+## Intake Selection
+
+1. If the request includes an issue reference (number, URL, or repo-qualified id), treat it as tracked-task intake.
+2. If no issue reference is provided, start from direct brief and create an assumption log.
+3. When both exist, use the issue as system of record and include brief-only assumptions as supplements.
+
+## Workflow
+
+1. Discover minimal context first.
+2. Pick `solo`, `sub-agent`, or `agent-team` using risk and scope.
+3. Implement in bounded slices.
+4. Validate locally before review handoff.
+5. Open/update PR and request review path.
+6. Resolve review feedback and refresh status summaries.
+
+## Tracked-Task Responsibilities
+
+- Read issue context before coding when tracked-task intake is selected.
+- Keep issue updates milestone-oriented, not commit-by-commit logs.
+- Link PR and verification evidence in issue updates.
+
+## Direct-Brief Responsibilities
+
+- Convert brief into a checklist, assumptions, and unresolved questions.
+- Keep assumptions visible in local artifacts.
+- Escalate to tracked-task mode only when project policy requires durable tracker state.
+
+## Review Loop
+
+- Use GitHub PR review as review system of record.
+- Treat CodeRabbit findings as layered, additive input.
+- Respond to substantive findings with visible PR follow-up.
+
+## Guardrails
+
+- Do not claim external updates were performed when they were manual-only.
+- Do not collapse direct-brief and tracked-task evidence into one ambiguous status.
+- Keep repo-local generated behavior authoritative over user-level defaults for this repository.

--- a/examples/generated-skills/github-heavy-dual-intake-coderabbit/.claude/skills/peakweb/peakweb-workflow/skill.json
+++ b/examples/generated-skills/github-heavy-dual-intake-coderabbit/.claude/skills/peakweb/peakweb-workflow/skill.json
@@ -1,0 +1,22 @@
+{
+  "name": "peakweb-workflow",
+  "generated_by": "skill-builder",
+  "generated_at": "2026-04-16T14:20:00Z",
+  "framework_release": "v1.1.0",
+  "schema_version": 1,
+  "repository": "github.com/example/atlas-portal",
+  "role": "primary orchestration",
+  "selected_fragments": [
+    "task-intake/direct-brief",
+    "project-management/github-issues",
+    "orchestration/team-sizing",
+    "delivery/pull-request-review",
+    "runtime/context-and-model-routing"
+  ],
+  "contract_versions": {
+    "generated_skill_layout": 1,
+    "fragment_schema": 1,
+    "integration_declaration": 1
+  },
+  "source_manifest": ".agency/skills/peakweb/manifest.yaml"
+}

--- a/examples/generated-skills/jira-heavy-mixed-delivery/.agency/skills/peakweb/decisions.yaml
+++ b/examples/generated-skills/jira-heavy-mixed-delivery/.agency/skills/peakweb/decisions.yaml
@@ -1,0 +1,24 @@
+schema_version: 1
+generated_at: 2026-04-16T14:35:00Z
+decisions:
+  work_intake_mode:
+    value: both
+    decision_state: confirmed
+    rationale: Team allows direct-brief spikes but requires Jira linkage for durable delivery.
+
+  primary_task_tracker:
+    value: jira
+    decision_state: confirmed
+
+  primary_code_host_review:
+    value: github-pull-requests
+    decision_state: confirmed
+
+  jira_update_mode:
+    value: manual-assist
+    decision_state: confirmed
+    rationale: Automation can read Jira but update permissions vary across projects.
+
+  runtime_context_budget:
+    value: medium
+    decision_state: assumed

--- a/examples/generated-skills/jira-heavy-mixed-delivery/.agency/skills/peakweb/fragments.lock.yaml
+++ b/examples/generated-skills/jira-heavy-mixed-delivery/.agency/skills/peakweb/fragments.lock.yaml
@@ -1,0 +1,28 @@
+schema_version: 1
+generated_at: 2026-04-16T14:35:00Z
+selected:
+  - id: task-intake/direct-brief
+    decision_state: confirmed
+    order: 10
+  - id: project-management/jira
+    decision_state: confirmed
+    order: 20
+  - id: orchestration/team-sizing
+    decision_state: confirmed
+    order: 40
+  - id: delivery/pull-request-review
+    decision_state: confirmed
+    order: 60
+  - id: runtime/context-and-model-routing
+    decision_state: assumed
+    order: 80
+suppressed:
+  - id: project-management/github-issues
+    reason: suppressed_by_exclusivity
+    bucket: primary-task-tracker
+emitted_blocks:
+  - task-intake
+  - task-status-updates
+  - team-sizing-rules
+  - review-loop
+  - context-budgeting

--- a/examples/generated-skills/jira-heavy-mixed-delivery/.agency/skills/peakweb/integrations.yaml
+++ b/examples/generated-skills/jira-heavy-mixed-delivery/.agency/skills/peakweb/integrations.yaml
@@ -1,0 +1,81 @@
+schema_version: 1
+generated_by: skill-builder
+generated_at: 2026-04-16T14:35:00Z
+providers:
+  local-direct-brief:
+    provider: local
+    kind: local
+    decision_state: confirmed
+    notes: Direct brief is enabled for bootstrap work.
+
+  jira:
+    provider: jira
+    kind: external
+    decision_state: confirmed
+    notes: Jira is tracked-task system of record.
+
+  github:
+    provider: github
+    kind: external
+    decision_state: confirmed
+    notes: GitHub is code-host review-of-record.
+
+capability_bindings:
+  task-intake.direct-brief:
+    provider_ref: local-direct-brief
+    support: full
+    decision_state: confirmed
+
+  task-intake.assumption-capture:
+    provider_ref: local-direct-brief
+    support: full
+    decision_state: confirmed
+
+  task-tracker.lookup:
+    provider_ref: jira
+    support: full
+    decision_state: confirmed
+
+  task-tracker.read:
+    provider_ref: jira
+    support: full
+    decision_state: confirmed
+
+  task-tracker.update:
+    provider_ref: jira
+    support: partial
+    decision_state: confirmed
+    fallback_mode: manual
+    manual_steps:
+      - Post milestone progress and completion comments in Jira manually.
+      - Add PR link and validation evidence before closing the Jira ticket.
+
+  code-host.pr.open:
+    provider_ref: github
+    support: full
+    decision_state: confirmed
+
+  code-host.pr.update:
+    provider_ref: github
+    support: full
+    decision_state: confirmed
+
+  code-host.pr.review-request:
+    provider_ref: github
+    support: full
+    decision_state: confirmed
+
+  code-host.pr.status-read:
+    provider_ref: github
+    support: full
+    decision_state: confirmed
+
+  review-feedback.read:
+    provider_ref: github
+    support: full
+    decision_state: confirmed
+
+  review-feedback.respond:
+    provider_ref: github
+    support: full
+    decision_state: confirmed

--- a/examples/generated-skills/jira-heavy-mixed-delivery/.agency/skills/peakweb/inventory.yaml
+++ b/examples/generated-skills/jira-heavy-mixed-delivery/.agency/skills/peakweb/inventory.yaml
@@ -1,0 +1,22 @@
+schema_version: 1
+repository: github.com/example/billing-gateway
+generated_at: 2026-04-16T14:34:00Z
+signals:
+  forge.github: true
+  workflow.pull_requests: true
+  task_tracker.jira: true
+  repo.references_jira_keys: true
+  workflow.task_tracker_optional: true
+  input.direct_brief: true
+  review.coderabbit: false
+  repo.multi_step_delivery: true
+  workflow.model_budget_matters: true
+evidence:
+  - source: docs/release-process.md
+    supports:
+      - task_tracker.jira
+      - repo.references_jira_keys
+  - source: .github/pull_request_template.md
+    supports:
+      - workflow.pull_requests
+      - forge.github

--- a/examples/generated-skills/jira-heavy-mixed-delivery/.agency/skills/peakweb/manifest.yaml
+++ b/examples/generated-skills/jira-heavy-mixed-delivery/.agency/skills/peakweb/manifest.yaml
@@ -1,0 +1,19 @@
+schema_version: 1
+generated_by: skill-builder
+generated_at: 2026-04-16T14:35:00Z
+framework_release: v1.1.0
+repository: github.com/example/billing-gateway
+bundle:
+  primary_skill: peakweb-workflow
+  companion_skills:
+    - peakweb-pr-review
+    - peakweb-task-tracking
+    - peakweb-runtime-guardrails
+contract_versions:
+  generated_skill_layout: 1
+  fragment_schema: 1
+  integration_declaration: 1
+compatibility:
+  status: compatible
+  reason: Generated on current framework release.
+  manual_review_required: true

--- a/examples/generated-skills/jira-heavy-mixed-delivery/.agency/skills/peakweb/review.md
+++ b/examples/generated-skills/jira-heavy-mixed-delivery/.agency/skills/peakweb/review.md
@@ -1,0 +1,22 @@
+# Builder Review Summary
+
+## Scenario
+
+Jira-heavy task tracking with GitHub PR delivery and dual intake support.
+
+## Why This Shape Was Generated
+
+- Jira key evidence and workflow docs strongly indicated Jira as tracker of record.
+- GitHub remained the delivery review-of-record path.
+- Direct-brief intake was preserved for exploratory work and early discovery slices.
+
+## Warnings And Manual Follow-Up
+
+- `task-tracker.update` is marked `manual` due partial Jira update permissions.
+- Reviewers should confirm every tracked-task completion includes explicit Jira update evidence.
+
+## Reviewer Checklist
+
+- Confirm Jira remains tracker of record for durable delivery tasks.
+- Confirm manual Jira-update step is acceptable for this team.
+- Confirm direct-brief work is still allowed before ticket linkage.

--- a/examples/generated-skills/jira-heavy-mixed-delivery/.claude/skills/peakweb/peakweb-pr-review/SKILL.md
+++ b/examples/generated-skills/jira-heavy-mixed-delivery/.claude/skills/peakweb/peakweb-pr-review/SKILL.md
@@ -1,0 +1,12 @@
+# Peakweb PR Review (Mixed Jira + GitHub)
+
+## Purpose
+
+Keep GitHub PR review and Jira traceability synchronized without collapsing their distinct responsibilities.
+
+## Rules
+
+1. Include Jira key in PR title/body when tracked-task intake is active.
+2. Keep PR summary current with test evidence and risk notes.
+3. Request human review in GitHub regardless of automation findings.
+4. After review updates, reflect status in Jira using manual or automated path as declared.

--- a/examples/generated-skills/jira-heavy-mixed-delivery/.claude/skills/peakweb/peakweb-pr-review/skill.json
+++ b/examples/generated-skills/jira-heavy-mixed-delivery/.claude/skills/peakweb/peakweb-pr-review/skill.json
@@ -1,0 +1,19 @@
+{
+  "name": "peakweb-pr-review",
+  "generated_by": "skill-builder",
+  "generated_at": "2026-04-16T14:35:00Z",
+  "framework_release": "v1.1.0",
+  "schema_version": 1,
+  "repository": "github.com/example/billing-gateway",
+  "role": "delivery review",
+  "selected_fragments": [
+    "delivery/pull-request-review",
+    "project-management/jira"
+  ],
+  "contract_versions": {
+    "generated_skill_layout": 1,
+    "fragment_schema": 1,
+    "integration_declaration": 1
+  },
+  "source_manifest": ".agency/skills/peakweb/manifest.yaml"
+}

--- a/examples/generated-skills/jira-heavy-mixed-delivery/.claude/skills/peakweb/peakweb-runtime-guardrails/SKILL.md
+++ b/examples/generated-skills/jira-heavy-mixed-delivery/.claude/skills/peakweb/peakweb-runtime-guardrails/SKILL.md
@@ -1,0 +1,12 @@
+# Peakweb Runtime Guardrails
+
+## Purpose
+
+Control context and model cost in a mixed-tool workflow with Jira plus GitHub review loops.
+
+## Rules
+
+- Prefer targeted ticket/PR reads over broad repo scans.
+- Keep implementation slices aligned to one acceptance milestone at a time.
+- Escalate to stronger reasoning tier only for ambiguous cross-service changes.
+- Re-check Jira and PR status surfaces before final completion summary.

--- a/examples/generated-skills/jira-heavy-mixed-delivery/.claude/skills/peakweb/peakweb-runtime-guardrails/skill.json
+++ b/examples/generated-skills/jira-heavy-mixed-delivery/.claude/skills/peakweb/peakweb-runtime-guardrails/skill.json
@@ -1,0 +1,19 @@
+{
+  "name": "peakweb-runtime-guardrails",
+  "generated_by": "skill-builder",
+  "generated_at": "2026-04-16T14:35:00Z",
+  "framework_release": "v1.1.0",
+  "schema_version": 1,
+  "repository": "github.com/example/billing-gateway",
+  "role": "runtime",
+  "selected_fragments": [
+    "runtime/context-and-model-routing",
+    "orchestration/team-sizing"
+  ],
+  "contract_versions": {
+    "generated_skill_layout": 1,
+    "fragment_schema": 1,
+    "integration_declaration": 1
+  },
+  "source_manifest": ".agency/skills/peakweb/manifest.yaml"
+}

--- a/examples/generated-skills/jira-heavy-mixed-delivery/.claude/skills/peakweb/peakweb-task-tracking/SKILL.md
+++ b/examples/generated-skills/jira-heavy-mixed-delivery/.claude/skills/peakweb/peakweb-task-tracking/SKILL.md
@@ -1,0 +1,13 @@
+# Peakweb Task Tracking (Jira)
+
+## Purpose
+
+Use Jira as the tracked-task source of truth while allowing direct-brief bootstrap work to coexist.
+
+## Behavior
+
+- Resolve Jira keys and URLs before planning tracked-task work.
+- Convert Jira acceptance fields into an implementation checklist.
+- Record blockers and review readiness in Jira-compatible language.
+- If direct brief starts without Jira key, track assumptions locally and mark Jira linkage unresolved.
+- Require Jira completion update before claiming tracked-task flow is done.

--- a/examples/generated-skills/jira-heavy-mixed-delivery/.claude/skills/peakweb/peakweb-task-tracking/skill.json
+++ b/examples/generated-skills/jira-heavy-mixed-delivery/.claude/skills/peakweb/peakweb-task-tracking/skill.json
@@ -1,0 +1,19 @@
+{
+  "name": "peakweb-task-tracking",
+  "generated_by": "skill-builder",
+  "generated_at": "2026-04-16T14:35:00Z",
+  "framework_release": "v1.1.0",
+  "schema_version": 1,
+  "repository": "github.com/example/billing-gateway",
+  "role": "task tracking",
+  "selected_fragments": [
+    "project-management/jira",
+    "task-intake/direct-brief"
+  ],
+  "contract_versions": {
+    "generated_skill_layout": 1,
+    "fragment_schema": 1,
+    "integration_declaration": 1
+  },
+  "source_manifest": ".agency/skills/peakweb/manifest.yaml"
+}

--- a/examples/generated-skills/jira-heavy-mixed-delivery/.claude/skills/peakweb/peakweb-workflow/SKILL.md
+++ b/examples/generated-skills/jira-heavy-mixed-delivery/.claude/skills/peakweb/peakweb-workflow/SKILL.md
@@ -1,0 +1,35 @@
+# Peakweb Workflow (Jira-heavy mixed delivery)
+
+## Mission
+
+Deliver work with Jira as tracked-task system of record and GitHub pull requests as review-of-record, while still supporting direct-brief intake for scoped exploratory slices.
+
+## Intake Policy
+
+1. If a Jira key or URL is present, run tracked-task-first workflow.
+2. If only a direct brief is provided, begin in direct-brief mode and mark tracker linkage as pending.
+3. If both are present, use Jira for durable task state and keep brief context as additional constraints.
+
+## Tracked-Task Flow
+
+- Resolve Jira reference and read summary, acceptance details, and workflow state.
+- Keep branch/PR metadata aligned with Jira key conventions.
+- Post milestone status updates in Jira at planning start, review-ready handoff, and completion.
+
+## Direct-Brief Flow
+
+- Capture assumptions and unresolved questions in local metadata.
+- Proceed with implementation only when scope can be bounded safely.
+- If policy requires ticket traceability before merge, convert the brief to Jira-linked work before final handoff.
+
+## Delivery Flow
+
+- Use GitHub PRs for code-host review and status checks.
+- Treat CodeRabbit or other review automation as additive, not authoritative.
+- Keep review responses visible in the PR system of record.
+
+## Guardrails
+
+- Do not assume Jira transitions are always automated.
+- Use explicit manual-mode instructions when Jira update permissions are partial.
+- Keep direct-brief and Jira-linked status updates distinguishable.

--- a/examples/generated-skills/jira-heavy-mixed-delivery/.claude/skills/peakweb/peakweb-workflow/skill.json
+++ b/examples/generated-skills/jira-heavy-mixed-delivery/.claude/skills/peakweb/peakweb-workflow/skill.json
@@ -1,0 +1,22 @@
+{
+  "name": "peakweb-workflow",
+  "generated_by": "skill-builder",
+  "generated_at": "2026-04-16T14:35:00Z",
+  "framework_release": "v1.1.0",
+  "schema_version": 1,
+  "repository": "github.com/example/billing-gateway",
+  "role": "primary orchestration",
+  "selected_fragments": [
+    "task-intake/direct-brief",
+    "project-management/jira",
+    "orchestration/team-sizing",
+    "delivery/pull-request-review",
+    "runtime/context-and-model-routing"
+  ],
+  "contract_versions": {
+    "generated_skill_layout": 1,
+    "fragment_schema": 1,
+    "integration_declaration": 1
+  },
+  "source_manifest": ".agency/skills/peakweb/manifest.yaml"
+}

--- a/skills/README.md
+++ b/skills/README.md
@@ -49,6 +49,8 @@ The repo-local provider and capability binding format now lives in [`docs/projec
 
 The fallback rules for unavailable, partial, or manual-only capabilities now live in [`docs/capability-fallback-behavior.md`](../docs/capability-fallback-behavior.md).
 
+Concrete generated-skill reference scenarios live in [`examples/generated-skills/`](../examples/generated-skills/README.md).
+
 ## Intended Flow
 
 1. Peakweb Agency Agents is installed into the user's home directory with the base agent roster and reusable skill fragments.


### PR DESCRIPTION
## Summary
- add a new `examples/generated-skills/` reference pack with full generated artifacts under both `.claude/skills/peakweb/` and `.agency/skills/peakweb/`
- include three concrete scenarios: GitHub-heavy dual intake with CodeRabbit, Jira-heavy mixed delivery with dual intake, and direct-brief vibe bootstrap
- link these reference scenarios from key entry points in README and builder/generated-skill contracts

## Verification
- validated all `skill.json` files parse as JSON via `node`
- verified scenario/docs links and acceptance-criteria coverage with `rg` checks

Closes #28

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive reference scenarios showcasing three example generated-skill configurations (direct-brief bootstrap, GitHub-heavy dual intake, and Jira-heavy mixed delivery) with complete workflow documentation and builder metadata.
  * Updated builder usage guide with step for validating generated outputs against reference bundles.
  * Enhanced documentation links to point users toward concrete generated-skill examples across different workflow styles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->