### PR TITLE
Configurable worktree isolation with per-task override contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,14 @@ Superagents supports isolated execution with `git worktree`, enabling multiple i
 
 Repo-local generated Superagents skills are authoritative in that repository, while user-level installed skills remain reusable defaults and source material.
 
+Worktree isolation is intended to be configurable per repository, with optional per-task override, not a forced always-on behavior. The generated workflow should support:
+
+- `off` (default compatibility mode)
+- `manual` (operator-managed worktree steps)
+- `auto` (deterministic task-scoped worktree reuse/creation)
+
+For a step-by-step usage runbook and deterministic precedence rules, see [`docs/builder-usage-and-repo-local-precedence-contract.md`](docs/builder-usage-and-repo-local-precedence-contract.md).
+
 See: [docs/builder-usage-and-repo-local-precedence-contract.md](docs/builder-usage-and-repo-local-precedence-contract.md)
 
 ### 7. Multi-Tool Installation

--- a/docs/builder-inventory-workflow.md
+++ b/docs/builder-inventory-workflow.md
@@ -80,6 +80,8 @@ Example normalized signals:
 - `workflow.parallel_agents`
 - `workflow.parallel_work_bounded`
 - `workflow.peer_coordination_required`
+- `workflow.worktree_policy_documented`
+- `workflow.worktree_parallel_isolation_expected`
 - `workflow.model_budget_matters`
 - `review.coderabbit`
 - `docs.references_jira_workflows`
@@ -293,6 +295,8 @@ Common signals:
 - `workflow.review_and_validation_expected`
 - `workflow.model_budget_matters`
 - `workflow.specialist_handoffs_likely`
+- `workflow.worktree_policy_documented`
+- `workflow.worktree_parallel_isolation_expected`
 - `runtime.expensive_context`
 
 Typical evidence sources:

--- a/docs/builder-questionnaire-flow.md
+++ b/docs/builder-questionnaire-flow.md
@@ -202,7 +202,26 @@ Examples:
 - Should bounded parallel implementation default to `sub-agent` before `agent-team`?
 - Are there recurring tasks in this repo where active peer-to-peer coordination materially improves outcomes?
 
-### Priority 4: Runtime / Budget Constraints
+### Priority 4: Worktree Isolation Strategy
+
+Question goal:
+
+- determine whether worktree usage should default to `off`, `manual`, or `auto`
+- determine whether per-task override is allowed on top of the repository default
+
+Ask when:
+
+- repository evidence suggests parallel ticket work, but there is no explicit worktree policy
+- branch collision risk appears meaningful, but the team may prefer manual control
+- existing docs mention branch conventions but do not clarify worktree behavior
+
+Examples:
+
+- Should this repository default to `off`, `manual`, or `auto` worktree strategy?
+- Should a task be allowed to override the repository default worktree strategy?
+- If `auto` is selected, should deterministic task worktree paths use a sibling root or a custom root?
+
+### Priority 5: Runtime / Budget Constraints
 
 Question goal:
 
@@ -220,7 +239,7 @@ Examples:
 - Are there model, reasoning-effort, or budget constraints the builder should encode in runtime guidance?
 - Should this repo default to small-task `narrow` context budgets, or start at large-repo `medium` budgeting with package-mapping first?
 
-### Priority 5: PR And Branching Conventions
+### Priority 6: PR And Branching Conventions
 
 Question goal:
 

--- a/docs/builder-usage-and-repo-local-precedence-contract.md
+++ b/docs/builder-usage-and-repo-local-precedence-contract.md
@@ -28,6 +28,7 @@ This contract covers:
 - builder usage flow inside a target repository
 - precedence between user-level reusable skills and repo-local generated skills
 - review/versioning guidance for generated repo-local output
+- configurable worktree isolation defaults and per-task override behavior
 
 This contract does not cover:
 
@@ -69,6 +70,11 @@ The builder should:
 - choose applicable fragments
 - assemble generated project-local skills and metadata
 
+Worktree isolation should be configured here as part of workflow behavior:
+
+- repository default mode: `off`, `manual`, or `auto`
+- whether task-level override is allowed
+
 ### Step 3: Confirm Generated Output Roots
 
 After generation, confirm both repo-local roots exist:
@@ -87,6 +93,11 @@ Review generated artifacts as normal project files, including:
 - generated `SKILL.md` and `skill.json` files under `.claude/skills/superagents/`
 - metadata files under `.agency/skills/superagents/`
 - `.agency/skills/superagents/review.md` for assumptions, unresolved decisions, compatibility notes, and warnings
+
+Specifically verify worktree behavior in:
+
+- `.agency/skills/peakweb/decisions.yaml` for `worktree_strategy_default` and `worktree_allow_task_override`
+- generated workflow instructions for precedence and failure behavior
 
 ### Step 5: Commit Generated Output Together
 
@@ -149,6 +160,24 @@ Regenerate when:
 - generated output is missing required metadata or compatibility context
 
 Regeneration behavior and compatibility classification continue to follow [`docs/release-versioning-and-upgrade-contract.md`](./release-versioning-and-upgrade-contract.md).
+
+## Worktree Strategy Resolution Contract
+
+Worktree isolation is optional and repository-scoped by default.
+
+Supported modes:
+
+1. `off`: no worktree management
+2. `manual`: emit operator instructions only
+3. `auto`: create or reuse task-scoped worktrees
+
+When task-level override is enabled, resolve in order:
+
+1. task override (if valid)
+2. repository default
+3. safe fallback `off`
+
+Generated workflow guidance should include deterministic naming/reuse rules and non-destructive failure remediation for `auto` mode.
 
 ## Relationship To Existing Contracts
 

--- a/docs/generated-skill-layout.md
+++ b/docs/generated-skill-layout.md
@@ -194,6 +194,24 @@ The MVP metadata bundle should include:
 
 These files make generated output reviewable, diffable, and regenerable.
 
+### Worktree Strategy Metadata
+
+Worktree isolation strategy should be recorded in `decisions.yaml` as runtime-relevant workflow configuration.
+
+Recommended decision keys:
+
+- `worktree_strategy_default`
+  - allowed values: `off`, `manual`, `auto`
+  - purpose: repository-level default for task execution isolation
+- `worktree_allow_task_override`
+  - allowed values: `true`, `false`
+  - purpose: whether task-level override is permitted
+- `worktree_root_strategy` (optional)
+  - examples: `sibling`, `custom-path`
+  - purpose: explain expected path-root strategy for deterministic worktree placement
+
+Task-level override resolution should follow the precedence contract in [`docs/orchestration-execution-rubric.md`](./orchestration-execution-rubric.md).
+
 The release/upgrade rules that interpret this metadata now live in [`docs/release-versioning-and-upgrade-contract.md`](./release-versioning-and-upgrade-contract.md).
 
 The rules that produce this lock file now live in [`docs/fragment-assembly-rules.md`](./fragment-assembly-rules.md).
@@ -265,6 +283,8 @@ Every builder run should produce a `review.md` file that highlights:
 - any model-tier escalations (for example `economy` -> `balanced` -> `strong`) and why lower tiers were insufficient
 - any reasoning-effort and token-budget profile changes (for example effort `low` -> `medium` -> `high`, profile `lean` -> `standard` -> `expanded`) and what triggered escalation or de-escalation
 - any delegation boundary choices that affected overlap risk, context reuse, or decision to stay in `solo` vs escalate
+- the repository default worktree strategy and whether task-level override was enabled
+- for each executed task, the resolved worktree mode (`off`, `manual`, or `auto`) and any fallback/remediation applied
 
 This review file should make doc-only PR review practical.
 

--- a/docs/orchestration-execution-rubric.md
+++ b/docs/orchestration-execution-rubric.md
@@ -115,6 +115,76 @@ When generated guidance references per-agent model assignment in `agent-team` se
 
 Generated skills should avoid promising strict static per-agent model enforcement for `agent-team` execution.
 
+## Worktree Isolation Strategy (Configurable)
+
+Worktree isolation should be configurable, not universally forced.
+
+Generated guidance should support exactly three modes:
+
+1. `off`
+2. `manual`
+3. `auto`
+
+### `off`
+
+- do not create or manage worktrees
+- execute in the current repository checkout
+- default choice when no strong parallel-work signal exists
+
+### `manual`
+
+- do not create worktrees automatically
+- emit explicit operator instructions for creating or selecting the task worktree
+- continue only after the operator confirms the expected branch/worktree context
+
+### `auto`
+
+- create or reuse a task-scoped worktree automatically
+- create or switch to the task branch in that worktree
+- keep concurrent tasks isolated by branch and filesystem path
+
+## Worktree Strategy Precedence
+
+Worktree strategy resolution should be deterministic:
+
+1. task-level override (if provided and valid)
+2. repository default from generated metadata
+3. safe fallback default: `off`
+
+Generated review output should report both:
+
+- the configured repository default
+- the resolved per-task mode used for execution
+
+## Deterministic Naming And Reuse Rules
+
+When `auto` mode is active, generated guidance should use stable naming and reuse rules:
+
+- derive a `task_slug` from issue/ticket id when available; otherwise use a sanitized short task label
+- branch naming should stay deterministic for the same task input (for example `feat/<task_slug>`)
+- worktree path should stay deterministic for the same task input under a configured root
+- if the deterministic path already exists and points to the expected branch/task context, reuse it
+- if the path exists but maps to a different task context, fail safely with clear remediation steps
+
+The exact path root may vary by environment, but generated behavior should avoid ad hoc per-run naming that creates accidental collisions.
+
+## Failure Handling Expectations
+
+Worktree handling must be non-destructive.
+
+Generated guidance should treat common failures explicitly:
+
+- missing Git worktree support
+- permission denied while creating worktree paths
+- path conflict with unrelated existing directory
+- branch conflict or detached `HEAD` ambiguity
+
+Failure behavior by mode:
+
+- `off`: continue normally (no worktree operations attempted)
+- `manual`: emit operator actions and pause until context is corrected
+- `auto`: either recover by reusing a valid existing task worktree or fail with actionable instructions; do not silently continue in an ambiguous checkout
+
 ## Example Task Classifications
 
 ### `solo` Examples
@@ -158,9 +228,11 @@ Generated skills should:
 - require explicit rationale before `agent-team` selection
 - preserve the model-assignment caveat for `agent-team`
 - apply context budgets progressively using the runtime contract instead of front-loading full-repo reads
+- record repository-default worktree mode and honor valid task-level overrides using deterministic precedence
 
 Generated skills should not:
 
 - default to `agent-team` for generic "complexity" labels alone
 - imply that higher agent count is always better
 - promise guaranteed per-agent model pinning in team mode
+- force worktree usage when repository policy is `off` or when task-level override selects `off`

--- a/examples/generated-skills/README.md
+++ b/examples/generated-skills/README.md
@@ -18,6 +18,7 @@ Highlights:
 - GitHub Issues as tracked-task system of record
 - GitHub PR workflow with CodeRabbit layered input
 - direct-brief intake kept active alongside tracked-task intake
+- worktree strategy defaulted to `auto` with per-task override enabled
 
 ### 2. Jira-heavy with mixed GitHub delivery and dual intake
 
@@ -28,6 +29,7 @@ Highlights:
 - Jira as primary task tracker
 - GitHub pull requests as code-host review system of record
 - direct-brief bootstrap supported for exploratory work while tracked-task flow remains primary
+- worktree strategy defaulted to `manual` with per-task override enabled
 
 ### 3. Direct-brief vibe bootstrap (tracker optional)
 
@@ -38,6 +40,7 @@ Highlights:
 - direct-brief as primary intake mode
 - assumption capture and runtime guardrails emphasized
 - tracked-task bindings intentionally unresolved/optional to keep integration boundary explicit
+- worktree strategy defaulted to `off` with per-task override enabled
 
 ## Notes
 

--- a/examples/generated-skills/direct-brief-vibe-bootstrap/.agency/skills/superagents/decisions.yaml
+++ b/examples/generated-skills/direct-brief-vibe-bootstrap/.agency/skills/superagents/decisions.yaml
@@ -15,6 +15,16 @@ decisions:
     decision_state: confirmed
     rationale: Create or link ticket only when team requests durable external traceability.
 
+  worktree_strategy_default:
+    value: off
+    decision_state: confirmed
+    rationale: Team usually handles one scoped brief at a time and prefers minimal Git workflow overhead.
+
+  worktree_allow_task_override:
+    value: true
+    decision_state: confirmed
+    rationale: High-risk tasks may still request `manual` or `auto` isolation.
+
   primary_code_host_review:
     value: github-pull-requests
     decision_state: assumed

--- a/examples/generated-skills/direct-brief-vibe-bootstrap/.agency/skills/superagents/review.md
+++ b/examples/generated-skills/direct-brief-vibe-bootstrap/.agency/skills/superagents/review.md
@@ -9,15 +9,18 @@ Direct-brief-first bootstrap repository with tracker-optional policy.
 - Inventory and questionnaire confirmed direct-brief as primary intake mode.
 - No tracker provider was selected as system of record.
 - PR workflow remained active through assumed GitHub host capabilities.
+- Worktree default stayed `off` to avoid unnecessary overhead for single-brief execution.
 
 ## Warnings And Manual Follow-Up
 
 - `code-host.pr.review-request` is partial and uses manual fallback.
 - `code-host.pr.status-read` is partial and requires host-UI verification.
 - Tracker capabilities are intentionally unavailable and do not block direct-brief flow.
+- Task-level worktree override is allowed; reviewers should confirm when high-risk tasks used `manual` or `auto`.
 
 ## Reviewer Checklist
 
 - Confirm tracker-optional policy still applies.
 - Confirm manual reviewer-request step is acceptable.
 - Confirm direct-brief assumption capture is visible in PR summaries.
+- Confirm the selected worktree mode in task updates matches policy (`off` by default, override allowed).

--- a/examples/generated-skills/direct-brief-vibe-bootstrap/.claude/skills/superagents/superagents-workflow/SKILL.md
+++ b/examples/generated-skills/direct-brief-vibe-bootstrap/.claude/skills/superagents/superagents-workflow/SKILL.md
@@ -14,9 +14,19 @@ Start from a human brief, shape it into executable slices, and deliver review-re
 
 1. Clarify goals, constraints, and success signals from the brief.
 2. Pick smallest capable team (`solo` by default unless risk is high).
-3. Implement in short slices with tight verification loops.
-4. Open PR and route review in code host.
-5. Capture follow-up work as local action items or optional tracker references.
+3. Resolve worktree mode (`off` default; task may override to `manual` or `auto`).
+4. Implement in short slices with tight verification loops.
+5. Open PR and route review in code host.
+6. Capture follow-up work as local action items or optional tracker references.
+
+## Worktree Strategy
+
+- Default mode: `off`
+- Task override allowed: yes (`off|manual|auto`)
+- Resolution precedence: task override -> repository default -> `off`
+
+In `manual`, emit explicit operator steps and wait for confirmation before changing files.
+In `auto`, use deterministic task slug naming for branch/worktree, reuse valid task paths, and stop with remediation if path/branch context is ambiguous.
 
 ## Assumption Capture Rules
 

--- a/examples/generated-skills/github-heavy-dual-intake-coderabbit/.agency/skills/superagents/decisions.yaml
+++ b/examples/generated-skills/github-heavy-dual-intake-coderabbit/.agency/skills/superagents/decisions.yaml
@@ -18,6 +18,16 @@ decisions:
     value: coderabbit
     decision_state: confirmed
 
+  worktree_strategy_default:
+    value: auto
+    decision_state: confirmed
+    rationale: Parallel issue execution is common and branch collision prevention is prioritized.
+
+  worktree_allow_task_override:
+    value: true
+    decision_state: confirmed
+    rationale: Operators may force `manual` for recovery or `off` for one-off low-risk edits.
+
   runtime_context_budget:
     value: medium
     decision_state: assumed

--- a/examples/generated-skills/github-heavy-dual-intake-coderabbit/.agency/skills/superagents/review.md
+++ b/examples/generated-skills/github-heavy-dual-intake-coderabbit/.agency/skills/superagents/review.md
@@ -9,14 +9,17 @@ GitHub-heavy repository with CodeRabbit layered review and dual intake support.
 - GitHub Issues evidence was strong and confirmed as primary tracked-task system.
 - Direct brief remained enabled because the team explicitly allows exploratory work to start without an issue.
 - CodeRabbit was included as additive review input, not review-of-record replacement.
+- Worktree default was set to `auto` because concurrent issue execution is common in this workflow.
 
 ## Warnings And Manual Follow-Up
 
 - `review-feedback.read` is partial for CodeRabbit and marked `warn`; unresolved GitHub review threads remain the baseline queue.
 - No manual-only capability bindings are active in this scenario.
+- Task-level worktree override is allowed for one-off low-risk edits (`off`) or recovery operations (`manual`).
 
 ## Reviewer Checklist
 
 - Confirm direct-brief and tracked-task coexistence is still policy.
 - Confirm CodeRabbit usage is additive and does not bypass human approval rules.
 - Confirm runtime budget assumptions remain appropriate for current repo size.
+- Confirm resolved task worktree mode and any remediation notes are visible in execution summaries.

--- a/examples/generated-skills/github-heavy-dual-intake-coderabbit/.claude/skills/superagents/superagents-workflow/SKILL.md
+++ b/examples/generated-skills/github-heavy-dual-intake-coderabbit/.claude/skills/superagents/superagents-workflow/SKILL.md
@@ -19,10 +19,19 @@ Choose intake per request and keep the chosen path explicit in updates.
 
 1. Discover minimal context first.
 2. Pick `solo`, `sub-agent`, or `agent-team` using risk and scope.
-3. Implement in bounded slices.
-4. Validate locally before review handoff.
-5. Open/update PR and request review path.
-6. Resolve review feedback and refresh status summaries.
+3. Resolve worktree mode (`auto` default; task may override to `off` or `manual`).
+4. Implement in bounded slices.
+5. Validate locally before review handoff.
+6. Open/update PR and request review path.
+7. Resolve review feedback and refresh status summaries.
+
+## Worktree Strategy
+
+- Default mode: `auto`
+- Task override allowed: yes (`off|manual|auto`)
+- Resolution precedence: task override -> repository default -> `off`
+
+Use deterministic naming for task worktrees/branches. Reuse an existing path only when it maps to the same task context. If path or branch context is ambiguous, stop and emit remediation instead of continuing in-place.
 
 ## Tracked-Task Responsibilities
 

--- a/examples/generated-skills/jira-heavy-mixed-delivery/.agency/skills/superagents/decisions.yaml
+++ b/examples/generated-skills/jira-heavy-mixed-delivery/.agency/skills/superagents/decisions.yaml
@@ -19,6 +19,16 @@ decisions:
     decision_state: confirmed
     rationale: Automation can read Jira but update permissions vary across projects.
 
+  worktree_strategy_default:
+    value: manual
+    decision_state: confirmed
+    rationale: Team wants ticket isolation but prefers explicit operator control in enterprise repos.
+
+  worktree_allow_task_override:
+    value: true
+    decision_state: confirmed
+    rationale: Tasks can request `auto` when environment support is known-good.
+
   runtime_context_budget:
     value: medium
     decision_state: assumed

--- a/examples/generated-skills/jira-heavy-mixed-delivery/.agency/skills/superagents/review.md
+++ b/examples/generated-skills/jira-heavy-mixed-delivery/.agency/skills/superagents/review.md
@@ -9,14 +9,17 @@ Jira-heavy task tracking with GitHub PR delivery and dual intake support.
 - Jira key evidence and workflow docs strongly indicated Jira as tracker of record.
 - GitHub remained the delivery review-of-record path.
 - Direct-brief intake was preserved for exploratory work and early discovery slices.
+- Worktree default was set to `manual` to preserve operator control in mixed-permission enterprise repos.
 
 ## Warnings And Manual Follow-Up
 
 - `task-tracker.update` is marked `manual` due partial Jira update permissions.
 - Reviewers should confirm every tracked-task completion includes explicit Jira update evidence.
+- Task-level worktree override remains enabled for cases where `auto` isolation is safe and preferred.
 
 ## Reviewer Checklist
 
 - Confirm Jira remains tracker of record for durable delivery tasks.
 - Confirm manual Jira-update step is acceptable for this team.
 - Confirm direct-brief work is still allowed before ticket linkage.
+- Confirm task updates show resolved worktree mode and any manual setup steps used.

--- a/examples/generated-skills/jira-heavy-mixed-delivery/.claude/skills/superagents/superagents-workflow/SKILL.md
+++ b/examples/generated-skills/jira-heavy-mixed-delivery/.claude/skills/superagents/superagents-workflow/SKILL.md
@@ -24,9 +24,19 @@ Deliver work with Jira as tracked-task system of record and GitHub pull requests
 
 ## Delivery Flow
 
+- Resolve worktree mode (`manual` default; task may override to `off` or `auto`).
 - Use GitHub PRs for code-host review and status checks.
 - Treat CodeRabbit or other review automation as additive, not authoritative.
 - Keep review responses visible in the PR system of record.
+
+## Worktree Strategy
+
+- Default mode: `manual`
+- Task override allowed: yes (`off|manual|auto`)
+- Resolution precedence: task override -> repository default -> `off`
+
+In `manual`, surface exact operator actions for worktree setup and branch context checks.
+In `auto`, apply deterministic task path/branch naming and fail safely when permissions, path conflicts, or detached-head ambiguity block isolation.
 
 ## Guardrails
 

--- a/skills/fragments/orchestration/team-sizing.md
+++ b/skills/fragments/orchestration/team-sizing.md
@@ -48,6 +48,22 @@ Select the smallest capable agent team for a task based on scope, risk, and doma
 - Expanded team: add domain specialists when work spans frontend plus backend, infra plus security, or similar cross-cutting concerns.
 - Escalate team size when acceptance criteria are numerous, the blast radius is high, or integration points are unclear.
 
+## Worktree Isolation (Optional)
+
+Treat worktree usage as a configurable execution strategy, not a universal requirement.
+
+- `off`: run in the current checkout with no worktree management.
+- `manual`: provide explicit operator steps for selecting/creating a task worktree.
+- `auto`: create or reuse deterministic task worktrees and branch context automatically.
+
+When task-level override is enabled, resolve mode in this order:
+
+1. task override
+2. repository default
+3. safe fallback `off`
+
+In `auto`, do not continue silently after path or branch ambiguity. Surface actionable remediation and keep behavior non-destructive.
+
 ## Builder Notes
 
 - This fragment should usually be present in the primary orchestration skill.

--- a/skills/skill-builder/SKILL.md
+++ b/skills/skill-builder/SKILL.md
@@ -50,6 +50,7 @@ Ask only the unresolved questions that materially affect skill composition. Prio
 - Project management system when tracked-task intake is in scope: GitHub Issues, Jira, Linear, or other
 - Review tooling: CodeRabbit, human-only review, custom CI gates
 - Whether tasks should default to solo execution or team orchestration
+- Worktree isolation strategy: `off`, `manual`, or `auto`, plus whether per-task override is allowed
 - Any budget or model constraints
 - Preferred PR workflow and branch naming
 


### PR DESCRIPTION
## Summary
- implement worktree isolation as a configurable strategy (`off|manual|auto`) instead of always-on behavior
- define deterministic precedence (task override -> repo default -> safe fallback `off`) and non-destructive failure handling
- wire the strategy into builder docs, orchestration contracts, fragment guidance, and generated-skill reference artifacts

## What Changed
- Updated orchestration contract with:
  - mode definitions (`off`, `manual`, `auto`)
  - precedence rules
  - deterministic naming/reuse guidance
  - explicit failure-mode handling expectations
- Updated generated layout contract to require worktree strategy keys in `decisions.yaml`:
  - `worktree_strategy_default`
  - `worktree_allow_task_override`
  - optional `worktree_root_strategy`
- Updated questionnaire flow to explicitly ask worktree policy as a high-priority workflow decision
- Updated builder usage runbook to review/verify worktree strategy decisions and resolution behavior
- Updated builder skill and orchestration fragment guidance to include optional worktree behavior
- Updated generated-skill reference scenarios to include concrete worktree defaults per scenario and override behavior in:
  - `.agency/skills/peakweb/decisions.yaml`
  - `.agency/skills/peakweb/review.md`
  - `.claude/skills/peakweb/peakweb-workflow/SKILL.md`
- Updated README to describe optional/configurable worktree strategy rather than forced always-on behavior

## Acceptance Criteria Mapping
- [x] Worktree strategy is represented in generated/runtime config and documented
- [x] Runtime/orchestration path honors repo default + per-task override precedence
- [x] `auto` mode behavior is defined with deterministic create/reuse + isolation expectations
- [x] `manual` mode behavior is defined as instruction-only with no side effects
- [x] `off` mode behavior is defined as no worktree management
- [x] Failure handling is explicit, actionable, and non-destructive
- [x] README and related docs reflect configurable behavior accurately

Closes #71

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

**Documentation**
- Introduced configurable worktree isolation strategy with three modes: `off` (compatibility default), `manual` (operator-managed), and `auto` (deterministic task-scoped isolation).
- Added repository-level default configuration with optional per-task override support.
- Updated workflow documentation with explicit strategy resolution precedence and deterministic naming guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->