### PR TITLE
Milestone 4: batch spec planning contract and artifact model (#76)

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,7 @@ Use one worktree per issue/team stream to keep execution isolated.
 - [docs/builder-questionnaire-flow.md](docs/builder-questionnaire-flow.md)
 - [docs/generated-skill-layout.md](docs/generated-skill-layout.md)
 - [docs/spec-builder-contract.md](docs/spec-builder-contract.md)
+- [docs/spec-batch-planning-contract.md](docs/spec-batch-planning-contract.md)
 - [docs/builder-usage-and-repo-local-precedence-contract.md](docs/builder-usage-and-repo-local-precedence-contract.md)
 - [docs/install-packaging-skill-fragments-contract.md](docs/install-packaging-skill-fragments-contract.md)
 - [docs/runtime-context-budgeting-and-repo-reading.md](docs/runtime-context-budgeting-and-repo-reading.md)

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -252,6 +252,11 @@ Non-goals:
 
 Add a pre-implementation specification builder that turns a brief, portfolio item, or discovery output into an implementation-ready spec and tracked work item.
 
+Primary contracts:
+
+- single-item baseline: [`docs/spec-builder-contract.md`](./docs/spec-builder-contract.md)
+- batch planning extension: [`docs/spec-batch-planning-contract.md`](./docs/spec-batch-planning-contract.md)
+
 Goals:
 
 - define a spec-builder workflow that runs before implementation execution for work that is not implementation-ready

--- a/docs/capability-fallback-behavior.md
+++ b/docs/capability-fallback-behavior.md
@@ -13,6 +13,7 @@ It builds on:
 - the first-wave task-system fragment set in [`docs/task-system-provider-fragment-set.md`](./task-system-provider-fragment-set.md)
 - the first-wave code-host/review fragment set in [`docs/code-host-review-provider-fragment-set.md`](./code-host-review-provider-fragment-set.md)
 - the generated-skill layout contract in [`docs/generated-skill-layout.md`](./generated-skill-layout.md)
+- the batch spec planning contract in [`docs/spec-batch-planning-contract.md`](./spec-batch-planning-contract.md)
 
 ## Why This Exists
 
@@ -269,6 +270,36 @@ Manual-mode steps should appear in:
 - `integrations.yaml`
 - `review.md`
 - generated skill instructions if the step is likely to recur in normal use
+
+## Batch Spec Planning Fallback Expectations
+
+For multi-item planning runs, fallback outcomes should be item-scoped whenever possible.
+
+### Rule 1: Degrade The Smallest Valid Slice First
+
+If one item cannot satisfy a capability path safely:
+
+- mark that item `warn`, `manual`, or `fail` as appropriate
+- keep unrelated items in `continue` when their required capabilities are satisfied
+
+### Rule 2: Avoid Batch-Wide False Blocking
+
+Do not escalate the entire batch to `fail` unless the missing capability blocks intake-wide correctness.
+
+Examples of intake-wide blockers:
+
+- inability to read the planning intake source at all
+- inability to persist any canonical system-of-record artifact for all items in the run
+
+### Rule 3: Preserve Item-Level Handoff Truth
+
+In batch mode, fallback reporting should preserve per-item truth in review artifacts:
+
+- item A may be `ready-for-build`
+- item B may be `needs-clarification` with manual follow-up
+- item C may be `blocked`
+
+This is valid and should not be collapsed into all-or-nothing reporting.
 
 ## Recommended Binding Fields In `integrations.yaml`
 

--- a/docs/external-capability-model.md
+++ b/docs/external-capability-model.md
@@ -139,6 +139,11 @@ These determine how work begins.
 - Notes:
   - this is commonly satisfied by generated-skill behavior and metadata output rather than by an external provider
 
+Batch planning note:
+
+- the same intake capabilities apply when input is a multi-item planning object (epic objective + candidate work items + constraints) as defined in [`docs/spec-batch-planning-contract.md`](./spec-batch-planning-contract.md)
+- assumption capture should remain item-scoped where possible instead of collapsing all uncertainty into one batch-level unresolved state
+
 ### 2. Tracked-Task Capabilities
 
 These apply when work begins from or must sync back to an external issue system.

--- a/docs/generated-skill-layout.md
+++ b/docs/generated-skill-layout.md
@@ -19,6 +19,7 @@ It builds on:
 - the release versioning and upgrade contract in [`docs/release-versioning-and-upgrade-contract.md`](./release-versioning-and-upgrade-contract.md)
 - the user-level install and packaging contract for reusable fragments in [`docs/install-packaging-skill-fragments-contract.md`](./install-packaging-skill-fragments-contract.md)
 - the user-facing builder usage and precedence contract in [`docs/builder-usage-and-repo-local-precedence-contract.md`](./builder-usage-and-repo-local-precedence-contract.md)
+- the batch spec planning and artifact model in [`docs/spec-batch-planning-contract.md`](./spec-batch-planning-contract.md)
 - the roadmap direction toward a workflow operating system instead of a loose prompt library
 
 ## Why This Exists
@@ -71,6 +72,17 @@ The builder should also write a repo-local metadata bundle under:
 This metadata root is Superagents-specific and exists so the generated skills stay reviewable and reproducible without polluting the execution-facing skill folders.
 
 The metadata bundle should be committed alongside the generated skills.
+
+### Related Spec-Builder Artifacts
+
+Spec-builder artifacts are a separate contract surface from generated skill artifacts.
+
+When pre-implementation spec generation is used:
+
+- single-item canonical specs live under `.agency/specs/<slug>.md` per [`docs/spec-builder-contract.md`](./spec-builder-contract.md)
+- batch planning runs may add grouped bundle artifacts under `.agency/specs/batches/...` per [`docs/spec-batch-planning-contract.md`](./spec-batch-planning-contract.md)
+
+These paths should remain reviewable repository artifacts and should be treated like other committed workflow configuration/output docs when teams opt into spec-first planning.
 
 ## Naming Conventions
 

--- a/docs/spec-batch-planning-contract.md
+++ b/docs/spec-batch-planning-contract.md
@@ -1,0 +1,226 @@
+# Batch Spec Planning Contract And Artifact Model
+
+This document defines the Milestone 4 contract for issue `#76`:
+
+- [#76 Milestone 4: Define Batch Spec Planning Contract And Artifact Model](https://github.com/peakweb-team/pw-agency-agents/issues/76)
+
+It extends, and does not replace, the single-item spec-builder contract in [`docs/spec-builder-contract.md`](./spec-builder-contract.md) from issue `#68`.
+
+It builds on:
+
+- roadmap scope for Milestone 4 / Epic 11 in [`ROADMAP.md`](../ROADMAP.md)
+- capability semantics in [`docs/external-capability-model.md`](./external-capability-model.md)
+- fallback semantics in [`docs/capability-fallback-behavior.md`](./capability-fallback-behavior.md)
+- generated artifact reviewability expectations in [`docs/generated-skill-layout.md`](./generated-skill-layout.md)
+
+## Why This Exists
+
+Issue `#68` defines the pre-implementation flow for a single spec artifact.
+
+Real sprint planning often starts from one epic objective and yields multiple implementation-ready specs.
+
+This contract defines how batch planning should produce that multi-spec output deterministically, reviewably, and without breaking single-item behavior.
+
+## Compatibility With #68 Single-Item Flow
+
+The following #68 semantics are unchanged:
+
+- single-item direct-brief path still supports `.agency/specs/<slug>.md`
+- canonical handoff states remain `ready-for-build`, `needs-clarification`, and `blocked`
+- per-item spec quality gate remains the minimum spec package from [`docs/spec-builder-contract.md`](./spec-builder-contract.md)
+- tracker-backed, direct-brief, and dual-path storage-of-record behavior remain valid
+
+Batch planning is an additive mode.
+
+If intake contains exactly one work item, the system may use single-item behavior only and may omit batch-group artifacts.
+
+## Batch Intake Model
+
+A batch planning intake object must be explicit, reviewable, and durable.
+
+### Required Intake Fields
+
+- `epic_objective`
+  - concise objective statement for the planning batch
+- `candidate_work_items`
+  - list of candidate items to decompose/specify
+- `constraints`
+  - delivery, policy, sequencing, or resource constraints that materially affect decomposition
+
+### Recommended Intake Fields
+
+- `epic_id` or stable external reference
+- `milestone` (or sprint/release label)
+- `planning_window` (for example `2026-sprint-09`)
+- `source_refs` (tickets, docs, links)
+- `default_assumptions` that apply broadly unless item-overridden
+
+### Candidate Work Item Minimum Shape
+
+Each candidate work item should include:
+
+- `item_id` (stable within batch)
+- `title`
+- `problem_or_outcome`
+- `initial_scope_notes`
+- `known_dependencies` (optional)
+- `risk_flags` (optional)
+
+## Parent/Child Decomposition And Dependency Ordering
+
+Batch decomposition must create a parent/child map from epic objective to implementable item specs.
+
+### Decomposition Rules
+
+- each generated item has exactly one parent epic objective for the current batch
+- child items may reference another child item as a dependency, but not as an ownership parent
+- decomposition must produce independently reviewable item-level acceptance criteria
+- items that are too large or ambiguous should be split before handoff
+
+### Dependency Rules
+
+- dependencies must be represented as a directed acyclic graph (DAG)
+- cycles are not allowed; cyclic items must be marked `blocked` until resolved
+- ordering should use topological sort with stable tie-breakers
+- stable tie-breaker for equal dependency depth: normalized item slug ascending
+
+### Sequencing Output
+
+The batch output should include:
+
+- dependency edges (`from_item` -> `to_item`)
+- ordered execution waves (`wave: 0, 1, 2...`)
+- per-item `depends_on` and `blocks` sets
+
+## Artifact Layout For Multi-Spec Runs
+
+The layout must support grouped review by epic/milestone while preserving per-item canonical specs.
+
+### Canonical Per-Item Spec Location (Unchanged)
+
+Each item in a batch still maps to the single-item canonical spec lineage:
+
+- `.agency/specs/<item-slug>.md`
+
+If scope/acceptance materially changes, increment item `revision` using #68 semantics.
+
+### Batch Grouping Bundle
+
+When more than one item is planned in one run, write a grouped bundle under:
+
+- `.agency/specs/batches/<epic-slug>/<milestone-slug-or-unscoped>/<batch-key>/`
+
+Recommended bundle contents:
+
+- `intake.yaml`
+  - normalized batch intake and source references
+- `decomposition.yaml`
+  - parent/child mapping, DAG edges, wave ordering
+- `decisions.yaml`
+  - confirmed/assumed/unresolved decisions, item-scoped
+- `review.md`
+  - human review summary and readiness table
+- `items/<order>-<item-slug>.md`
+  - item summary sheet with links to canonical per-item spec files
+
+`batch-key` should be stable for reruns of the same planning unit (for example epic + milestone + planning window).
+
+## Item-Scoped Decisions, Assumptions, And Unresolved Handling
+
+Batch planning must not be all-or-nothing.
+
+### Per-Item Decision Ledger
+
+`decisions.yaml` should represent decisions at item scope first:
+
+- `items.<item-id>.confirmed[]`
+- `items.<item-id>.assumed[]`
+- `items.<item-id>.unresolved[]`
+
+Batch-level entries are allowed only for truly shared decisions:
+
+- `batch.confirmed[]`
+- `batch.assumed[]`
+- `batch.unresolved[]`
+
+### Readiness And Blocking Semantics
+
+Each item gets its own handoff state:
+
+- `ready-for-build`: implementation for that item may proceed
+- `needs-clarification`: item is not ready; other ready items may proceed
+- `blocked`: external dependency/risk gate blocks that item
+
+Batch-level summary should aggregate, not override, item states.
+
+Example summary states:
+
+- `fully-ready` (all items `ready-for-build`)
+- `partially-ready` (mixed item states)
+- `blocked` (no item is currently build-ready)
+
+## Reviewability Contract
+
+Batch output must be reviewable as normal repository artifacts.
+
+`review.md` for batch runs should include:
+
+- epic objective and planning window
+- item table with slug, wave, state, and dependency summary
+- assumptions and unresolved decisions grouped by item
+- explicit links to each canonical `.agency/specs/<item-slug>.md`
+- rerun delta summary (what changed from previous batch revision)
+
+This keeps planning decisions auditable without requiring runtime logs.
+
+## Rerun And Idempotency Expectations
+
+Batch planning must be deterministic enough for clean diffs.
+
+### Idempotent Regeneration Rules
+
+- rerunning with unchanged normalized intake should preserve item slugs and ordering
+- rerunning the same `batch-key` should update artifacts in place and increment `batch_revision`
+- unchanged items should not receive artificial revision bumps
+- only items with material scope/acceptance changes should increment item `revision`
+
+### Determinism Requirements
+
+- normalization of epic/milestone/item slugs should follow #68 slug rules
+- dependency ordering should be reproducible from the same DAG and tie-breakers
+- per-item unresolved status should not cascade to unrelated items
+
+## Fallback Alignment
+
+Batch planning should follow capability fallback semantics from [`docs/capability-fallback-behavior.md`](./capability-fallback-behavior.md), with item-scoped impact where possible.
+
+- missing capability for one item path should degrade that item first
+- only intake-wide capability failures should block the full batch
+- manual-mode steps may apply to specific items without marking unrelated items unresolved
+
+## Acceptance Criteria Coverage For #76
+
+- Batch planning contract is explicit and reviewable:
+  - see `Batch Intake Model`, `Parent/Child Decomposition And Dependency Ordering`, `Artifact Layout For Multi-Spec Runs`, `Reviewability Contract`
+- Contract preserves compatibility with #68 single-item flow:
+  - see `Compatibility With #68 Single-Item Flow` and `Canonical Per-Item Spec Location (Unchanged)`
+- Artifact model supports grouped review by epic/milestone:
+  - see `Batch Grouping Bundle` and `review.md` expectations in `Reviewability Contract`
+- Unresolved decisions can be item-scoped (not all-or-nothing):
+  - see `Per-Item Decision Ledger` and `Readiness And Blocking Semantics`
+
+## MVP Boundary
+
+This contract does not require:
+
+- runtime/tooling implementation of batch execution
+- automatic reprioritization algorithms
+- provider-specific decomposition schemas
+
+It does require:
+
+- explicit batch intake shape
+- deterministic decomposition and dependency ordering semantics
+- grouped multi-spec artifact model by epic/milestone
+- item-scoped unresolved handling
+- compatibility with #68 single-item behavior

--- a/docs/spec-builder-contract.md
+++ b/docs/spec-builder-contract.md
@@ -8,6 +8,7 @@ It builds on:
 - capability semantics in [`docs/external-capability-model.md`](./external-capability-model.md)
 - task-system provider behavior in [`docs/task-system-provider-fragment-set.md`](./task-system-provider-fragment-set.md)
 - role ownership and handoff expectations in [`docs/orchestration-role-handoff-contract.md`](./orchestration-role-handoff-contract.md)
+- batch planning and decomposition extension in [`docs/spec-batch-planning-contract.md`](./spec-batch-planning-contract.md)
 
 ## Why This Exists
 
@@ -27,6 +28,10 @@ The spec-builder covers:
 - storage-of-record behavior for spec artifacts
 
 The spec-builder does not replace implementation, review, or validation flows after the spec is accepted.
+
+This document is the canonical single-item baseline.
+
+Batch/sprint planning behavior for multi-item spec generation is defined as an additive extension in [`docs/spec-batch-planning-contract.md`](./spec-batch-planning-contract.md).
 
 ## Core Workflow
 
@@ -98,6 +103,10 @@ Canonical slug/version rules for `.agency/specs/<slug>.md`:
   - collapse repeated `-` and strip leading/trailing `-`
 - if two candidate specs normalize to the same slug, treat that as the same spec lineage and increment `revision` instead of creating a second base slug file
 - bump `revision` when acceptance criteria or scope boundaries materially change; keep minor wording edits in the current revision when possible
+
+Batch compatibility note:
+
+- multi-item planning runs may produce grouped batch artifacts under `.agency/specs/batches/`, but each item must still map to a canonical `.agency/specs/<slug>.md` lineage that follows the same slug and revision rules
 
 ### Dual Path
 


### PR DESCRIPTION
## Summary
- add canonical batch planning contract for multi-spec sprint/epic runs
- preserve #68 single-item semantics as explicit baseline behavior
- define intake model, parent/child decomposition, dependency ordering, grouped artifact layout, item-scoped decision handling, and rerun/idempotency expectations
- cross-reference related contracts and index docs for discoverability

## Files changed
- docs/spec-batch-planning-contract.md (new)
- docs/spec-builder-contract.md
- docs/generated-skill-layout.md
- docs/capability-fallback-behavior.md
- docs/external-capability-model.md
- ROADMAP.md
- README.md

## Acceptance criteria mapping (#76)
- [x] Batch planning contract is explicit and reviewable
  - docs/spec-batch-planning-contract.md: Batch Intake Model; Parent/Child Decomposition And Dependency Ordering; Artifact Layout For Multi-Spec Runs; Reviewability Contract
- [x] Contract preserves compatibility with #68 single-item flow
  - docs/spec-batch-planning-contract.md: Compatibility With #68 Single-Item Flow; Canonical Per-Item Spec Location (Unchanged)
  - docs/spec-builder-contract.md: canonical single-item baseline + batch compatibility note
- [x] Artifact model supports grouped review by epic/milestone
  - docs/spec-batch-planning-contract.md: Batch Grouping Bundle; review.md expectations
  - docs/generated-skill-layout.md: Related Spec-Builder Artifacts
- [x] Unresolved decisions can be item-scoped (not all-or-nothing)
  - docs/spec-batch-planning-contract.md: Per-Item Decision Ledger; Readiness And Blocking Semantics
  - docs/capability-fallback-behavior.md: Batch Spec Planning Fallback Expectations

Closes #76

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**Documentation**
- Introduced comprehensive batch spec planning documentation and contract specifications.
- Clarified fallback behavior for multi-item planning, enabling per-item capability degradation without blocking entire batches.
- Updated artifact organization and structure documentation to support batch planning workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->