### PR TITLE
docs: finalize #74 portfolio-to-spec decomposition workflow

### DIFF
--- a/docs/portfolio-to-spec-decomposition-workflow.md
+++ b/docs/portfolio-to-spec-decomposition-workflow.md
@@ -46,6 +46,16 @@ Use this path when intake represents a portfolio/sprint planning unit.
 
 This preserves #68 compatibility while making multi-item planning explicit.
 
+## Ad-Hoc vs Batch Operator Experience
+
+Use one intake surface with deterministic path selection rather than separate competing commands.
+
+- ad-hoc direct brief that normalizes to one item follows Path A
+- planning input that normalizes to multiple items follows Path B
+- operators should not need to manually force mode unless override policy is explicitly configured
+
+This keeps ad-hoc and batch usage from overlapping in confusing ways.
+
 ## Planning-Batch Workflow
 
 ### Step 1: Normalize Intake
@@ -69,6 +79,20 @@ For each candidate work item:
 - attach parent epic linkage and candidate dependencies
 
 If decomposition produces cycles in dependencies, mark involved items `blocked` until cycle resolution.
+
+### Step 2a: Focused Follow-Up Policy For Ambiguity
+
+Ask follow-up questions only when missing information would materially change one or more of:
+
+- item boundaries or splitting outcome
+- dependency edges or execution wave ordering
+- acceptance criteria needed for implementation handoff
+
+When follow-up is needed:
+
+- ask the smallest focused set required to unblock decomposition (prefer item-scoped prompts)
+- keep unaffected items moving; do not block the whole batch for one ambiguous item
+- if unanswered, record unresolved decision entries and mark only impacted items `needs-clarification` or `blocked`
 
 ### Step 3: Generate Per-Item Minimum Spec Package
 
@@ -170,3 +194,12 @@ This workflow does not define:
   - see `Step 5`
 - Existing single-item spec workflow remains intact:
   - see `Path A` and `Path Selection Rule`
+
+## UX Expectations Coverage For #74
+
+- Can be used for sprint kickoff planning:
+  - see `Path B: Planning-Batch` and `Step 1`
+- Supports ad-hoc mode and batch mode without confusing overlap:
+  - see `Path Selection Rule` and `Ad-Hoc vs Batch Operator Experience`
+- Asks focused follow-ups only where ambiguity materially changes decomposition:
+  - see `Step 2a: Focused Follow-Up Policy For Ambiguity`

--- a/skills/fragments/task-intake/portfolio-spec-decomposition.md
+++ b/skills/fragments/task-intake/portfolio-spec-decomposition.md
@@ -46,9 +46,11 @@ Add a planning-oriented intake path that can turn one portfolio/sprint planning 
 ## Expected Behaviors
 
 - Keep #68 single-item semantics intact for one-item intake.
+- Use deterministic path selection so one-item ad-hoc intake stays single-item while multi-item intake runs planning-batch.
 - When intake includes multiple candidate items, decompose into independently reviewable item specs.
 - Generate a minimum spec package per item with independent acceptance criteria and handoff state.
 - Preserve item-scoped decisions and unresolved questions instead of collapsing to one batch verdict.
+- Ask focused follow-up questions only when ambiguity would materially change decomposition boundaries, dependency ordering, or acceptance criteria.
 - Produce a batch summary/index with suggested execution waves and links to canonical `.agency/specs/<item-slug>.md` artifacts.
 
 ## Builder Notes


### PR DESCRIPTION
## Summary
Refines Milestone 4 issue #74 by making decomposition UX behavior explicit where it was previously implicit.

Scope is intentionally narrow and limited to #74 workflow semantics:
- clarifies deterministic ad-hoc vs planning-batch path selection
- defines focused ambiguity follow-up policy (item-scoped, minimal prompts)
- aligns task-intake fragment guidance with the #74 workflow contract

## Acceptance Criteria Checklist (Issue #74)
- [x] Multi-item planning input can generate multiple specs in one run  
  Mapped to: `docs/portfolio-to-spec-decomposition-workflow.md` (`Path B: Planning-Batch`, `Step 2`, `Step 3`)
- [x] Each generated item has independent readiness state and acceptance criteria  
  Mapped to: `docs/portfolio-to-spec-decomposition-workflow.md` (`Step 3`, `Step 4`)
- [x] Batch summary/index is produced for reviewer/operator use  
  Mapped to: `docs/portfolio-to-spec-decomposition-workflow.md` (`Step 5`)
- [x] Existing single-item spec workflow remains intact  
  Mapped to: `docs/portfolio-to-spec-decomposition-workflow.md` (`Path A`, `Path Selection Rule`)

## UX Expectations Coverage (Issue #74 body)
- [x] Sprint kickoff planning support  
  Mapped to: `docs/portfolio-to-spec-decomposition-workflow.md` (`Path B`, `Step 1`)
- [x] Ad-hoc + batch mode without confusing overlap  
  Mapped to: `docs/portfolio-to-spec-decomposition-workflow.md` (`Path Selection Rule`, `Ad-Hoc vs Batch Operator Experience`)
- [x] Focused follow-ups only when ambiguity materially changes decomposition  
  Mapped to: `docs/portfolio-to-spec-decomposition-workflow.md` (`Step 2a`), `skills/fragments/task-intake/portfolio-spec-decomposition.md` (`Expected Behaviors`)

## Compatibility Notes
- Preserves #68 single-item behavior by keeping one-item normalization on Path A.
- Preserves #76 batch artifact model and per-item readiness expectations; no schema or path changes introduced.

## Validation
- `git diff --check` (pass)
- `./scripts/lint-agents.sh` (pass with existing repo warnings only; no new errors)

Closes #74


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified operator interaction and ambiguity-handling behavior in the portfolio-to-spec decomposition workflow.
  * Added guidance on deterministic path selection based on intake type (ad-hoc vs. batch).
  * Enhanced documentation on when follow-up questions will be triggered during the planning process.
  * Updated acceptance criteria and UX expectations coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->