### PR TITLE
Link #55 runtime follow-on while closing Epic #8

### DIFF
--- a/docs/orchestration-execution-rubric.md
+++ b/docs/orchestration-execution-rubric.md
@@ -4,9 +4,10 @@ This document defines the proposed contract for issue `#22`:
 
 - [#22 Define solo, sub-agent, and agent-team heuristics](https://github.com/peakweb-team/pw-agency-agents/issues/22)
 
-Related runtime routing follow-on:
+Related runtime routing follow-ons:
 
 - [#25 Define model-routing and subtask-splitting heuristics](https://github.com/peakweb-team/pw-agency-agents/issues/25)
+- [#55 Define reasoning-effort and token-budget heuristics](https://github.com/peakweb-team/pw-agency-agents/issues/55)
 
 It builds on:
 


### PR DESCRIPTION
## Summary
- close out Epic #8 now that child issues #24, #25, and #55 are complete
- add one tiny consistency fix in docs by linking issue #55 from the orchestration execution rubric runtime follow-ons section
- update issue #8 with checked child items, canonical doc links, and explicit acceptance-criteria mapping

## Testing
- docs-only change; no runtime tests required


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the orchestration execution rubric documentation with additional guidance on reasoning-effort and token-budget heuristics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->