### PR TITLE
Add isolated devcontainer bootstrap skill for safer skip-permissions workflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ This installs:
 
 - agents to `~/.claude/agents/`
 - builder source bundle to `~/.claude/skills/superagents-skill-builder/`
+- devcontainer bootstrap bundle to `~/.claude/skills/superagents-devcontainer-bootstrap/`
 
 ### 2. Create Skills For A Specific Repository
 
@@ -134,6 +135,19 @@ Expected generated roots:
 Review and commit both roots together.
 
 Full contract: [docs/builder-usage-and-repo-local-precedence-contract.md](docs/builder-usage-and-repo-local-precedence-contract.md)
+
+### 2b. Bootstrap An Isolated Devcontainer (Optional)
+
+If your account constraints require `--dangerously-skip-permissions`, run the `superagents-devcontainer-bootstrap` skill to scaffold an Anthropic-based `.devcontainer/` and user-level Superagents install hooks inside the container.
+
+Installed skill bundle:
+
+- `~/.claude/skills/superagents-devcontainer-bootstrap/SKILL.md`
+- `~/.claude/skills/superagents-devcontainer-bootstrap/templates/*`
+
+Reference docs:
+
+- [Anthropic devcontainer guide](https://code.claude.com/docs/en/devcontainer)
 
 ### 3. Use Skills Day-To-Day
 
@@ -193,6 +207,7 @@ Use one worktree per issue/team stream to keep execution isolated.
 - [docs/builder-usage-and-repo-local-precedence-contract.md](docs/builder-usage-and-repo-local-precedence-contract.md)
 - [docs/install-packaging-skill-fragments-contract.md](docs/install-packaging-skill-fragments-contract.md)
 - [docs/runtime-context-budgeting-and-repo-reading.md](docs/runtime-context-budgeting-and-repo-reading.md)
+- [docs/isolated-devcontainer-bootstrap-workflow.md](docs/isolated-devcontainer-bootstrap-workflow.md)
 - [examples/generated-skills/README.md](examples/generated-skills/README.md)
 
 ## Other Integrations

--- a/docs/install-packaging-skill-fragments-contract.md
+++ b/docs/install-packaging-skill-fragments-contract.md
@@ -1,8 +1,9 @@
-# Installation And Packaging Contract For Reusable Skill Fragments
+# Installation And Packaging Contract For Reusable Superagents Skills
 
-This document defines the canonical install/packaging contract for issue `#26`:
+This document defines the canonical install/packaging contract for:
 
 - [#26 Ship reusable skill fragments in installation and packaging flow](https://github.com/peakweb-team/pw-agency-agents/issues/26)
+- [#83 Feature: Superagents skill for isolated Anthropic dev container + user-level packaging](https://github.com/peakweb-team/pw-agency-agents/issues/83)
 
 It aligns with:
 
@@ -13,12 +14,13 @@ It aligns with:
 
 ## Why This Exists
 
-Superagents now has two user-level assets that must ship together:
+Superagents now has multiple user-level assets that must ship together:
 
 - the base agent roster
-- the reusable skill-builder and fragment source bundle
+- the reusable `superagents-skill-builder` bundle with fragment source material
+- the reusable `superagents-devcontainer-bootstrap` bundle for isolated Anthropic-based container scaffolding
 
-Without an explicit install contract, users can end up with agents installed but no fragment library available for project-local generation.
+Without an explicit install contract, users can end up with agents installed but missing critical reusable skills.
 
 ## User-Level Installation Paths (Claude-First MVP)
 
@@ -32,11 +34,13 @@ the installer must place assets at deterministic user-level paths:
 
 - agents:
   - `~/.claude/agents/*.md`
-- reusable skill bundle:
+- reusable skills:
   - `~/.claude/skills/superagents-skill-builder/SKILL.md`
   - `~/.claude/skills/superagents-skill-builder/fragments/**/*.md`
+  - `~/.claude/skills/superagents-devcontainer-bootstrap/SKILL.md`
+  - `~/.claude/skills/superagents-devcontainer-bootstrap/templates/*`
 
-The reusable bundle path is intentionally namespaced (`superagents-`) so it does not collide with unrelated local skills.
+The reusable bundle paths are intentionally namespaced (`superagents-`) so they do not collide with unrelated local skills.
 
 ## Packaging Behavior
 
@@ -45,15 +49,18 @@ Superagents framework packaging for install flows must include all of the follow
 - `agents/**`
 - `skills/skill-builder/SKILL.md`
 - `skills/fragments/**/*.md`
+- `skills/devcontainer-bootstrap/**`
 - `scripts/install.sh`
 
-Installer behavior for the reusable skill bundle is deterministic:
+Installer behavior for reusable skills is deterministic:
 
-1. `SKILL.md` is copied into `~/.claude/skills/superagents-skill-builder/`.
+1. `superagents-skill-builder` is staged and activated at `~/.claude/skills/superagents-skill-builder/`.
 2. The target `fragments/` subtree under that bundle is replaced.
 3. Current repository fragments are copied into the rebuilt subtree.
+4. `superagents-devcontainer-bootstrap` is staged and activated at `~/.claude/skills/superagents-devcontainer-bootstrap/`.
+5. Existing target bundle directories are replaced atomically.
 
-Step 2 ensures removed or renamed fragments do not linger as stale local files across reinstall/upgrade runs.
+Atomic replacement ensures removed or renamed files do not linger as stale local content across reinstall/upgrade runs.
 
 ## Relationship To Repo-Local Generated Output
 
@@ -62,7 +69,7 @@ This contract does not change generated output roots:
 - generated project-local skills remain under `.claude/skills/superagents/`
 - generated metadata remains under `.agency/skills/superagents/`
 
-User-level reusable fragments are source material for generation. Repo-local generated output remains the project-authoritative execution layer.
+User-level reusable skills are source material and helper workflows. Repo-local generated output remains the project-authoritative execution layer.
 
 ## Migration Expectations
 
@@ -76,13 +83,14 @@ If a user previously installed only `~/.claude/agents`, migration is:
 Expected result:
 
 - existing agent files are refreshed as before
-- the reusable skill bundle is added at `~/.claude/skills/superagents-skill-builder/`
+- `superagents-skill-builder` is installed at `~/.claude/skills/superagents-skill-builder/`
+- `superagents-devcontainer-bootstrap` is installed at `~/.claude/skills/superagents-devcontainer-bootstrap/`
 
 No project-local generated files are created or overwritten by this installer step.
 
 ### Existing users with repo-local generated skills
 
-No immediate regeneration is required purely because the user-level fragment bundle is now installed.
+No immediate regeneration is required purely because user-level reusable bundles are refreshed or expanded.
 
 Regeneration guidance continues to follow [`docs/release-versioning-and-upgrade-contract.md`](./release-versioning-and-upgrade-contract.md).
 
@@ -90,8 +98,8 @@ Regeneration guidance continues to follow [`docs/release-versioning-and-upgrade-
 
 This contract requires:
 
-- deterministic user-level installation paths for reusable fragments
-- packaging that ships fragments with the roster install flow
+- deterministic user-level installation paths for reusable Superagents skills
+- packaging that ships reusable skills with the roster install flow
 - explicit migration guidance for agents-only installs
 
 This contract does not require:

--- a/docs/isolated-devcontainer-bootstrap-workflow.md
+++ b/docs/isolated-devcontainer-bootstrap-workflow.md
@@ -1,0 +1,64 @@
+# Isolated Devcontainer Bootstrap Workflow
+
+This document defines the workflow introduced for issue `#83`:
+
+- [#83 Feature: Superagents skill for isolated Anthropic dev container + user-level packaging](https://github.com/peakweb-team/pw-agency-agents/issues/83)
+
+## Goal
+
+Provide a repeatable and safer path for users who need `claude --dangerously-skip-permissions` by running inside an isolated Anthropic-based devcontainer and installing Superagents at user scope inside that container.
+
+## Scope
+
+- Reusable skill: `superagents-devcontainer-bootstrap`
+- Skill install path: `~/.claude/skills/superagents-devcontainer-bootstrap/`
+- Template assets:
+  - `templates/scaffold-devcontainer.sh`
+  - `templates/post-create-superagents.sh`
+  - `templates/smoke-test-superagents.sh`
+
+## Safety Guidance
+
+- Use this workflow only with trusted repositories.
+- Isolation reduces host risk but does not eliminate in-container credential exfiltration risk.
+- Do not recommend host-level use of `--dangerously-skip-permissions` as a default workflow.
+
+## Workflow
+
+1. Install Superagents for Claude Code:
+
+```bash
+./scripts/install.sh --tool claude-code
+```
+
+2. In a target repository, copy the template scripts from the installed skill bundle into `.devcontainer/`.
+
+3. Run scaffold script from the target repository root:
+
+```bash
+.devcontainer/scaffold-devcontainer.sh
+```
+
+4. Reopen the repository in the container.
+
+5. After container startup, run smoke test inside container:
+
+```bash
+.devcontainer/smoke-test-superagents.sh
+```
+
+6. If the smoke test passes, the container has user-level Superagents installed and is ready for trusted-repo workflows that may require `--dangerously-skip-permissions`.
+
+## Anthropic Baseline Dependency
+
+The scaffold script pulls baseline files from Anthropic reference source:
+
+- `devcontainer.json`
+- `Dockerfile`
+- `init-firewall.sh`
+
+Default source URL:
+
+- `https://raw.githubusercontent.com/anthropics/claude-code/main/.devcontainer`
+
+Override with `ANTHROPIC_DEVCONTAINER_BASE_URL` when pinning to a specific fork or revision mirror.

--- a/integrations/claude-code/README.md
+++ b/integrations/claude-code/README.md
@@ -3,14 +3,16 @@
 The Agency was built for Claude Code. No conversion needed — agents work
 natively with the existing `.md` + YAML frontmatter format.
 
-The Claude install flow now also ships a reusable Superagents skill bundle
-containing the skill-builder and fragment source library.
+The Claude install flow now also ships reusable Superagents skills, including:
+
+- `superagents-skill-builder` with fragment source library
+- `superagents-devcontainer-bootstrap` for isolated Anthropic-based devcontainer scaffolding
 
 ## Install
 
 ```bash
 # Copy all agents to your Claude Code agents directory
-# and install the Superagents reusable fragment bundle
+# and install reusable Superagents skills
 ./scripts/install.sh --tool claude-code
 
 # Or manually copy a category
@@ -34,10 +36,12 @@ Use the Reality Checker agent to verify this feature is production-ready.
 Agents are organized into divisions. See the [main README](../../README.md) for
 the full Agency roster.
 
-Reusable skill bundle path:
+Reusable skill bundle paths:
 
 - `~/.claude/skills/superagents-skill-builder/SKILL.md`
 - `~/.claude/skills/superagents-skill-builder/fragments/**/*.md`
+- `~/.claude/skills/superagents-devcontainer-bootstrap/SKILL.md`
+- `~/.claude/skills/superagents-devcontainer-bootstrap/templates/*`
 
 Install/packaging and migration contract:
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -10,7 +10,7 @@
 #   ./scripts/install.sh [--tool <name>] [--interactive] [--no-interactive] [--parallel] [--jobs N] [--help]
 #
 # Tools:
-#   claude-code  -- Copy agents to ~/.claude/agents/ and Superagents skill bundle to ~/.claude/skills/superagents-skill-builder/
+#   claude-code  -- Copy agents to ~/.claude/agents/ and Superagents reusable skills to ~/.claude/skills/
 #   copilot      -- Copy agents to ~/.github/agents/ and ~/.copilot/agents/
 #   antigravity  -- Copy skills to ~/.gemini/antigravity/skills/
 #   gemini-cli   -- Install extension to ~/.gemini/extensions/agency-agents/
@@ -317,6 +317,11 @@ install_claude_code() {
   local skills_dest="${HOME}/.claude/skills/superagents-skill-builder"
   local skills_backup="${HOME}/.claude/skills/superagents-skill-builder.bak"
   local skills_stage=""
+  local devcontainer_src="$SKILLS_ROOT/devcontainer-bootstrap"
+  local devcontainer_dest="${HOME}/.claude/skills/superagents-devcontainer-bootstrap"
+  local devcontainer_backup="${HOME}/.claude/skills/superagents-devcontainer-bootstrap.bak"
+  local devcontainer_stage=""
+  local devcontainer_count=0
   local builder_src="$SKILLS_ROOT/skill-builder/SKILL.md"
   local fragments_src="$SKILLS_ROOT/fragments"
   local count=0
@@ -361,6 +366,32 @@ install_claude_code() {
   skills_stage=""
   trap - RETURN
 
+  [[ -f "$devcontainer_src/SKILL.md" ]] || { err "skills/devcontainer-bootstrap/SKILL.md missing."; return 1; }
+  devcontainer_stage="$(mktemp -d "$skills_parent/superagents-devcontainer-bootstrap.tmp.XXXXXX")"
+  trap '[[ -n "$devcontainer_stage" && -d "$devcontainer_stage" ]] && rm -rf "$devcontainer_stage"' RETURN
+  cp -R "$devcontainer_src/." "$devcontainer_stage/"
+  devcontainer_count=$(find "$devcontainer_src" -type f | wc -l | awk '{print $1}')
+  if (( devcontainer_count == 0 )); then
+    rm -rf "$devcontainer_stage"
+    err "skills/devcontainer-bootstrap contains no files."
+    return 1
+  fi
+  rm -rf "$devcontainer_backup"
+  if [[ -d "$devcontainer_dest" ]]; then
+    mv "$devcontainer_dest" "$devcontainer_backup"
+  fi
+  if ! mv "$devcontainer_stage" "$devcontainer_dest"; then
+    err "failed to activate staged devcontainer skill bundle at $devcontainer_dest"
+    rm -rf "$devcontainer_dest"
+    if [[ -d "$devcontainer_backup" ]]; then
+      mv "$devcontainer_backup" "$devcontainer_dest"
+    fi
+    return 1
+  fi
+  rm -rf "$devcontainer_backup"
+  devcontainer_stage=""
+  trap - RETURN
+
   mkdir -p "$dest"
   for dir in "${AGENT_DIRS[@]}"; do
     [[ -d "$AGENTS_ROOT/$dir" ]] || continue
@@ -374,6 +405,7 @@ install_claude_code() {
 
   ok "Claude Code: $count agents -> $dest"
   ok "Claude Code: skill-builder + $fragment_count fragments -> $skills_dest"
+  ok "Claude Code: devcontainer bootstrap skill + $devcontainer_count files -> $devcontainer_dest"
 }
 
 install_copilot() {

--- a/skills/README.md
+++ b/skills/README.md
@@ -12,6 +12,8 @@ This directory is the starting point for the Superagents skills layer.
 
 - `skill-builder/`
   - Interactive builder skill that inventories a repo, asks a targeted questionnaire, and assembles project-specific skills.
+- `devcontainer-bootstrap/`
+  - Isolated Claude devcontainer bootstrap skill based on Anthropic reference assets, including user-level Superagents install hooks for containerized `--dangerously-skip-permissions` usage.
 - `fragments/task-intake/`
   - Work-entry fragments for direct-brief and other intake modes.
 - `fragments/project-management/`
@@ -59,7 +61,9 @@ Concrete generated-skill reference scenarios live in [`examples/generated-skills
 4. The builder assembles one primary skill and any needed companion skills under `.claude/skills/superagents/`, then writes reviewable builder metadata under `.agency/skills/superagents/`.
 5. The repo commits both generated roots together and treats repo-local generated output as authoritative over user-level defaults for that repository.
 
-User-level installation for the reusable fragment source bundle is now deterministic via `./scripts/install.sh --tool claude-code`:
+User-level installation for reusable Superagents skills is deterministic via `./scripts/install.sh --tool claude-code`:
 
 - `~/.claude/skills/superagents-skill-builder/SKILL.md`
 - `~/.claude/skills/superagents-skill-builder/fragments/**/*.md`
+- `~/.claude/skills/superagents-devcontainer-bootstrap/SKILL.md`
+- `~/.claude/skills/superagents-devcontainer-bootstrap/templates/*`

--- a/skills/devcontainer-bootstrap/SKILL.md
+++ b/skills/devcontainer-bootstrap/SKILL.md
@@ -1,0 +1,55 @@
+---
+name: superagents-devcontainer-bootstrap
+description: Scaffold an isolated Claude Code devcontainer from Anthropic's reference and install Superagents at user scope inside the container.
+disable-model-invocation: true
+argument-hint: "[optional-project-path]"
+---
+
+# Superagents Devcontainer Bootstrap
+
+Use this skill when a team needs to run Claude Code with `--dangerously-skip-permissions` in an isolated containerized environment.
+
+## Safety Boundary
+
+- Always use this only for trusted repositories.
+- Container isolation reduces host risk, but it does not prevent in-container credential exfiltration.
+- Never recommend host-level `--dangerously-skip-permissions` for normal workflows.
+
+## Inputs
+
+- Optional project path. If omitted, use the current working directory.
+- Optional env overrides:
+  - `ANTHROPIC_DEVCONTAINER_BASE_URL` (default: Anthropic reference `.devcontainer` on `main`)
+  - `SUPERAGENTS_REPO` (default: `https://github.com/peakweb-team/pw-agency-agents.git`)
+  - `SUPERAGENTS_REF` (default: `main`)
+
+## Workflow
+
+1. Resolve the target project path.
+2. Ensure a `.devcontainer/` directory exists in that project.
+3. Copy the template scripts from this skill bundle into the target `.devcontainer/` directory:
+   - `scaffold-devcontainer.sh`
+   - `post-create-superagents.sh`
+   - `smoke-test-superagents.sh`
+4. Run `scaffold-devcontainer.sh` from the project root.
+5. Confirm `.devcontainer/devcontainer.json` has `postCreateCommand` set to `.devcontainer/post-create-superagents.sh`.
+6. Ask the user to reopen the repository in the container.
+7. After container startup, run `.devcontainer/smoke-test-superagents.sh` in the container terminal.
+8. Summarize what was generated and any follow-up required.
+
+## Template Location
+
+After installation, this skill's templates are expected at:
+
+- `~/.claude/skills/superagents-devcontainer-bootstrap/templates/`
+
+## Success Criteria
+
+- `.devcontainer/` exists and is based on Anthropic's reference assets (`devcontainer.json`, `Dockerfile`, `init-firewall.sh`).
+- `postCreateCommand` installs Superagents with user-level scope inside the container.
+- Smoke test passes after container creation.
+
+## Reference
+
+- Anthropic devcontainer docs: `https://code.claude.com/docs/en/devcontainer`
+- Anthropic reference source: `https://github.com/anthropics/claude-code/tree/main/.devcontainer`

--- a/skills/devcontainer-bootstrap/templates/post-create-superagents.sh
+++ b/skills/devcontainer-bootstrap/templates/post-create-superagents.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SUPERAGENTS_REPO="${SUPERAGENTS_REPO:-https://github.com/peakweb-team/pw-agency-agents.git}"
+SUPERAGENTS_REF="${SUPERAGENTS_REF:-main}"
+WORKDIR="$(mktemp -d)"
+
+cleanup() {
+  rm -rf "$WORKDIR"
+}
+trap cleanup EXIT
+
+git clone --depth 1 --branch "$SUPERAGENTS_REF" "$SUPERAGENTS_REPO" "$WORKDIR/pw-agency-agents"
+"$WORKDIR/pw-agency-agents/scripts/install.sh" --tool claude-code --no-interactive
+
+echo "Superagents installed at user scope in ${HOME}/.claude"

--- a/skills/devcontainer-bootstrap/templates/scaffold-devcontainer.sh
+++ b/skills/devcontainer-bootstrap/templates/scaffold-devcontainer.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+TARGET_DIR="${1:-.devcontainer}"
+BASE_URL="${ANTHROPIC_DEVCONTAINER_BASE_URL:-https://raw.githubusercontent.com/anthropics/claude-code/main/.devcontainer}"
+
+mkdir -p "$TARGET_DIR"
+
+curl -fsSL "$BASE_URL/devcontainer.json" -o "$TARGET_DIR/devcontainer.json"
+curl -fsSL "$BASE_URL/Dockerfile" -o "$TARGET_DIR/Dockerfile"
+curl -fsSL "$BASE_URL/init-firewall.sh" -o "$TARGET_DIR/init-firewall.sh"
+chmod +x "$TARGET_DIR/init-firewall.sh"
+
+TEMPLATE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cp "$TEMPLATE_DIR/post-create-superagents.sh" "$TARGET_DIR/post-create-superagents.sh"
+cp "$TEMPLATE_DIR/smoke-test-superagents.sh" "$TARGET_DIR/smoke-test-superagents.sh"
+chmod +x "$TARGET_DIR/post-create-superagents.sh" "$TARGET_DIR/smoke-test-superagents.sh"
+
+node - "$TARGET_DIR/devcontainer.json" <<'NODE'
+const fs = require('fs');
+const file = process.argv[2];
+const doc = JSON.parse(fs.readFileSync(file, 'utf8'));
+doc.postCreateCommand = '.devcontainer/post-create-superagents.sh';
+fs.writeFileSync(file, `${JSON.stringify(doc, null, 2)}\n`);
+NODE
+
+echo "Scaffolded Anthropic-based devcontainer into $TARGET_DIR"
+echo "Next step: reopen this repository in container and run .devcontainer/smoke-test-superagents.sh"

--- a/skills/devcontainer-bootstrap/templates/smoke-test-superagents.sh
+++ b/skills/devcontainer-bootstrap/templates/smoke-test-superagents.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+test -f "${HOME}/.claude/skills/superagents-skill-builder/SKILL.md"
+test -f "${HOME}/.claude/skills/superagents-devcontainer-bootstrap/SKILL.md"
+test -f "${HOME}/.claude/skills/superagents-devcontainer-bootstrap/templates/scaffold-devcontainer.sh"
+command -v claude >/dev/null 2>&1
+
+echo "OK: Superagents user-level bundles are installed inside the container."
+echo "Optional: run 'claude --dangerously-skip-permissions' only for trusted repositories."


### PR DESCRIPTION
## Summary
- add a reusable `superagents-devcontainer-bootstrap` skill with templates to scaffold an Anthropic-based devcontainer
- add post-create install and smoke-test scripts so Superagents installs at user scope inside the container
- extend Claude installer packaging to ship the new skill bundle under `~/.claude/skills/`
- update docs and contracts for install paths, migration expectations, and the isolated workflow

## Validation
- `bash -n scripts/install.sh`
- `bash -n skills/devcontainer-bootstrap/templates/scaffold-devcontainer.sh`
- `bash -n skills/devcontainer-bootstrap/templates/post-create-superagents.sh`
- `bash -n skills/devcontainer-bootstrap/templates/smoke-test-superagents.sh`
- `HOME=/tmp/superagents-install-smoke ./scripts/install.sh --tool claude-code --no-interactive`

Closes #83


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added optional devcontainer bootstrap workflow enabling users to scaffold an isolated Claude Code devcontainer and install Superagents within the container environment.
  * Introduced new `superagents-devcontainer-bootstrap` skill with scaffolding and verification templates.

* **Documentation**
  * Updated guides to document the new devcontainer bootstrap workflow and additional installed skill paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->