### PR TITLE
Milestone 4: add portfolio-to-spec decomposition workflow (#74)

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,7 @@ Use one worktree per issue/team stream to keep execution isolated.
 - [docs/generated-skill-layout.md](docs/generated-skill-layout.md)
 - [docs/spec-builder-contract.md](docs/spec-builder-contract.md)
 - [docs/spec-batch-planning-contract.md](docs/spec-batch-planning-contract.md)
+- [docs/portfolio-to-spec-decomposition-workflow.md](docs/portfolio-to-spec-decomposition-workflow.md)
 - [docs/builder-usage-and-repo-local-precedence-contract.md](docs/builder-usage-and-repo-local-precedence-contract.md)
 - [docs/install-packaging-skill-fragments-contract.md](docs/install-packaging-skill-fragments-contract.md)
 - [docs/runtime-context-budgeting-and-repo-reading.md](docs/runtime-context-budgeting-and-repo-reading.md)

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -256,6 +256,7 @@ Primary contracts:
 
 - single-item baseline: [`docs/spec-builder-contract.md`](./docs/spec-builder-contract.md)
 - batch planning extension: [`docs/spec-batch-planning-contract.md`](./docs/spec-batch-planning-contract.md)
+- portfolio-to-spec decomposition workflow: [`docs/portfolio-to-spec-decomposition-workflow.md`](./docs/portfolio-to-spec-decomposition-workflow.md)
 
 Goals:
 

--- a/docs/builder-inventory-workflow.md
+++ b/docs/builder-inventory-workflow.md
@@ -72,12 +72,14 @@ Example normalized signals:
 
 - `input.task_reference`
 - `input.direct_brief`
+- `input.batch_planning_object`
 - `forge.github`
 - `task_tracker.github_issues`
 - `task_tracker.jira`
 - `repo.monorepo`
 - `workflow.pull_requests`
 - `workflow.parallel_agents`
+- `workflow.sprint_kickoff_planning`
 - `workflow.parallel_work_bounded`
 - `workflow.peer_coordination_required`
 - `workflow.worktree_policy_documented`
@@ -95,6 +97,7 @@ They are also the bridge between repository inspection and later capability-mapp
 Use one or more signals to infer builder decisions such as:
 
 - work intake mode
+- whether intake should support single-item only, planning-batch only, or dual-path behavior
 - primary task tracker, if tracker-backed intake is in scope
 - review loop shape
 - whether team-sizing guidance is needed
@@ -171,8 +174,10 @@ Common signals:
 
 - `input.task_reference`
 - `input.direct_brief`
+- `input.batch_planning_object`
 - `workflow.bootstrap_greenfield_likely`
 - `workflow.task_tracker_optional`
+- `workflow.sprint_kickoff_planning`
 
 Typical evidence sources:
 

--- a/docs/builder-questionnaire-flow.md
+++ b/docs/builder-questionnaire-flow.md
@@ -156,6 +156,7 @@ The initial MVP questionnaire should focus on the smallest set of decisions that
 Question goal:
 
 - determine whether generated skills should start from a tracked task, a direct brief, or support both
+- determine whether direct-brief intake should support single-item only, planning-batch only, or both companion paths
 
 Ask when:
 
@@ -163,10 +164,12 @@ Ask when:
 - the repo clearly uses a forge but issue authority is still unclear
 - the repo appears greenfield, light-process, or likely to benefit from direct-brief bootstrap
 - the intended UX wants a dual entry path such as `/agent-task <ticket-or-prompt>`
+- the team plans sprint kickoff runs where one intake should generate multiple candidate specs
 
 Examples:
 
 - Should the generated skill expect work to begin from a tracked task, a direct brief, or both?
+- Should direct-brief intake support single-item spec creation, planning-batch decomposition, or both?
 - If both GitHub Issues and Jira are used, which one should the builder treat as the source of truth for tracked-task intake?
 - Should a greenfield repo support a direct-brief bootstrap mode even if GitHub Issues exists?
 

--- a/docs/capability-fallback-behavior.md
+++ b/docs/capability-fallback-behavior.md
@@ -332,6 +332,7 @@ These fields extend the declaration format without changing its basic provider-b
 ### Task Intake
 
 - Missing `task-intake.direct-brief` in a tracked-task-only workflow may still be `continue`
+- Missing `task-intake.batch-planning` should usually be `warn` when single-item flow remains available, and `fail` only if the selected workflow requires multi-item planning runs
 - Missing `task-tracker.read` in a tracked-task-only workflow should usually be `fail`
 - Missing tracked-task support in a dual-intake workflow may be `manual` or `warn` if direct-brief remains safe
 

--- a/docs/code-host-review-provider-fragment-set.md
+++ b/docs/code-host-review-provider-fragment-set.md
@@ -180,6 +180,11 @@ capability_bindings:
     support: full
     decision_state: confirmed
 
+  task-intake.batch-planning:
+    provider_ref: local-direct-brief
+    support: full
+    decision_state: assumed
+
   code-host.pr.open:
     provider_ref: github
     support: full

--- a/docs/external-capability-model.md
+++ b/docs/external-capability-model.md
@@ -129,13 +129,12 @@ These determine how work begins.
 
 #### `task-intake.batch-planning`
 
-- Purpose: allow intake to begin from one planning object that can decompose into multiple implementation-ready item specs in one run
+- Purpose: allow intake to begin from one planning object that can decompose into multiple item-scoped spec drafts and readiness outcomes in one run
 - Required for:
   - portfolio/sprint kickoff spec planning workflows
   - dual-path workflows that support both single-item and multi-item spec intake
 - Semantics:
-  - accept normalized signal `input.batch_planning_object` containing objective, candidate items, and constraints
-  - accept a planning intake object containing an objective, candidate items, and constraints
+  - accept normalized signal `input.batch_planning_object` with `epic_objective`, `candidate_work_items`, and `constraints`
   - preserve item-scoped decomposition, acceptance criteria, and readiness outcomes
   - generate a reviewer/operator summary index with suggested execution order
 - Notes:

--- a/docs/external-capability-model.md
+++ b/docs/external-capability-model.md
@@ -127,6 +127,20 @@ These determine how work begins.
   - this is usually satisfied by local prompt input, not a third-party system
   - this capability should pair naturally with explicit assumption capture
 
+#### `task-intake.batch-planning`
+
+- Purpose: allow intake to begin from one planning object that can decompose into multiple implementation-ready item specs in one run
+- Required for:
+  - portfolio/sprint kickoff spec planning workflows
+  - dual-path workflows that support both single-item and multi-item spec intake
+- Semantics:
+  - accept a planning intake object containing an objective, candidate items, and constraints
+  - preserve item-scoped decomposition, acceptance criteria, and readiness outcomes
+  - generate a reviewer/operator summary index with suggested execution order
+- Notes:
+  - this capability is additive and must not replace `task-intake.direct-brief` single-item behavior
+  - canonical artifact semantics for this mode are defined in [`docs/spec-batch-planning-contract.md`](./spec-batch-planning-contract.md) and [`docs/portfolio-to-spec-decomposition-workflow.md`](./portfolio-to-spec-decomposition-workflow.md)
+
 #### `task-intake.assumption-capture`
 
 - Purpose: record assumptions, missing facts, and unresolved decisions when work starts without a fully structured ticket
@@ -141,7 +155,7 @@ These determine how work begins.
 
 Batch planning note:
 
-- the same intake capabilities apply when input is a multi-item planning object (epic objective + candidate work items + constraints) as defined in [`docs/spec-batch-planning-contract.md`](./spec-batch-planning-contract.md)
+- `task-intake.batch-planning` is the explicit multi-item intake capability for planning objects (epic objective + candidate work items + constraints)
 - assumption capture should remain item-scoped where possible instead of collapsing all uncertainty into one batch-level unresolved state
 
 ### 2. Tracked-Task Capabilities
@@ -321,6 +335,16 @@ Not required:
 
 This mode explicitly allows generated skills to operate without an external task system.
 
+### Planning-Batch (Direct-Brief)
+
+Required capabilities:
+
+- `task-intake.direct-brief`
+- `task-intake.batch-planning`
+- `task-intake.assumption-capture`
+
+This mode allows one planning object to produce multiple item specs in one run while keeping item-scoped readiness and acceptance details.
+
 ### Tracked-Task-First
 
 Required capabilities:
@@ -339,6 +363,7 @@ This mode assumes the tracked task is the system of record for work intake.
 Required capabilities:
 
 - `task-intake.direct-brief`
+- `task-intake.batch-planning` (when multi-item planning input is in scope)
 - `task-intake.assumption-capture`
 - `task-tracker.create`
 - `task-tracker.read`
@@ -354,6 +379,7 @@ This mode turns a brief or portfolio objective into a tracker-backed implementat
 Required capabilities:
 
 - `task-intake.direct-brief`
+- `task-intake.batch-planning` (when planning-batch path is enabled)
 - `task-intake.assumption-capture`
 - `task-tracker.lookup`
 - `task-tracker.read`
@@ -378,6 +404,7 @@ Examples:
 - Jira may satisfy the same tracked-task capabilities with different field semantics
 - GitHub Pull Requests may satisfy `code-host.pr.open`, `code-host.pr.update`, `code-host.pr.review-request`, `code-host.pr.status-read`, `review-feedback.read`, and `review-feedback.respond`
 - local prompt input satisfies `task-intake.direct-brief` without any external provider at all
+- local planning intake objects satisfy `task-intake.batch-planning` without any external provider at all
 
 This document defines the capability semantics, not the declaration format for those mappings. The declaration shape now lives in [`docs/project-integration-declaration-format.md`](./project-integration-declaration-format.md).
 

--- a/docs/external-capability-model.md
+++ b/docs/external-capability-model.md
@@ -134,6 +134,7 @@ These determine how work begins.
   - portfolio/sprint kickoff spec planning workflows
   - dual-path workflows that support both single-item and multi-item spec intake
 - Semantics:
+  - accept normalized signal `input.batch_planning_object` containing objective, candidate items, and constraints
   - accept a planning intake object containing an objective, candidate items, and constraints
   - preserve item-scoped decomposition, acceptance criteria, and readiness outcomes
   - generate a reviewer/operator summary index with suggested execution order

--- a/docs/fragment-schema.md
+++ b/docs/fragment-schema.md
@@ -138,6 +138,7 @@ Every fragment must define the following fields.
 - Purpose: describe the workflow capability this fragment adds
 - Example values:
   - `task-intake.direct-brief`
+  - `task-intake.batch-planning`
   - `task-intake.assumption-capture`
   - `task-tracker.lookup`
   - `task-tracker.read`

--- a/docs/generated-skill-layout.md
+++ b/docs/generated-skill-layout.md
@@ -81,6 +81,7 @@ When pre-implementation spec generation is used:
 
 - single-item canonical specs live under `.agency/specs/<slug>.md` per [`docs/spec-builder-contract.md`](./spec-builder-contract.md)
 - batch planning runs may add grouped bundle artifacts under `.agency/specs/batches/...` per [`docs/spec-batch-planning-contract.md`](./spec-batch-planning-contract.md)
+- portfolio-to-spec planning runs should expose an operator-facing batch index under the grouped bundle per [`docs/portfolio-to-spec-decomposition-workflow.md`](./portfolio-to-spec-decomposition-workflow.md)
 
 These paths should remain reviewable repository artifacts and should be treated like other committed workflow configuration/output docs when teams opt into spec-first planning.
 

--- a/docs/portfolio-to-spec-decomposition-workflow.md
+++ b/docs/portfolio-to-spec-decomposition-workflow.md
@@ -1,0 +1,160 @@
+# Portfolio-To-Spec Decomposition Workflow
+
+This document defines the Milestone 4 workflow behavior for issue `#74`:
+
+- [#74 Milestone 4: Add Portfolio-To-Spec Decomposition Workflow](https://github.com/peakweb-team/pw-agency-agents/issues/74)
+
+It builds on:
+
+- the single-item baseline in [`docs/spec-builder-contract.md`](./spec-builder-contract.md) from issue `#68`
+- the batch artifact model in [`docs/spec-batch-planning-contract.md`](./spec-batch-planning-contract.md) from issue `#76`
+- fallback semantics in [`docs/capability-fallback-behavior.md`](./capability-fallback-behavior.md)
+
+## Why This Exists
+
+Issue `#68` defines how one brief becomes one implementation-ready spec.
+
+Issue `#76` defines the multi-item artifact contract.
+
+This workflow bridges them with an explicit planning-oriented execution path for sprint and portfolio kickoff where one intake run produces multiple candidate implementation specs with independent handoff states.
+
+## Invocation Paths
+
+Spec generation has two companion invocation paths.
+
+### Path A: Single-Item (Unchanged From #68)
+
+Use this path when intake represents one implementation item.
+
+- input shape: one brief or one tracked task
+- output: one canonical `.agency/specs/<slug>.md`
+- no batch bundle required
+
+### Path B: Planning-Batch (New In #74)
+
+Use this path when intake represents a portfolio/sprint planning unit.
+
+- input shape: batch planning object as defined in [`docs/spec-batch-planning-contract.md`](./spec-batch-planning-contract.md)
+- output: many canonical `.agency/specs/<item-slug>.md` files plus one grouped batch bundle
+- each item keeps independent acceptance criteria and handoff state
+
+### Path Selection Rule
+
+- if normalized intake has exactly one candidate implementation item, keep single-item behavior and batch artifacts are optional
+- if normalized intake has more than one candidate implementation item, run planning-batch behavior
+
+This preserves #68 compatibility while making multi-item planning explicit.
+
+## Planning-Batch Workflow
+
+### Step 1: Normalize Intake
+
+Normalize the batch intake object into deterministic fields:
+
+- `epic_objective`
+- `candidate_work_items[]`
+- `constraints`
+- optional context (`epic_id`, `milestone`, `planning_window`, `source_refs`, `default_assumptions`)
+
+Normalize slugs using #68 rules for all generated item lineages.
+
+### Step 2: Decompose Into Candidate Implementation Items
+
+For each candidate work item:
+
+- split oversized or ambiguity-heavy items before spec drafting
+- ensure each resulting item has one clear implementable outcome
+- assign stable `item_id` and normalized `item_slug`
+- attach parent epic linkage and candidate dependencies
+
+If decomposition produces cycles in dependencies, mark involved items `blocked` until cycle resolution.
+
+### Step 3: Generate Per-Item Minimum Spec Package
+
+Generate one canonical spec lineage per item at:
+
+- `.agency/specs/<item-slug>.md`
+
+Each item spec must include the #68 minimum package:
+
+- problem and desired outcome
+- in-scope and out-of-scope boundaries
+- acceptance criteria with testable completion conditions
+- dependency and sequencing notes
+- risk notes and open questions
+- validation expectations and evidence requirements
+- explicit handoff state (`ready-for-build`, `needs-clarification`, or `blocked`)
+
+Each item must stand alone for implementation handoff.
+
+### Step 4: Evaluate Independent Item Readiness
+
+Readiness is per-item, not batch-wide.
+
+- `ready-for-build`: this item may proceed
+- `needs-clarification`: item-level questions remain; unrelated ready items may proceed
+- `blocked`: external dependency/risk prevents safe handoff
+
+Do not collapse mixed outcomes into one forced global state.
+
+### Step 5: Produce Batch Summary / Index
+
+For multi-item runs, write grouped artifacts under:
+
+- `.agency/specs/batches/<epic-slug>/<milestone-slug-or-unscoped>/<batch-key>/`
+
+Required reviewer/operator outputs:
+
+- `index.md`
+  - primary summary and navigation index for the run
+  - execution waves in suggested build order
+  - per-item state summary (`ready-for-build`, `needs-clarification`, `blocked`)
+  - links to canonical per-item specs
+- `review.md`
+  - reviewer-oriented rationale, assumptions, unresolved decisions, and rerun deltas
+- `decomposition.yaml`
+  - DAG edges and wave ordering
+- `decisions.yaml`
+  - item-scoped confirmed/assumed/unresolved decisions
+- `items/<order>-<item-slug>.md`
+  - per-item summary sheets linked to canonical spec files
+
+`index.md` is the operator-facing table of contents; `review.md` is the reviewer-facing decision narrative.
+
+## Suggested Execution Order Rules
+
+The summary/index should compute suggested execution order with deterministic rules:
+
+1. topological sort by dependency edges
+2. group into waves (`wave: 0, 1, 2...`)
+3. tie-break items in same wave by normalized slug ascending
+
+Only `ready-for-build` items should appear in the default "build now" subset.
+
+## Rerun Behavior
+
+Reruns of the same `batch-key` should:
+
+- update batch bundle files in place
+- keep unchanged item slugs stable
+- avoid artificial `revision` bumps for unchanged item scope/acceptance
+- increment `revision` only for material item changes
+
+## Non-Goals
+
+This workflow does not define:
+
+- provider-specific bulk tracker write mechanics (handled separately)
+- sprint capacity prediction heuristics
+- automatic reprioritization beyond deterministic DAG ordering
+
+## Acceptance Criteria Coverage For #74
+
+- Multi-item planning input can generate multiple specs in one run:
+  - see `Path B: Planning-Batch`, `Step 2`, and `Step 3`
+- Each generated item has independent readiness state and acceptance criteria:
+  - see `Step 3` and `Step 4`
+- Batch summary/index is produced for reviewer/operator use:
+  - see `Step 5`
+- Existing single-item spec workflow remains intact:
+  - see `Path A` and `Path Selection Rule`

--- a/docs/project-integration-declaration-format.md
+++ b/docs/project-integration-declaration-format.md
@@ -77,6 +77,7 @@ These map canonical capabilities to one declared provider entry.
 Examples:
 
 - `task-intake.direct-brief` -> local direct-brief input
+- `task-intake.batch-planning` -> local planning-batch intake object
 - `task-tracker.read` -> Jira
 - `task-tracker.create` -> GitHub Issues
 - `code-host.pr.open` -> GitHub
@@ -112,6 +113,11 @@ capability_bindings:
     provider_ref: local-direct-brief
     support: full
     decision_state: confirmed
+
+  task-intake.batch-planning:
+    provider_ref: local-direct-brief
+    support: full
+    decision_state: assumed
 
   task-tracker.lookup:
     provider_ref: github
@@ -349,6 +355,7 @@ That means:
 
 - local providers are valid first-class entries in `providers`
 - `task-intake.direct-brief` may bind to a `kind: local` provider
+- `task-intake.batch-planning` may bind to the same local provider when planning-batch mode is enabled
 - `task-intake.assumption-capture` may also bind to a local provider or generated-skill behavior record
 
 Example:
@@ -362,6 +369,11 @@ providers:
 
 capability_bindings:
   task-intake.direct-brief:
+    provider_ref: local-direct-brief
+    support: full
+    decision_state: confirmed
+
+  task-intake.batch-planning:
     provider_ref: local-direct-brief
     support: full
     decision_state: confirmed
@@ -431,6 +443,11 @@ capability_bindings:
     provider_ref: local-direct-brief
     support: full
     decision_state: confirmed
+
+  task-intake.batch-planning:
+    provider_ref: local-direct-brief
+    support: full
+    decision_state: assumed
 
   task-intake.assumption-capture:
     provider_ref: local-direct-brief

--- a/docs/provider-matrix.md
+++ b/docs/provider-matrix.md
@@ -30,7 +30,7 @@ Execution-tier choices (`solo`, `sub-agent`, `agent-team`) are intentionally out
 
 ## Canonical Capability Subset Used In This Matrix
 
-Task intake is always available through local paths (`task-intake.direct-brief`, `task-intake.assumption-capture`) and is therefore omitted from provider rows below.
+Task intake is always available through local paths (`task-intake.direct-brief`, `task-intake.batch-planning`, `task-intake.assumption-capture`) and is therefore omitted from provider rows below.
 
 The provider matrix focuses on external-provider capabilities:
 

--- a/docs/spec-batch-planning-contract.md
+++ b/docs/spec-batch-planning-contract.md
@@ -12,6 +12,7 @@ It builds on:
 - capability semantics in [`docs/external-capability-model.md`](./external-capability-model.md)
 - fallback semantics in [`docs/capability-fallback-behavior.md`](./capability-fallback-behavior.md)
 - generated artifact reviewability expectations in [`docs/generated-skill-layout.md`](./generated-skill-layout.md)
+- operational decomposition workflow in [`docs/portfolio-to-spec-decomposition-workflow.md`](./portfolio-to-spec-decomposition-workflow.md)
 
 ## Why This Exists
 
@@ -120,6 +121,8 @@ Recommended bundle contents:
   - confirmed/assumed/unresolved decisions, item-scoped
 - `review.md`
   - human review summary and readiness table
+- `index.md`
+  - operator-facing summary/index with suggested execution order and links to canonical per-item specs
 - `items/<order>-<item-slug>.md`
   - item summary sheet with links to canonical per-item spec files
 
@@ -170,6 +173,12 @@ Batch output must be reviewable as normal repository artifacts.
 - assumptions and unresolved decisions grouped by item
 - explicit links to each canonical `.agency/specs/<item-slug>.md`
 - rerun delta summary (what changed from previous batch revision)
+
+`index.md` for batch runs should include:
+
+- concise run summary for operators
+- suggested execution order by wave
+- quick state rollup for each item (`ready-for-build`, `needs-clarification`, `blocked`)
 
 This keeps planning decisions auditable without requiring runtime logs.
 

--- a/docs/spec-builder-contract.md
+++ b/docs/spec-builder-contract.md
@@ -9,6 +9,7 @@ It builds on:
 - task-system provider behavior in [`docs/task-system-provider-fragment-set.md`](./task-system-provider-fragment-set.md)
 - role ownership and handoff expectations in [`docs/orchestration-role-handoff-contract.md`](./orchestration-role-handoff-contract.md)
 - batch planning and decomposition extension in [`docs/spec-batch-planning-contract.md`](./spec-batch-planning-contract.md)
+- workflow execution path for multi-item planning in [`docs/portfolio-to-spec-decomposition-workflow.md`](./portfolio-to-spec-decomposition-workflow.md)
 
 ## Why This Exists
 
@@ -32,6 +33,8 @@ The spec-builder does not replace implementation, review, or validation flows af
 This document is the canonical single-item baseline.
 
 Batch/sprint planning behavior for multi-item spec generation is defined as an additive extension in [`docs/spec-batch-planning-contract.md`](./spec-batch-planning-contract.md).
+
+Operational decomposition behavior for that batch/sprint path is defined in [`docs/portfolio-to-spec-decomposition-workflow.md`](./portfolio-to-spec-decomposition-workflow.md).
 
 ## Core Workflow
 
@@ -138,6 +141,7 @@ If these conditions are not met, the handoff remains `needs-clarification` or `b
 Spec-builder behavior relies on canonical capabilities:
 
 - `task-intake.direct-brief`
+- `task-intake.batch-planning` (when planning-batch invocation is enabled)
 - `task-intake.assumption-capture`
 - `task-tracker.lookup`
 - `task-tracker.read`

--- a/docs/task-system-provider-fragment-set.md
+++ b/docs/task-system-provider-fragment-set.md
@@ -150,6 +150,11 @@ capability_bindings:
     support: full
     decision_state: confirmed
 
+  task-intake.batch-planning:
+    provider_ref: local-direct-brief
+    support: full
+    decision_state: assumed
+
   task-tracker.lookup:
     provider_ref: jira
     support: full

--- a/skills/fragments/README.md
+++ b/skills/fragments/README.md
@@ -20,6 +20,7 @@ In v1, each fragment is:
 
 - `task-intake/`
   - direct-brief and other work-entry fragments
+  - includes companion planning-batch intake fragments for portfolio-to-spec decomposition
 - `project-management/`
   - task-system and workflow-of-record fragments
 - `delivery/`

--- a/skills/fragments/task-intake/direct-brief.md
+++ b/skills/fragments/task-intake/direct-brief.md
@@ -18,6 +18,7 @@ selection:
 composition:
   requires: []
   suggests:
+    - task-intake/portfolio-spec-decomposition
     - orchestration/team-sizing
     - runtime/context-and-model-routing
   conflicts: []
@@ -52,4 +53,5 @@ Allow work to begin from a freeform prompt or bootstrap brief instead of requiri
 
 - Pair well with `orchestration/team-sizing.md`.
 - Pair well with `runtime/context-and-model-routing.md`.
+- Add `task-intake/portfolio-spec-decomposition.md` when direct-brief intake must also support multi-item planning runs.
 - This fragment is a first-class alternative to task-system provider fragments, not just a fallback.

--- a/skills/fragments/task-intake/portfolio-spec-decomposition.md
+++ b/skills/fragments/task-intake/portfolio-spec-decomposition.md
@@ -1,0 +1,58 @@
+---
+schema_version: 1
+id: task-intake/portfolio-spec-decomposition
+title: Portfolio-To-Spec Decomposition
+fragment_type: generic
+layer: task-intake
+summary: Add a planning-oriented intake path that decomposes one portfolio/sprint planning object into multiple item specs without replacing single-item flow.
+capabilities:
+  - task-intake.batch-planning
+  - task-intake.assumption-capture
+selection:
+  evidence_any:
+    - input.batch_planning_object
+    - workflow.sprint_kickoff_planning
+    - workflow.parallel_work_bounded
+  evidence_all: []
+  evidence_none: []
+  preference: 68
+composition:
+  requires:
+    - task-intake/direct-brief
+  suggests:
+    - orchestration/team-sizing
+    - runtime/context-and-model-routing
+  conflicts: []
+  exclusive_within: []
+  emits:
+    - spec-planning-batch
+    - decomposition-ordering
+    - item-readiness-gating
+  order: 15
+---
+
+# Fragment: Portfolio-To-Spec Decomposition
+
+## Purpose
+
+Add a planning-oriented intake path that can turn one portfolio/sprint planning input into multiple implementation-ready item specs in a single run.
+
+## Include When
+
+- Sprint or milestone kickoff often starts from one epic objective with many candidate implementation items.
+- The team wants deterministic decomposition and ordering before implementation starts.
+- Reviewers need one grouped batch index plus canonical per-item specs.
+
+## Expected Behaviors
+
+- Keep #68 single-item semantics intact for one-item intake.
+- When intake includes multiple candidate items, decompose into independently reviewable item specs.
+- Generate a minimum spec package per item with independent acceptance criteria and handoff state.
+- Preserve item-scoped decisions and unresolved questions instead of collapsing to one batch verdict.
+- Produce a batch summary/index with suggested execution waves and links to canonical `.agency/specs/<item-slug>.md` artifacts.
+
+## Builder Notes
+
+- This fragment is additive to direct-brief intake, not a replacement.
+- Pair with orchestration and runtime fragments to keep decomposition deterministic and budget-aware.
+- Follow [`docs/portfolio-to-spec-decomposition-workflow.md`](../../../docs/portfolio-to-spec-decomposition-workflow.md) and [`docs/spec-batch-planning-contract.md`](../../../docs/spec-batch-planning-contract.md) for artifact and readiness rules.

--- a/skills/skill-builder/SKILL.md
+++ b/skills/skill-builder/SKILL.md
@@ -47,6 +47,7 @@ Summarize what was detected and what is still unknown.
 Ask only the unresolved questions that materially affect skill composition. Prioritize:
 
 - Work intake mode: direct brief, tracked task, or both
+- Spec intake shape for direct brief: single-item flow, planning-batch flow, or both
 - Project management system when tracked-task intake is in scope: GitHub Issues, Jira, Linear, or other
 - Review tooling: CodeRabbit, human-only review, custom CI gates
 - Whether tasks should default to solo execution or team orchestration


### PR DESCRIPTION
## Summary
Add a planning-oriented companion path for Milestone 4 spec generation so one portfolio/sprint intake can produce multiple per-item spec drafts with independent handoff states, while preserving #68 single-item behavior.

## What Changed
- Added a dedicated workflow runbook for portfolio-to-spec decomposition.
- Added a reusable task-intake fragment for planning-batch decomposition (`task-intake/portfolio-spec-decomposition`).
- Introduced explicit `task-intake.batch-planning` capability semantics and aligned integration/fallback/provider docs.
- Extended batch artifact expectations to include an operator-facing `index.md` summary with suggested execution order.

## Acceptance Criteria Mapping
- [x] Multi-item planning input can generate multiple specs in one run  
  - `docs/portfolio-to-spec-decomposition-workflow.md` (`Path B: Planning-Batch`, `Step 2`, `Step 3`)  
  - `skills/fragments/task-intake/portfolio-spec-decomposition.md` (`Expected Behaviors`)
- [x] Each generated item has independent readiness state and acceptance criteria  
  - `docs/portfolio-to-spec-decomposition-workflow.md` (`Step 3`, `Step 4`)  
  - `docs/spec-batch-planning-contract.md` (`Readiness And Blocking Semantics` + `index.md` additions)
- [x] Batch summary/index is produced for reviewer/operator use  
  - `docs/portfolio-to-spec-decomposition-workflow.md` (`Step 5`)  
  - `docs/spec-batch-planning-contract.md` (`Batch Grouping Bundle` + `Reviewability Contract` updates for `index.md`)
- [x] Existing single-item spec workflow remains intact  
  - `docs/portfolio-to-spec-decomposition-workflow.md` (`Path A`, `Path Selection Rule`)  
  - `docs/spec-builder-contract.md` (explicit additive reference only; single-item baseline unchanged)

## Validation
- Ran `./scripts/lint-agents.sh` (passes; pre-existing warnings only).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Planning‑Batch intake mode that decomposes one planning input into multiple per-item specs, emits grouped batch bundles with an operator-facing index, per-item readiness states, and a deterministic suggested execution order

* **Documentation**
  * Expanded docs, questionnaires, capability mappings, fragment guidance, provider examples, and contracts to describe batch‑planning intake semantics, artifacts, rollout rules, and evaluation/readiness behavior
<!-- end of auto-generated comment: release notes by coderabbit.ai -->