### PR TITLE
Define reasoning-effort and token-budget heuristics

### DIFF
--- a/docs/builder-questionnaire-flow.md
+++ b/docs/builder-questionnaire-flow.md
@@ -216,8 +216,8 @@ Ask when:
 
 Examples:
 
-- Should the generated skill optimize aggressively for low token/tool cost, or favor stronger reasoning by default?
-- Are there model or budget constraints the builder should encode in runtime guidance?
+- Should the generated skill optimize aggressively for low token/tool cost, or favor stronger reasoning effort by default?
+- Are there model, reasoning-effort, or budget constraints the builder should encode in runtime guidance?
 
 ### Priority 5: PR And Branching Conventions
 
@@ -391,7 +391,7 @@ unresolved_decisions:
     topic: runtime budget preference
     why_unresolved: The repo suggests complex work, but no explicit budget preference was found.
     impact: medium
-    recommended_question: Should the generated skill optimize for lower cost or stronger reasoning by default?
+    recommended_question: Should the generated skill optimize for lower cost or stronger reasoning effort by default?
     safe_to_proceed: true
 ```
 

--- a/docs/fragment-assembly-rules.md
+++ b/docs/fragment-assembly-rules.md
@@ -539,10 +539,14 @@ Final emitted block order:
 4. `review-loop`
 5. `context-budgeting`
 6. `model-routing-rules`
+7. `reasoning-effort-rules`
+8. `token-budgeting-rules`
 
 The meaning of `context-budgeting` should follow the canonical runtime contract in [`docs/runtime-context-budgeting-and-repo-reading.md`](./runtime-context-budgeting-and-repo-reading.md) rather than ad hoc file-reading guidance.
 
 The meaning of `model-routing-rules` should also follow that runtime contract, including provider-neutral tier semantics, escalation triggers, and bounded subtask-splitting rules.
+
+The meaning of `reasoning-effort-rules` and `token-budgeting-rules` should follow that runtime contract as well, including provider-neutral defaults, escalation/de-escalation triggers, and provider-mapping boundaries.
 
 Outcome:
 

--- a/docs/generated-skill-layout.md
+++ b/docs/generated-skill-layout.md
@@ -262,6 +262,7 @@ Every builder run should produce a `review.md` file that highlights:
   - for `solo`, report one aggregate slice for the full task (or explicitly note no per-slice breakdown)
   - for `sub-agent` and `agent-team`, report per specialist/role slice
 - any model-tier escalations (for example `economy` -> `balanced` -> `strong`) and why lower tiers were insufficient
+- any reasoning-effort and token-budget profile changes (for example effort `low` -> `medium` -> `high`, profile `lean` -> `standard` -> `expanded`) and what triggered escalation or de-escalation
 - any delegation boundary choices that affected overlap risk, context reuse, or decision to stay in `solo` vs escalate
 
 This review file should make doc-only PR review practical.

--- a/docs/orchestration-execution-rubric.md
+++ b/docs/orchestration-execution-rubric.md
@@ -143,7 +143,7 @@ This rubric is the canonical sizing source for:
 - generated review metadata that explains why a tier was chosen
 - role and handoff behavior that follows the selected tier (see [`docs/orchestration-role-handoff-contract.md`](./orchestration-role-handoff-contract.md))
 
-Model-tier routing, progressive context loading (`discover` -> `select` -> `deepen` -> `execute` -> `verify`), candidate-file budgeting, and bounded subtask-splitting heuristics are canonical in [`docs/runtime-context-budgeting-and-repo-reading.md`](./runtime-context-budgeting-and-repo-reading.md). This rubric should define tier selection, while runtime guidance defines how work is routed inside the selected tier.
+Model-tier routing, reasoning-effort and token-budget heuristics, progressive context loading (`discover` -> `select` -> `deepen` -> `execute` -> `verify`), candidate-file budgeting, and bounded subtask-splitting heuristics are canonical in [`docs/runtime-context-budgeting-and-repo-reading.md`](./runtime-context-budgeting-and-repo-reading.md). This rubric should define tier selection, while runtime guidance defines how work is routed inside the selected tier.
 
 Related contracts should reference this document rather than redefining tier boundaries independently.
 

--- a/docs/runtime-context-budgeting-and-repo-reading.md
+++ b/docs/runtime-context-budgeting-and-repo-reading.md
@@ -191,6 +191,36 @@ Generated guidance should use provider-neutral model tiers:
 
 Generated skills may map local/provider model names onto these tiers, but runtime behavior should reason in terms of these tier semantics.
 
+## Reasoning-Effort Tier Vocabulary
+
+Generated guidance should use provider-neutral effort tiers that are independent from provider parameter names:
+
+- `low`
+  - minimal deliberate reasoning overhead; best for clear, low-risk, bounded steps
+- `medium`
+  - default effort for most implementation and verification work
+- `high`
+  - deeper deliberate reasoning for ambiguous, high-risk, or cross-domain synthesis
+
+Effort-tier rules:
+
+- effort tier is a runtime-budget lever, not a quality guarantee by itself
+- higher effort does not replace missing context or weak acceptance criteria
+- model tier and effort tier should be selected together, but escalated independently when triggers differ
+
+## Token-Budget Profiles
+
+Generated skills should use provider-neutral token-budget profiles as qualitative operating intent:
+
+- `lean`
+  - prioritize lower cost/latency with concise reasoning and tighter retries
+- `standard`
+  - default profile balancing quality, latency, and cost
+- `expanded`
+  - allow broader reasoning/verification loops for correctness-critical synthesis
+
+Token-budget profiles should guide behavior (retry depth, synthesis breadth, and escalation tolerance), not promise exact provider token counts.
+
 ## Model-Routing Heuristics By Collaboration Tier
 
 ### `solo`
@@ -225,6 +255,39 @@ Advisory-only caveat:
 
 - generated skills must not rely on static per-agent model pinning in `agent-team` for correctness-critical behavior
 - if correctness would fail without strict pinning, route through `sub-agent` with explicit bounded handoffs instead
+
+## Reasoning-Effort And Token-Budget Defaults By Task Category
+
+Generated skills should apply the following default heuristics before custom project overrides:
+
+- drafting
+  - default: effort `low`, token profile `lean`, model tier `economy` or `balanced`
+  - escalate when requirements are contradictory or audience constraints are high-risk
+- planning
+  - default: effort `low`, token profile `lean`, model tier `economy`
+  - escalate to effort `medium` when decomposition has non-trivial dependencies or risk
+- implementation
+  - default: effort `medium`, token profile `standard`, model tier `balanced`
+  - downgrade to effort `low` for straightforward edits with tight tests
+  - escalate to effort `high` only when correctness depends on deep algorithmic or cross-domain reasoning
+- debugging
+  - default: effort `medium`, token profile `standard`, model tier `balanced`
+  - escalate to effort `high` when root cause remains unresolved after one focused hypothesis/test pass
+- review
+  - default: effort `medium`, token profile `standard`, model tier `balanced`
+  - escalate to effort `high` for contentious, security-sensitive, or architecture-level findings
+- validation
+  - default: effort `medium`, token profile `standard`, model tier `balanced`
+  - escalate to effort `high` and token profile `expanded` only for release-gating ambiguity or conflicting evidence
+- synthesis
+  - default: effort `medium`, token profile `standard`, model tier `balanced`
+  - escalate to effort `high` with model tier `strong` when reconciling conflicting outputs across slices/domains
+
+Guidance alignment rules:
+
+- escalate model tier first when failure signals indicate capability limits rather than reasoning-depth limits
+- escalate effort first when model tier is already appropriate but reasoning depth appears insufficient
+- escalate token profile only when evidence quality requires broader reasoning or validation loops
 
 ## Subtask-Splitting And Delegation Rules
 
@@ -356,6 +419,35 @@ Escalation discipline:
 - re-run `discover` and `select` after each escalation before further deep reads
 - if `wide` still fails to resolve correctness-critical ambiguity, request explicit clarification instead of continuing blind
 
+### Higher Effort Escalation (`low` -> `medium` -> `high`)
+
+Escalate effort tier when at least one trigger is true:
+
+- one focused pass at the current effort tier fails due to unresolved reasoning ambiguity
+- reviewer/validator feedback indicates logic quality gaps rather than missing context
+- risk is `high` and completion claims require stronger argument quality
+- cross-slice synthesis repeatedly produces conflicting conclusions
+
+Escalation discipline:
+
+- do not jump directly from `low` to `high` unless risk is already `high`
+- do not escalate effort to compensate for missing discovery/select/deepen steps
+- record the trigger and failed prior attempt in handoff or review metadata
+
+### Effort And Budget De-Escalation Triggers
+
+De-escalate effort tier and/or token-budget profile when one of the following is true:
+
+- two consecutive slices pass validation without ambiguity at the current elevated setting
+- the task phase shifts from ambiguity-heavy synthesis to routine bounded edits
+- reviewer/validator confirms risk has dropped from `high` to `medium` or `low`
+
+De-escalation discipline:
+
+- step down one level at a time (`high` -> `medium` -> `low`; `expanded` -> `standard` -> `lean`)
+- preserve elevated settings for unresolved high-risk slices while de-escalating routine slices
+- record de-escalation rationale so reviewers can confirm budget intent
+
 ## Small Task Vs Large Repo Behavior
 
 ### Small Task Behavior
@@ -394,24 +486,56 @@ Example:
 
 ## Sub-Agent Routing By Task Type
 
-Use task type, not only task size, to route model tiers.
+Use task type, not only task size, to route model tiers, effort tiers, and token-budget profiles.
 
 - planning
-  - default: `economy` for clear bounded planning
-  - escalate: `balanced` or `strong` when decomposition is high-risk or ambiguous
+  - default: model `economy`, effort `low`, token profile `lean`
+  - escalate: model `balanced` and effort `medium` when decomposition is high-risk or ambiguous
 - implementation
-  - default: `balanced`
-  - downgrade: `economy` for straightforward refactors with clear acceptance tests
-  - escalate: `strong` for tricky algorithms, migrations, or cross-domain coupling
-- validation
-  - default: `balanced`
-  - escalate: `strong` for flaky/conflicting evidence or high-impact release gates
+  - default: model `balanced`, effort `medium`, token profile `standard`
+  - downgrade: model `economy` and effort `low` for straightforward refactors with clear acceptance tests
+  - escalate: model `strong` and effort `high` for tricky algorithms, migrations, or cross-domain coupling
+- debugging
+  - default: model `balanced`, effort `medium`, token profile `standard`
+  - escalate: model `strong` and effort `high` when one focused root-cause pass fails
+- review/validation
+  - default: model `balanced`, effort `medium`, token profile `standard`
+  - escalate: model `strong`, effort `high`, and token profile `expanded` for conflicting evidence or release-gate findings
 - synthesis/integration
-  - default: lead at `balanced`
-  - escalate: lead at `strong` when conflicting slice outputs need deep reconciliation
+  - default: lead at model `balanced`, effort `medium`, token profile `standard`
+  - escalate: lead at model `strong` and effort `high` when conflicting slice outputs need deep reconciliation
 - ambiguity/risk triage
-  - default: lead at `balanced`
-  - escalate: `strong` when unresolved ambiguity can affect correctness or safety claims
+  - default: lead at model `balanced`, effort `medium`, token profile `standard`
+  - escalate: model `strong` and effort `high` when unresolved ambiguity can affect correctness or safety claims
+
+## Providers Without Explicit Effort Controls
+
+When a provider/runtime lacks an explicit effort parameter:
+
+- keep provider-neutral effort-tier selection in generated guidance (`low`/`medium`/`high`)
+- implement effort intent via adjacent levers:
+  - context-stage strictness (`discover`/`select`/`deepen` breadth)
+  - model-tier routing (`economy`/`balanced`/`strong`)
+  - validation depth (number and strictness of checks before completion claims)
+  - bounded retry/clarification loops
+- record in metadata that effort intent was applied indirectly due to provider surface limits
+
+Generated skills should not claim "effort unsupported" and skip reasoning-budget discipline entirely.
+
+## Provider Mapping Examples (Non-Normative)
+
+These examples are implementation guidance only.
+Core generated contract text should remain provider-neutral.
+
+- Claude example
+  - effort tiers: `low` -> `effort: low`, `medium` -> `effort: medium`, `high` -> `effort: high`
+  - token profile intent remains independent; profile changes should still be reflected in context breadth and verification depth
+- Provider with no effort knob example
+  - effort tiers remain in runtime metadata
+  - map `low`/`medium`/`high` primarily through model tier and validation-depth controls
+- Future-provider example
+  - if provider exposes a differently named reasoning parameter, map it to `low`/`medium`/`high` semantics in provider adapter notes
+  - do not rename core tiers per provider
 
 ## File-Discovery And Selective-Reading Rules
 
@@ -549,7 +673,7 @@ Why this is bad:
 
 ## Integration With Existing Contracts
 
-This document is the canonical runtime contract for context budgeting, repo reading, model routing, and subtask splitting.
+This document is the canonical runtime contract for context budgeting, repo reading, model routing, reasoning-effort budgeting, and subtask splitting.
 
 Related docs should reference it rather than redefining these rules:
 


### PR DESCRIPTION
## Summary
- expand the runtime contract with provider-neutral reasoning-effort tiers and token-budget profile semantics
- add default effort/budget heuristics for drafting, planning, implementation, debugging, review, validation, and synthesis
- define explicit effort escalation and de-escalation triggers, plus behavior when a provider lacks an explicit effort parameter
- add non-normative provider mapping examples (including Claude `effort`) while keeping core contract text provider-neutral
- align linked orchestration, assembly, generated-skill, and builder-questionnaire docs with the updated runtime guidance

## Testing
- docs consistency pass across runtime/orchestration/assembly/generated-skill/builder-questionnaire contracts

Closes #55
Part of #8

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated questionnaire prompts and assembly rules with explicit reasoning-effort tier definitions and token-budget profile specifications
  * Enhanced skill review requirements to document reasoning-effort and budget transitions across tiers with escalation triggers
  * Expanded runtime context budgeting guidance with task-type-specific routing criteria and escalation/de-escalation protocols

<!-- end of auto-generated comment: release notes by coderabbit.ai -->