### PR TITLE
Milestone 4: add bulk tracker sync + approval gates for spec batches (#75)

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,7 @@ Use one worktree per issue/team stream to keep execution isolated.
 - [docs/spec-builder-contract.md](docs/spec-builder-contract.md)
 - [docs/spec-batch-planning-contract.md](docs/spec-batch-planning-contract.md)
 - [docs/portfolio-to-spec-decomposition-workflow.md](docs/portfolio-to-spec-decomposition-workflow.md)
+- [docs/spec-batch-tracker-sync-and-approval-gates.md](docs/spec-batch-tracker-sync-and-approval-gates.md)
 - [docs/builder-usage-and-repo-local-precedence-contract.md](docs/builder-usage-and-repo-local-precedence-contract.md)
 - [docs/install-packaging-skill-fragments-contract.md](docs/install-packaging-skill-fragments-contract.md)
 - [docs/runtime-context-budgeting-and-repo-reading.md](docs/runtime-context-budgeting-and-repo-reading.md)

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -257,6 +257,7 @@ Primary contracts:
 - single-item baseline: [`docs/spec-builder-contract.md`](./docs/spec-builder-contract.md)
 - batch planning extension: [`docs/spec-batch-planning-contract.md`](./docs/spec-batch-planning-contract.md)
 - portfolio-to-spec decomposition workflow: [`docs/portfolio-to-spec-decomposition-workflow.md`](./docs/portfolio-to-spec-decomposition-workflow.md)
+- batch tracker sync and approval gates: [`docs/spec-batch-tracker-sync-and-approval-gates.md`](./docs/spec-batch-tracker-sync-and-approval-gates.md)
 
 Goals:
 

--- a/docs/capability-fallback-behavior.md
+++ b/docs/capability-fallback-behavior.md
@@ -301,6 +301,32 @@ In batch mode, fallback reporting should preserve per-item truth in review artif
 
 This is valid and should not be collapsed into all-or-nothing reporting.
 
+### Rule 4: Keep Tracker Writes Behind Explicit Approval Gates
+
+For batch tracker synchronization:
+
+- generate planned create/update actions first (dry run)
+- require reviewer/operator approval before durable tracker writes
+- if approval is missing, record pending state rather than executing writes
+
+Lack of approval is not a silent success path. It should be reported clearly as intentional non-execution.
+
+### Rule 5: Treat Duplicate-Risk And Ambiguous Linking As Safety Conditions
+
+If a batch item cannot be matched safely to an existing tracker record:
+
+- do not guess between possible targets
+- avoid create operations that may duplicate an existing ticket
+- degrade that item to `manual` or `fail` according to available human fallback
+
+### Rule 6: Surface Partial Provider Failures With Retry Scope
+
+When some batch writes fail:
+
+- preserve successful outcomes for other items
+- report exactly which item ids/slugs are safe to retry
+- include explicit retry preconditions for each failed item (permission fix, required field, transition state, duplicate resolution)
+
 ## Recommended Binding Fields In `integrations.yaml`
 
 To support fallback reviewability, capability bindings may include:

--- a/docs/portfolio-to-spec-decomposition-workflow.md
+++ b/docs/portfolio-to-spec-decomposition-workflow.md
@@ -8,6 +8,7 @@ It builds on:
 
 - the single-item baseline in [`docs/spec-builder-contract.md`](./spec-builder-contract.md) from issue `#68`
 - the batch artifact model in [`docs/spec-batch-planning-contract.md`](./spec-batch-planning-contract.md) from issue `#76`
+- batch tracker sync and approval gates in [`docs/spec-batch-tracker-sync-and-approval-gates.md`](./spec-batch-tracker-sync-and-approval-gates.md) from issue `#75`
 - fallback semantics in [`docs/capability-fallback-behavior.md`](./capability-fallback-behavior.md)
 
 ## Why This Exists
@@ -140,11 +141,22 @@ Reruns of the same `batch-key` should:
 - avoid artificial `revision` bumps for unchanged item scope/acceptance
 - increment `revision` only for material item changes
 
+## Tracker Sync Follow-On For Batch Runs
+
+When batch outputs are tracker-backed, run a post-planning sync lifecycle defined in [`docs/spec-batch-tracker-sync-and-approval-gates.md`](./spec-batch-tracker-sync-and-approval-gates.md):
+
+1. generate dry-run planned writes
+2. complete reviewer and operator approval gates
+3. apply approved create/update operations
+4. publish per-item created/updated/skipped/failed outcomes with retry guidance
+
+Planning-batch decomposition should not bypass approval boundaries for tracker writes.
+
 ## Non-Goals
 
 This workflow does not define:
 
-- provider-specific bulk tracker write mechanics (handled separately)
+- provider-specific bulk tracker write mechanics (defined in [`docs/spec-batch-tracker-sync-and-approval-gates.md`](./spec-batch-tracker-sync-and-approval-gates.md))
 - sprint capacity prediction heuristics
 - automatic reprioritization beyond deterministic DAG ordering
 

--- a/docs/spec-batch-planning-contract.md
+++ b/docs/spec-batch-planning-contract.md
@@ -13,6 +13,7 @@ It builds on:
 - fallback semantics in [`docs/capability-fallback-behavior.md`](./capability-fallback-behavior.md)
 - generated artifact reviewability expectations in [`docs/generated-skill-layout.md`](./generated-skill-layout.md)
 - operational decomposition workflow in [`docs/portfolio-to-spec-decomposition-workflow.md`](./portfolio-to-spec-decomposition-workflow.md)
+- batch tracker sync and approval behavior in [`docs/spec-batch-tracker-sync-and-approval-gates.md`](./spec-batch-tracker-sync-and-approval-gates.md)
 
 ## Why This Exists
 
@@ -206,6 +207,17 @@ Batch planning should follow capability fallback semantics from [`docs/capabilit
 - missing capability for one item path should degrade that item first
 - only intake-wide capability failures should block the full batch
 - manual-mode steps may apply to specific items without marking unrelated items unresolved
+
+## Tracker Synchronization Alignment
+
+This contract defines planning artifacts and item readiness semantics.
+
+Bulk tracker create/update execution for batch runs is defined separately in [`docs/spec-batch-tracker-sync-and-approval-gates.md`](./spec-batch-tracker-sync-and-approval-gates.md), including:
+
+- dry-run planning of proposed writes
+- reviewer/operator approval gates before writes
+- idempotency expectations for reruns
+- per-item result reporting for partial failure handling
 
 ## Acceptance Criteria Coverage For #76
 

--- a/docs/spec-batch-tracker-sync-and-approval-gates.md
+++ b/docs/spec-batch-tracker-sync-and-approval-gates.md
@@ -80,6 +80,24 @@ After reviewer sign-off and before provider writes:
 
 No batch create/update operation should run without explicit operator approval.
 
+Required operator approval artifact:
+
+- `.agency/specs/batches/<epic-slug>/<milestone-slug-or-unscoped>/<batch-key>/tracker-sync-approval.yaml`
+- minimum fields:
+  - `approval_id` (stable approval record id)
+  - `batch_key`
+  - `approver_id`
+  - `approved_at` (timestamp)
+  - `decision` (`approved` or `rejected`)
+  - `comment` (optional)
+  - `approval_nonce` (or equivalent integrity marker)
+
+Execution enforcement requirements:
+
+- apply phase must look up `tracker-sync-approval.yaml` for the current `batch-key` before any provider write
+- if approval artifact is missing, malformed, or not `decision: approved`, reject batch create/update execution
+- approval artifacts should be treated as immutable decision records and retained with the batch bundle for auditability
+
 ### Phase 4: Apply Writes And Record Results
 
 Execute approved writes and persist one result ledger:
@@ -172,4 +190,3 @@ Fail mode remains required when:
   - see `Phase 4: Apply Writes And Record Results` and `Partial Failure Handling And Retry Guidance`
 - Capability fallback behavior remains aligned with existing contracts:
   - see `Fallback Alignment`
-

--- a/docs/spec-batch-tracker-sync-and-approval-gates.md
+++ b/docs/spec-batch-tracker-sync-and-approval-gates.md
@@ -1,0 +1,175 @@
+# Batch Tracker Sync And Approval Gates
+
+This document defines the Milestone 4 contract for issue `#75`:
+
+- [#75 Milestone 4: Add Bulk Tracker Sync And Approval Gates For Spec Batches](https://github.com/peakweb-team/pw-agency-agents/issues/75)
+
+It extends:
+
+- the single-item spec-builder baseline in [`docs/spec-builder-contract.md`](./spec-builder-contract.md) from issue `#68`
+- the batch planning artifact model in [`docs/spec-batch-planning-contract.md`](./spec-batch-planning-contract.md) from issue `#76`
+- the portfolio decomposition workflow in [`docs/portfolio-to-spec-decomposition-workflow.md`](./portfolio-to-spec-decomposition-workflow.md) from issue `#74`
+- fallback semantics in [`docs/capability-fallback-behavior.md`](./capability-fallback-behavior.md)
+
+## Why This Exists
+
+Batch planning should not create tracker noise.
+
+Teams need an explicit review and authorization boundary before a multi-item create/update run writes into GitHub Issues, Jira, or equivalent systems.
+
+This contract adds that boundary while keeping reruns idempotent and preserving #68 single-item behavior.
+
+## Compatibility Rules
+
+The following remain unchanged:
+
+- #68 single-item workflow semantics and handoff states
+- #74 planning-batch decomposition and grouped artifact generation
+- #76 item-scoped readiness, decisions, and deterministic rerun behavior
+
+This contract is additive:
+
+- single-item sync may continue with existing behavior
+- batch tracker sync introduces explicit pre-write planning and approval gates
+
+## Batch Tracker Sync Lifecycle
+
+Batch tracker synchronization has four explicit phases.
+
+### Phase 1: Build Planned Writes (Dry Run)
+
+For each item in a batch run, compute a planned tracker action:
+
+- `create`: no linked tracker record exists for the canonical item lineage
+- `update`: linked tracker record exists and content drift is material
+- `skip`: no material tracker change needed
+
+Dry-run output should be written to:
+
+- `.agency/specs/batches/<epic-slug>/<milestone-slug-or-unscoped>/<batch-key>/tracker-sync-plan.yaml`
+
+Minimum per-item plan fields:
+
+- `item_id`
+- `item_slug`
+- `proposed_action` (`create`, `update`, `skip`)
+- `idempotency_key`
+- `tracker_locator` (when known, such as issue number/key/url)
+- `change_summary`
+- `status` (`pending-approval`, `ready-to-apply`, `applied`, `failed`, `skipped`)
+
+### Phase 2: Reviewer Gate
+
+Before any write:
+
+- reviewer validates scope/quality for planned tracker operations
+- reviewer confirms no low-quality or duplicate ticket payloads are queued
+- reviewer may change planned actions (for example force `skip` on low-value updates)
+
+Expected reviewer decision is recorded in:
+
+- `tracker-sync-review.md`
+
+### Phase 3: Operator Approval Gate
+
+After reviewer sign-off and before provider writes:
+
+- operator explicitly approves execution
+- operator confirms provider/project targeting (repo/project key, milestone mapping)
+- operator confirms safety constraints (rate limits, labeling policy, assignment policy)
+
+No batch create/update operation should run without explicit operator approval.
+
+### Phase 4: Apply Writes And Record Results
+
+Execute approved writes and persist one result ledger:
+
+- `tracker-sync-results.yaml`
+
+Minimum per-item result fields:
+
+- `item_id`
+- `item_slug`
+- `attempted_action`
+- `outcome` (`created`, `updated`, `skipped`, `failed`)
+- `tracker_locator`
+- `failure_reason` (when failed)
+- `retry_hint` (when failed)
+
+## Idempotency Rules For Reruns
+
+Reruns of the same `batch-key` must avoid duplicate tracker items.
+
+### Stable Identity Requirements
+
+- `item_slug` remains the canonical lineage key
+- each item write uses a deterministic `idempotency_key` derived from stable batch and item identity
+- if a tracker record already exists for that key or explicit cross-link, use `update` or `skip`, not `create`
+
+### Duplicate-Prevention Requirements
+
+- never `create` when an authoritative locator is already linked
+- never emit multiple create operations for the same `(batch-key, item_slug)` in one apply phase
+- when locator lookup is ambiguous, block that item with explicit manual resolution guidance instead of guessing
+
+### Material-Change Threshold
+
+`update` should run only for material deltas (scope, acceptance criteria, handoff state, dependencies, or risk posture), not trivial wording edits.
+
+## Grouped Epic/Milestone Assignment Behavior
+
+Where provider supports grouping:
+
+- map batch epic/milestone metadata into provider-native fields
+- keep item-level ticket identity independent from group assignment metadata
+
+Where provider does not support grouping:
+
+- preserve batch grouping in local artifacts
+- include equivalent grouping text labels in ticket body/labels when safe
+- do not claim provider-native grouping was applied if only local grouping exists
+
+## Partial Failure Handling And Retry Guidance
+
+Batch writes may partially succeed.
+
+Required behavior:
+
+- report per-item outcomes (`created`, `updated`, `skipped`, `failed`)
+- do not collapse partial success into one opaque batch result
+- continue safe writes for unrelated items when one item fails
+- provide concrete retry guidance for failed items in `tracker-sync-results.yaml` and `review.md`
+
+Retry guidance should include:
+
+- whether failure is safe to retry automatically
+- what human fix is required first (permission, required field, invalid transition, duplicate ambiguity)
+- the exact item ids/slugs safe for the next retry attempt
+
+## Fallback Alignment
+
+When capabilities degrade:
+
+- follow `warn`, `manual`, and `fail` semantics from [`docs/capability-fallback-behavior.md`](./capability-fallback-behavior.md)
+- preserve item-scoped fallback outcomes for batch runs
+- keep direct-brief/local-spec path available when tracker create/update is unavailable and project policy allows it
+
+Manual fallback remains valid when:
+
+- writes are blocked by permissions but human operators can safely complete updates in the tracker
+
+Fail mode remains required when:
+
+- no safe automated or manual path can produce truthful tracker synchronization claims
+
+## Acceptance Criteria Coverage For #75
+
+- Operator can review planned writes before execution:
+  - see `Phase 1: Build Planned Writes (Dry Run)`, `Phase 2: Reviewer Gate`, and `Phase 3: Operator Approval Gate`
+- Rerunning the same batch does not create duplicate tracker items:
+  - see `Idempotency Rules For Reruns`
+- Partial provider failure is surfaced clearly with retry guidance:
+  - see `Phase 4: Apply Writes And Record Results` and `Partial Failure Handling And Retry Guidance`
+- Capability fallback behavior remains aligned with existing contracts:
+  - see `Fallback Alignment`
+

--- a/docs/spec-builder-contract.md
+++ b/docs/spec-builder-contract.md
@@ -10,6 +10,7 @@ It builds on:
 - role ownership and handoff expectations in [`docs/orchestration-role-handoff-contract.md`](./orchestration-role-handoff-contract.md)
 - batch planning and decomposition extension in [`docs/spec-batch-planning-contract.md`](./spec-batch-planning-contract.md)
 - workflow execution path for multi-item planning in [`docs/portfolio-to-spec-decomposition-workflow.md`](./portfolio-to-spec-decomposition-workflow.md)
+- batch tracker sync and approval boundaries in [`docs/spec-batch-tracker-sync-and-approval-gates.md`](./spec-batch-tracker-sync-and-approval-gates.md)
 
 ## Why This Exists
 
@@ -85,6 +86,7 @@ When a primary task tracker is configured:
 - create or update the tracked item via canonical task-tracker capabilities
 - store the implementation-ready spec in the ticket/issue body or linked canonical artifact
 - persist milestones and final completion summaries in the same tracker
+- for planning-batch runs, require dry-run planning plus explicit reviewer/operator approval before bulk create/update writes
 
 ### Direct-Brief Path
 

--- a/docs/spec-builder-contract.md
+++ b/docs/spec-builder-contract.md
@@ -86,7 +86,7 @@ When a primary task tracker is configured:
 - create or update the tracked item via canonical task-tracker capabilities
 - store the implementation-ready spec in the ticket/issue body or linked canonical artifact
 - persist milestones and final completion summaries in the same tracker
-- for planning-batch runs, require dry-run planning plus explicit reviewer/operator approval before bulk create/update writes
+- for planning-batch runs, require dry-run planning plus explicit reviewer approval and explicit operator approval before bulk create/update writes
 
 ### Direct-Brief Path
 

--- a/docs/task-system-provider-fragment-set.md
+++ b/docs/task-system-provider-fragment-set.md
@@ -101,9 +101,11 @@ Both fragments may suggest direct-brief and assumption-capture fragments for dua
 - `task-tracker.create`
   - Create new tickets from approved spec artifacts when implementation cannot start from an existing tracked task.
   - Ensure project-key, issue-type, and required-field constraints are handled explicitly.
+  - For batch planning runs, execute create actions only after dry-run review and explicit operator approval.
 - `task-tracker.update`
   - Post durable human-facing progress updates and completion summaries.
   - Respect that transitions/permissions vary per project; do not assume uniform transition rights.
+  - For batch planning runs, publish per-item outcomes (`updated`, `skipped`, `failed`) and retry guidance.
 
 ## Fallback Expectations For This Fragment Set
 
@@ -119,8 +121,10 @@ Recommended behavior for first-wave task-system fragments:
 | `task-tracker.read` | `unavailable` for tracker-selected path | `fail` | Block tracker-first path; switch to direct-brief mode only if project intake decision permits it. |
 | `task-tracker.create` | readable tracker exists but create permission/required fields are missing | `manual` | Continue with explicit manual-create handoff and require linking created task before implementation starts. |
 | `task-tracker.create` | fully unavailable in a spec-first tracked workflow | `fail` | Do not claim tracker-backed spec intake; fall back to direct-brief/local spec path only if selected. |
+| `task-tracker.create` | batch write is not explicitly approved by reviewer/operator gate | `manual` | Keep planned writes in dry-run state; do not execute durable create operations until approval is recorded. |
 | `task-tracker.update` | readable but update path requires human/manual action | `manual` | Continue implementation flow, but require explicit human task update before marking workflow complete. |
 | `task-tracker.update` | fully unavailable and no safe manual process agreed | `fail` | Do not present durable tracker synchronization as completed. |
+| `task-tracker.update` | partial batch provider failure (some items succeed, some fail) | `warn` | Record item-level outcomes and retry guidance; do not collapse results into one opaque batch status. |
 
 ## Integration Declaration Expectations
 

--- a/docs/task-system-provider-fragment-set.md
+++ b/docs/task-system-provider-fragment-set.md
@@ -88,9 +88,11 @@ Both fragments may suggest direct-brief and assumption-capture fragments for dua
 - `task-tracker.create`
   - Create new issues from approved spec artifacts when implementation cannot start from an existing tracked task.
   - Ensure created issue content includes scope summary, acceptance expectations, and links to canonical spec artifacts.
+  - For batch planning runs, execute create actions only after dry-run review and explicit operator approval.
 - `task-tracker.update`
   - Post durable human-facing progress updates and completion summaries.
   - Keep updates milestone-oriented rather than mirroring every internal subtask.
+  - For batch planning runs, publish per-item outcomes (`updated`, `skipped`, `failed`) and retry guidance.
 
 ### Jira Fragment Responsibilities
 


### PR DESCRIPTION
## Summary
Implements Milestone 4 issue #75 by adding a dedicated batch tracker sync contract and integrating explicit review/approval gates, idempotent rerun behavior, and partial-failure retry reporting into the existing spec-batch workflow docs.

## Acceptance Criteria Mapping
- [x] Operator can review planned writes before execution
  - [`docs/spec-batch-tracker-sync-and-approval-gates.md`](./docs/spec-batch-tracker-sync-and-approval-gates.md)
    - `Phase 1: Build Planned Writes (Dry Run)`
    - `Phase 2: Reviewer Gate`
    - `Phase 3: Operator Approval Gate`
  - [`docs/portfolio-to-spec-decomposition-workflow.md`](./docs/portfolio-to-spec-decomposition-workflow.md)
    - `Tracker Sync Follow-On For Batch Runs`

- [x] Rerunning the same batch does not create duplicate tracker items
  - [`docs/spec-batch-tracker-sync-and-approval-gates.md`](./docs/spec-batch-tracker-sync-and-approval-gates.md)
    - `Idempotency Rules For Reruns`
    - `Stable Identity Requirements`
    - `Duplicate-Prevention Requirements`
  - [`docs/spec-batch-planning-contract.md`](./docs/spec-batch-planning-contract.md)
    - `Tracker Synchronization Alignment`

- [x] Partial provider failure is surfaced clearly with retry guidance
  - [`docs/spec-batch-tracker-sync-and-approval-gates.md`](./docs/spec-batch-tracker-sync-and-approval-gates.md)
    - `Phase 4: Apply Writes And Record Results`
    - `Partial Failure Handling And Retry Guidance`
  - [`docs/task-system-provider-fragment-set.md`](./docs/task-system-provider-fragment-set.md)
    - fallback table row for `task-tracker.update` partial batch provider failure
  - [`docs/capability-fallback-behavior.md`](./docs/capability-fallback-behavior.md)
    - `Rule 6: Surface Partial Provider Failures With Retry Scope`

- [x] Capability fallback behavior remains aligned with existing contracts
  - [`docs/capability-fallback-behavior.md`](./docs/capability-fallback-behavior.md)
    - `Rule 4`, `Rule 5`, `Rule 6` additions in batch fallback section
  - [`docs/task-system-provider-fragment-set.md`](./docs/task-system-provider-fragment-set.md)
    - fallback table additions for approval-gate/manual mode and partial failure/warn mode
  - [`docs/spec-builder-contract.md`](./docs/spec-builder-contract.md)
    - tracker-backed path note for planning-batch approval requirements

## Additional Coherence Updates
- Added cross-contract references so #68 single-item and #74/#76 multi-item planning semantics remain additive and non-conflicting:
  - `README.md`
  - `ROADMAP.md`
  - `docs/spec-batch-planning-contract.md`
  - `docs/portfolio-to-spec-decomposition-workflow.md`
  - `docs/spec-builder-contract.md`

## Validation
- Ran `./scripts/lint-agents.sh` (passes; existing repository warnings unrelated to this issue).

Closes #75


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new contract describing a four-phase batch tracker sync with dry-run planning, reviewer and operator approval gates, and execution/results recording.
  * Clarified idempotency and duplicate-prevention rules for batch runs and required per-item outcomes (created/updated/skipped/failed) with retry guidance.
  * Updated workflows and provider fragments to require approvals before bulk tracker writes and to define fallback behaviors for partial failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->