### PR TITLE
Close epic #9 with completion mapping and canonical links

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -172,9 +172,10 @@ Non-goals:
 
 Make the new skills layer installable, understandable, and usable alongside the existing agent roster.
 
-Canonical install/packaging contract:
+Canonical install/packaging and builder-usage contracts:
 
 - [`docs/install-packaging-skill-fragments-contract.md`](./docs/install-packaging-skill-fragments-contract.md)
+- [`docs/builder-usage-and-repo-local-precedence-contract.md`](./docs/builder-usage-and-repo-local-precedence-contract.md)
 
 Goals:
 


### PR DESCRIPTION
## Summary
- close out Epic #9 after child issues #26 and #27 completion
- add explicit acceptance-criteria mapping and canonical doc links in issue #9
- apply one scoped roadmap consistency tweak so Epic 7 canonical links include both install/packaging and builder-usage contracts

## Scope Guardrails
- no refactors
- docs-only, minimal change

## Validation
- verified issue #26 and #27 are closed
- updated and closed issue #9

Refs #9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Roadmap updated to reflect expanded scope of canonical contracts, now encompassing both install/packaging and builder-usage requirements alongside repository-local precedence considerations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->