### PR TITLE
docs: polish #74 UX expectation wording

### DIFF
--- a/docs/portfolio-to-spec-decomposition-workflow.md
+++ b/docs/portfolio-to-spec-decomposition-workflow.md
@@ -197,9 +197,6 @@ This workflow does not define:
 
 ## UX Expectations Coverage For #74
 
-- Can be used for sprint kickoff planning:
-  - see `Path B: Planning-Batch` and `Step 1`
-- Supports ad-hoc mode and batch mode without confusing overlap:
-  - see `Path Selection Rule` and `Ad-Hoc vs Batch Operator Experience`
-- Asks focused follow-ups only where ambiguity materially changes decomposition:
-  - see `Step 2a: Focused Follow-Up Policy For Ambiguity`
+- Supports sprint kickoff planning (see `Path B: Planning-Batch` and `Step 1`).
+- Supports ad-hoc mode and batch mode without confusing overlap (see `Path Selection Rule` and `Ad-Hoc vs Batch Operator Experience`).
+- Limits follow-up prompts to ambiguity that materially changes decomposition (see `Step 2a: Focused Follow-Up Policy For Ambiguity`).


### PR DESCRIPTION
## Summary
Apply the previously noted non-blocking CodeRabbit wording nitpick from #81.

## Scope
- tiny docs-only phrasing cleanup in one section
- no behavior, schema, or workflow contract changes

## Changes
- `docs/portfolio-to-spec-decomposition-workflow.md`
  - rewrite UX expectation bullets into parallel declarative statements

## Validation
- `git diff --check` (pass)
- `./scripts/lint-agents.sh` (pass; existing warnings only)

Follow-up to #81.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved formatting and clarity in workflow documentation for enhanced readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->