### PR TITLE
Issue #86: add federated workspace manifest spec and validator

### DIFF
--- a/.github/workflows/runtime-policy.yml
+++ b/.github/workflows/runtime-policy.yml
@@ -1,0 +1,21 @@
+name: Runtime Policy
+
+on:
+  pull_request:
+    paths:
+      - "scripts/**"
+      - "tests/**"
+      - ".github/workflows/**"
+
+jobs:
+  enforce:
+    name: Enforce single non-shell runtime
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Check runtime policy
+        run: |
+          chmod +x scripts/enforce-single-runtime.sh
+          ./scripts/enforce-single-runtime.sh

--- a/.github/workflows/workspace-manifest-validation.yml
+++ b/.github/workflows/workspace-manifest-validation.yml
@@ -1,0 +1,25 @@
+name: Workspace Manifest Validation
+
+on:
+  pull_request:
+    paths:
+      - "docs/federated-workspace-manifest-spec.md"
+      - "docs/schemas/superagents.workspace.schema.json"
+      - "docs/examples/workspace-manifests/**"
+      - "scripts/validate-workspace-manifest.sh"
+      - "scripts/validate-workspace-manifest.rb"
+      - "tests/test-workspace-manifest-validation.sh"
+      - "tests/fixtures/workspace-manifests/**"
+
+jobs:
+  validate:
+    name: Validate workspace manifest contract
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Run workspace manifest validation tests
+        run: |
+          chmod +x scripts/validate-workspace-manifest.sh scripts/validate-workspace-manifest.rb tests/test-workspace-manifest-validation.sh
+          ./tests/test-workspace-manifest-validation.sh

--- a/README.md
+++ b/README.md
@@ -79,6 +79,20 @@ Supported install targets include:
 - `qwen`
 - `kimi`
 
+### 8. Federated Multi-Repo Workspace Manifest
+
+Superagents supports a federated workspace contract for coordinating multiple repositories across different language/toolchain stacks.
+
+- Spec: [docs/federated-workspace-manifest-spec.md](docs/federated-workspace-manifest-spec.md)
+- Schema: [docs/schemas/superagents.workspace.schema.json](docs/schemas/superagents.workspace.schema.json)
+- Example: [docs/examples/workspace-manifests/superagents.workspace.yaml](docs/examples/workspace-manifests/superagents.workspace.yaml)
+
+Validate a manifest:
+
+```bash
+./scripts/validate-workspace-manifest.sh superagents.workspace.yaml
+```
+
 ## How Superagents Relates To Superpowers
 
 ### What Is Shared
@@ -208,6 +222,7 @@ Use one worktree per issue/team stream to keep execution isolated.
 - [docs/install-packaging-skill-fragments-contract.md](docs/install-packaging-skill-fragments-contract.md)
 - [docs/runtime-context-budgeting-and-repo-reading.md](docs/runtime-context-budgeting-and-repo-reading.md)
 - [docs/isolated-devcontainer-bootstrap-workflow.md](docs/isolated-devcontainer-bootstrap-workflow.md)
+- [docs/federated-workspace-manifest-spec.md](docs/federated-workspace-manifest-spec.md)
 - [examples/generated-skills/README.md](examples/generated-skills/README.md)
 
 ## Other Integrations

--- a/README.md
+++ b/README.md
@@ -208,6 +208,16 @@ Use one worktree per issue/team stream to keep execution isolated.
 - `integrations/`: generated integration outputs for supported tools
 - `scripts/`: conversion/install scripts
 
+## Runtime Policy
+
+Automation scripts must use a single non-shell runtime across the repository (shell scripts are exempt).
+
+Validate locally:
+
+```bash
+./scripts/enforce-single-runtime.sh
+```
+
 ## Key Documents
 
 - [ROADMAP.md](ROADMAP.md)

--- a/docs/examples/workspace-manifests/superagents.workspace.yaml
+++ b/docs/examples/workspace-manifests/superagents.workspace.yaml
@@ -12,7 +12,7 @@ repos:
     build_system: foundry
     issue_backend:
       type: repo_issues
-      repo: peakweb-team/protocol-core
+      repo: example/protocol-core
     ownership:
       team: protocol
       owners:

--- a/docs/examples/workspace-manifests/superagents.workspace.yaml
+++ b/docs/examples/workspace-manifests/superagents.workspace.yaml
@@ -1,0 +1,70 @@
+schema_version: 1
+workspace_id: atlas-x
+
+description: Cross-language feature delivery for protocol, infra, and clients.
+repos:
+  - id: protocol-core
+    remote: git@github.com:example/protocol-core.git
+    default_branch: main
+    role: protocol
+    language: solidity
+    runtime: evm
+    build_system: foundry
+    issue_backend:
+      type: repo_issues
+      repo: peakweb-team/protocol-core
+    ownership:
+      team: protocol
+      owners:
+        - team-protocol
+    policy_refs:
+      - policy://solidity/foundry-v1
+
+  - id: infra-live
+    path: ../infra-live
+    default_branch: main
+    role: devops
+    language: hcl
+    runtime: terraform
+    build_system: terraform
+    issue_backend:
+      type: external_tracker
+      tracker: jira
+      mapping:
+        project_key: INFRA
+        board: platform
+    ownership:
+      team: platform
+      owners:
+        - team-platform
+    policy_refs:
+      - policy://terraform/plan-apply-gates
+
+  - id: web-console
+    remote: https://github.com/example/web-console.git
+    default_branch: develop
+    role: webapp
+    language: typescript
+    runtime: node20
+    build_system: pnpm-workspace
+    issue_backend:
+      type: github_project
+      project_id: PVT_kwDOABC1234
+    ownership:
+      team: web
+      owners:
+        - team-web
+
+  - id: mobile-wallet
+    remote: git@github.com:example/mobile-wallet.git
+    default_branch: main
+    role: mobile
+    language: kotlin
+    runtime: jvm
+    build_system: gradle
+    issue_backend:
+      type: none
+    ownership:
+      team: mobile
+      owners:
+        - team-mobile

--- a/docs/federated-workspace-manifest-spec.md
+++ b/docs/federated-workspace-manifest-spec.md
@@ -41,7 +41,7 @@ repos:
     build_system: foundry
     issue_backend:
       type: repo_issues
-      repo: peakweb-team/protocol-core
+      repo: example/protocol-core
     ownership:
       team: protocol
       owners:
@@ -106,7 +106,7 @@ The validator checks schema contract rules and reports actionable field-level er
 ```text
 Manifest validation failed for superagents.workspace.yaml:
   - $.workspace_id: must match ^[a-z0-9][a-z0-9_-]*$
-  - $.repos[0]: must define one of 'path' or 'remote'
+  - $.repos[0]: must define exactly one of 'path' or 'remote'
   - $.repos[1].issue_backend.project_id: missing required key 'project_id'
 ```
 

--- a/docs/federated-workspace-manifest-spec.md
+++ b/docs/federated-workspace-manifest-spec.md
@@ -1,0 +1,172 @@
+# Federated Workspace Manifest Specification
+
+This document defines the workspace manifest contract for issue `#86`:
+
+- [#86 Spec: Workspace Manifest For Federated Multi-Repo Projects](https://github.com/peakweb-team/pw-agency-agents/issues/86)
+
+The goal is to coordinate multiple repositories under one workspace-level control plane across different languages and build systems.
+
+This is explicitly **not** a Turborepo/Nx single-stack package-graph format.
+
+## Manifest File Name
+
+Workspace manifests should be stored at the workspace root as:
+
+- `superagents.workspace.yaml`
+
+## Schema
+
+The canonical JSON schema lives at:
+
+- `docs/schemas/superagents.workspace.schema.json`
+
+Current schema contract version:
+
+- `schema_version: 1`
+
+## Top-Level Shape
+
+```yaml
+schema_version: 1
+workspace_id: atlas-x
+# optional
+description: Cross-language federated delivery workspace
+repos:
+  - id: protocol-core
+    remote: git@github.com:example/protocol-core.git
+    default_branch: main
+    role: protocol
+    language: solidity
+    runtime: evm
+    build_system: foundry
+    issue_backend:
+      type: repo_issues
+      repo: peakweb-team/protocol-core
+    ownership:
+      team: protocol
+      owners:
+        - team-protocol
+    policy_refs:
+      - policy://solidity/foundry-v1
+```
+
+## Required Fields
+
+### Top-level
+
+- `schema_version` (integer): currently must equal `1`.
+- `workspace_id` (string): lowercase identifier matching `^[a-z0-9][a-z0-9_-]*$`.
+- `repos` (array): must include at least one repository entry.
+
+### Per-repo
+
+- `id` (string): repo identifier matching `^[a-z0-9][a-z0-9_-]*$`; must be unique within `repos`.
+- `path` or `remote` (string): exactly one must be provided.
+- `default_branch` (string): repo default branch.
+- `role` (string): role in the federated program (for example `protocol`, `devops`, `webapp`, `mobile`).
+- `build_system` (string): repo-native build/test toolchain (for example `foundry`, `terraform`, `pnpm-workspace`, `gradle`).
+- `issue_backend` (object): issue/project tracking mapping for the repo.
+
+### Optional Per-repo
+
+- `language` (string)
+- `runtime` (string)
+- `ownership.team` (string)
+- `ownership.owners` (string array)
+- `policy_refs` (string array)
+
+## Issue Backend Contract
+
+`issue_backend.type` is required and must be one of:
+
+- `repo_issues`
+- `github_project`
+- `external_tracker`
+- `none`
+
+Additional requirements by type:
+
+- `repo_issues`: requires `issue_backend.repo`
+- `github_project`: requires `issue_backend.project_id`
+- `external_tracker`: requires `issue_backend.tracker` and non-empty `issue_backend.mapping`
+- `none`: no additional required fields
+
+## Validation CLI
+
+Use the built-in validator:
+
+```bash
+./scripts/validate-workspace-manifest.sh superagents.workspace.yaml
+```
+
+The validator checks schema contract rules and reports actionable field-level errors.
+
+## Error Message Examples
+
+```text
+Manifest validation failed for superagents.workspace.yaml:
+  - $.workspace_id: must match ^[a-z0-9][a-z0-9_-]*$
+  - $.repos[0]: must define one of 'path' or 'remote'
+  - $.repos[1].issue_backend.project_id: missing required key 'project_id'
+```
+
+## Heterogeneous Examples
+
+Reference manifest examples are provided in:
+
+- `docs/examples/workspace-manifests/superagents.workspace.yaml`
+
+That example includes multiple repo types in one workspace:
+
+- Solidity protocol repo (`foundry`)
+- Terraform devops repo (`terraform`)
+- TypeScript web repo (`pnpm-workspace`)
+- Kotlin mobile repo (`gradle`)
+
+### Minimal Node + Python + Terraform Example
+
+```yaml
+schema_version: 1
+workspace_id: mercury
+repos:
+  - id: api
+    remote: git@github.com:example/api.git
+    default_branch: main
+    role: backend
+    language: python
+    runtime: python3.12
+    build_system: poetry
+    issue_backend:
+      type: repo_issues
+      repo: example/api
+
+  - id: app
+    remote: git@github.com:example/app.git
+    default_branch: main
+    role: webapp
+    language: typescript
+    runtime: node20
+    build_system: pnpm
+    issue_backend:
+      type: github_project
+      project_id: PVT_kwDOXYZ123
+
+  - id: infra
+    path: ../infra
+    default_branch: main
+    role: devops
+    language: hcl
+    runtime: terraform
+    build_system: terraform
+    issue_backend:
+      type: external_tracker
+      tracker: jira
+      mapping:
+        project_key: INFRA
+```
+
+## Backward Compatibility Notes
+
+- This is an additive, opt-in manifest contract.
+- Existing repo-local workflows can continue without a workspace manifest.
+- Future schema changes should increment `schema_version` and preserve v1 parsing behavior where practical.

--- a/docs/schemas/superagents.workspace.schema.json
+++ b/docs/schemas/superagents.workspace.schema.json
@@ -164,7 +164,139 @@
             "minLength": 1
           }
         }
-      }
+      },
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "repo_issues"
+              }
+            }
+          },
+          "then": {
+            "required": [
+              "repo"
+            ],
+            "not": {
+              "anyOf": [
+                {
+                  "required": [
+                    "project_id"
+                  ]
+                },
+                {
+                  "required": [
+                    "tracker"
+                  ]
+                },
+                {
+                  "required": [
+                    "mapping"
+                  ]
+                }
+              ]
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "github_project"
+              }
+            }
+          },
+          "then": {
+            "required": [
+              "project_id"
+            ],
+            "not": {
+              "anyOf": [
+                {
+                  "required": [
+                    "repo"
+                  ]
+                },
+                {
+                  "required": [
+                    "tracker"
+                  ]
+                },
+                {
+                  "required": [
+                    "mapping"
+                  ]
+                }
+              ]
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "external_tracker"
+              }
+            }
+          },
+          "then": {
+            "required": [
+              "tracker",
+              "mapping"
+            ],
+            "not": {
+              "anyOf": [
+                {
+                  "required": [
+                    "repo"
+                  ]
+                },
+                {
+                  "required": [
+                    "project_id"
+                  ]
+                }
+              ]
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "none"
+              }
+            }
+          },
+          "then": {
+            "not": {
+              "anyOf": [
+                {
+                  "required": [
+                    "repo"
+                  ]
+                },
+                {
+                  "required": [
+                    "project_id"
+                  ]
+                },
+                {
+                  "required": [
+                    "tracker"
+                  ]
+                },
+                {
+                  "required": [
+                    "mapping"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      ]
     }
   }
 }

--- a/docs/schemas/superagents.workspace.schema.json
+++ b/docs/schemas/superagents.workspace.schema.json
@@ -1,0 +1,170 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/peakweb-team/pw-agency-agents/docs/schemas/superagents.workspace.schema.json",
+  "title": "Superagents Federated Workspace Manifest",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "workspace_id",
+    "repos"
+  ],
+  "properties": {
+    "schema_version": {
+      "type": "integer",
+      "const": 1
+    },
+    "workspace_id": {
+      "type": "string",
+      "pattern": "^[a-z0-9][a-z0-9_-]*$"
+    },
+    "description": {
+      "type": "string",
+      "minLength": 1
+    },
+    "repos": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/$defs/repo"
+      }
+    }
+  },
+  "$defs": {
+    "repo": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "default_branch",
+        "role",
+        "build_system",
+        "issue_backend"
+      ],
+      "properties": {
+        "id": {
+          "type": "string",
+          "pattern": "^[a-z0-9][a-z0-9_-]*$"
+        },
+        "path": {
+          "type": "string",
+          "minLength": 1
+        },
+        "remote": {
+          "type": "string",
+          "minLength": 1
+        },
+        "default_branch": {
+          "type": "string",
+          "minLength": 1
+        },
+        "role": {
+          "type": "string",
+          "minLength": 1
+        },
+        "language": {
+          "type": "string",
+          "minLength": 1
+        },
+        "runtime": {
+          "type": "string",
+          "minLength": 1
+        },
+        "build_system": {
+          "type": "string",
+          "minLength": 1
+        },
+        "issue_backend": {
+          "$ref": "#/$defs/issue_backend"
+        },
+        "ownership": {
+          "$ref": "#/$defs/ownership"
+        },
+        "policy_refs": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        }
+      },
+      "oneOf": [
+        {
+          "required": [
+            "path"
+          ],
+          "not": {
+            "required": [
+              "remote"
+            ]
+          }
+        },
+        {
+          "required": [
+            "remote"
+          ],
+          "not": {
+            "required": [
+              "path"
+            ]
+          }
+        }
+      ]
+    },
+    "ownership": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "team": {
+          "type": "string",
+          "minLength": 1
+        },
+        "owners": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        }
+      }
+    },
+    "issue_backend": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "type"
+      ],
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "repo_issues",
+            "github_project",
+            "external_tracker",
+            "none"
+          ]
+        },
+        "repo": {
+          "type": "string",
+          "minLength": 1
+        },
+        "project_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "tracker": {
+          "type": "string",
+          "minLength": 1
+        },
+        "mapping": {
+          "type": "object",
+          "minProperties": 1,
+          "additionalProperties": {
+            "type": "string",
+            "minLength": 1
+          }
+        }
+      }
+    }
+  }
+}

--- a/scripts/enforce-single-runtime.sh
+++ b/scripts/enforce-single-runtime.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Enforce a single non-shell scripting runtime for tracked shebang scripts.
+# Shell scripts (bash/sh/zsh) are excluded from runtime counting.
+
+if ! command -v git >/dev/null 2>&1; then
+  echo "ERROR: git is required to evaluate tracked files." >&2
+  exit 1
+fi
+
+normalize_interpreter() {
+  local shebang="$1"
+  local trimmed interpreter
+
+  trimmed="${shebang#\#!}"
+  trimmed="${trimmed#${trimmed%%[![:space:]]*}}"
+
+  if [[ "$trimmed" == /usr/bin/env* ]]; then
+    interpreter="${trimmed#/usr/bin/env}"
+    interpreter="${interpreter#${interpreter%%[![:space:]]*}}"
+    interpreter="${interpreter%% *}"
+  else
+    interpreter="${trimmed%% *}"
+    interpreter="${interpreter##*/}"
+  fi
+
+  case "$interpreter" in
+    python3*|python2*|python)
+      echo "python"
+      ;;
+    nodejs|node)
+      echo "node"
+      ;;
+    ruby)
+      echo "ruby"
+      ;;
+    perl)
+      echo "perl"
+      ;;
+    php)
+      echo "php"
+      ;;
+    lua)
+      echo "lua"
+      ;;
+    bash|sh|zsh)
+      echo "shell"
+      ;;
+    *)
+      echo "$interpreter"
+      ;;
+  esac
+}
+
+runtime_names=()
+runtime_paths=()
+
+runtime_index() {
+  local target="$1"
+  local i
+  for ((i = 0; i < ${#runtime_names[@]}; i += 1)); do
+    if [[ "${runtime_names[$i]}" == "$target" ]]; then
+      echo "$i"
+      return 0
+    fi
+  done
+  echo "-1"
+}
+
+while IFS= read -r file; do
+  [[ -f "$file" ]] || continue
+
+  if ! IFS= read -r first_line < "$file"; then
+    continue
+  fi
+
+  [[ "$first_line" == \#!* ]] || continue
+
+  interpreter="$(normalize_interpreter "$first_line")"
+  if [[ "$interpreter" == "shell" || -z "$interpreter" ]]; then
+    continue
+  fi
+
+  index="$(runtime_index "$interpreter")"
+  if [[ "$index" != "-1" ]]; then
+    runtime_paths[$index]="${runtime_paths[$index]}\n$file"
+  else
+    runtime_names+=("$interpreter")
+    runtime_paths+=("$file")
+  fi
+done < <(git ls-files)
+
+runtime_count="${#runtime_names[@]}"
+if [[ "$runtime_count" -gt 1 ]]; then
+  echo "ERROR: Multiple non-shell runtimes detected in shebang scripts." >&2
+  echo "Only one non-shell runtime is allowed (shell scripts are exempt)." >&2
+  for ((i = 0; i < runtime_count; i += 1)); do
+    runtime="${runtime_names[$i]}"
+    echo "- Runtime '$runtime' used by:" >&2
+    while IFS= read -r path; do
+      [[ -n "$path" ]] && echo "  - $path" >&2
+    done <<< "$(printf '%b' "${runtime_paths[$i]}")"
+  done
+  exit 1
+fi
+
+if [[ "$runtime_count" -eq 1 ]]; then
+  for runtime in "${runtime_names[@]}"; do
+    echo "Runtime policy OK: single non-shell runtime is '$runtime'."
+  done
+else
+  echo "Runtime policy OK: no non-shell runtime scripts detected."
+fi

--- a/scripts/validate-workspace-manifest.rb
+++ b/scripts/validate-workspace-manifest.rb
@@ -1,0 +1,323 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require 'json'
+require 'pathname'
+require 'psych'
+
+SCHEMA_PATH = Pathname.new(__dir__).join('../docs/schemas/superagents.workspace.schema.json').expand_path
+REPO_ID_REGEX = /\A[a-z0-9][a-z0-9_-]*\z/
+KNOWN_TOP_LEVEL_KEYS = %w[schema_version workspace_id description repos].freeze
+KNOWN_REPO_KEYS = %w[id path remote default_branch role language runtime build_system issue_backend ownership policy_refs].freeze
+KNOWN_ISSUE_BACKEND_KEYS = %w[type repo project_id tracker mapping].freeze
+KNOWN_OWNERSHIP_KEYS = %w[team owners].freeze
+ISSUE_BACKEND_TYPES = %w[repo_issues github_project external_tracker none].freeze
+
+class ValidationError < StandardError; end
+
+class ManifestValidator
+  def initialize(data)
+    @data = data
+    @errors = []
+  end
+
+  attr_reader :errors
+
+  def validate
+    validate_root
+    errors.empty?
+  end
+
+  private
+
+  def validate_root
+    unless @data.is_a?(Hash)
+      add_error('$', 'must be a YAML object')
+      return
+    end
+
+    require_key(@data, '$', 'schema_version')
+    require_key(@data, '$', 'workspace_id')
+    require_key(@data, '$', 'repos')
+
+    unknown_top_level = @data.keys - KNOWN_TOP_LEVEL_KEYS
+    unknown_top_level.each do |key|
+      add_error("$.#{key}", 'is not allowed by schema')
+    end
+
+    validate_schema_version(@data['schema_version'])
+    validate_workspace_id(@data['workspace_id'])
+    validate_description(@data['description']) if @data.key?('description')
+    validate_repos(@data['repos'])
+  end
+
+  def validate_schema_version(value)
+    add_error('$.schema_version', 'must be an integer') unless value.is_a?(Integer)
+    add_error('$.schema_version', 'must equal 1 for this schema') unless value == 1
+  end
+
+  def validate_workspace_id(value)
+    unless value.is_a?(String) && !value.strip.empty?
+      add_error('$.workspace_id', 'must be a non-empty string')
+      return
+    end
+
+    return if value.match?(REPO_ID_REGEX)
+
+    add_error('$.workspace_id', 'must match ^[a-z0-9][a-z0-9_-]*$')
+  end
+
+  def validate_description(value)
+    return if value.is_a?(String) && !value.strip.empty?
+
+    add_error('$.description', 'must be a non-empty string when provided')
+  end
+
+  def validate_repos(repos)
+    unless repos.is_a?(Array)
+      add_error('$.repos', 'must be an array')
+      return
+    end
+
+    if repos.empty?
+      add_error('$.repos', 'must contain at least one repository entry')
+      return
+    end
+
+    repo_ids = {}
+    repos.each_with_index do |repo, index|
+      pointer = "$.repos[#{index}]"
+      validate_repo(repo, pointer)
+
+      next unless repo.is_a?(Hash) && repo['id'].is_a?(String)
+
+      if repo_ids.key?(repo['id'])
+        add_error("#{pointer}.id", "duplicates repository id '#{repo['id']}' used at $.repos[#{repo_ids[repo['id']]}].id")
+      else
+        repo_ids[repo['id']] = index
+      end
+    end
+  end
+
+  def validate_repo(repo, pointer)
+    unless repo.is_a?(Hash)
+      add_error(pointer, 'must be an object')
+      return
+    end
+
+    %w[id default_branch role build_system issue_backend].each do |key|
+      require_key(repo, pointer, key)
+    end
+
+    unknown_repo_keys = repo.keys - KNOWN_REPO_KEYS
+    unknown_repo_keys.each do |key|
+      add_error("#{pointer}.#{key}", 'is not allowed by schema')
+    end
+
+    validate_repo_id(repo['id'], pointer)
+    validate_repo_location(repo, pointer)
+    validate_non_empty_string(repo['default_branch'], "#{pointer}.default_branch")
+    validate_non_empty_string(repo['role'], "#{pointer}.role")
+    validate_non_empty_string(repo['build_system'], "#{pointer}.build_system")
+    validate_non_empty_string(repo['language'], "#{pointer}.language") if repo.key?('language')
+    validate_non_empty_string(repo['runtime'], "#{pointer}.runtime") if repo.key?('runtime')
+    validate_issue_backend(repo['issue_backend'], "#{pointer}.issue_backend")
+    validate_ownership(repo['ownership'], "#{pointer}.ownership") if repo.key?('ownership')
+    validate_policy_refs(repo['policy_refs'], "#{pointer}.policy_refs") if repo.key?('policy_refs')
+  end
+
+  def validate_repo_id(value, pointer)
+    unless value.is_a?(String) && !value.strip.empty?
+      add_error("#{pointer}.id", 'must be a non-empty string')
+      return
+    end
+
+    return if value.match?(REPO_ID_REGEX)
+
+    add_error("#{pointer}.id", 'must match ^[a-z0-9][a-z0-9_-]*$')
+  end
+
+  def validate_repo_location(repo, pointer)
+    has_path = repo.key?('path')
+    has_remote = repo.key?('remote')
+
+    if has_path && has_remote
+      add_error(pointer, "must define exactly one of 'path' or 'remote' (not both)")
+      return
+    end
+
+    unless has_path || has_remote
+      add_error(pointer, "must define one of 'path' or 'remote'")
+      return
+    end
+
+    validate_non_empty_string(repo['path'], "#{pointer}.path") if has_path
+    validate_non_empty_string(repo['remote'], "#{pointer}.remote") if has_remote
+  end
+
+  def validate_issue_backend(backend, pointer)
+    unless backend.is_a?(Hash)
+      add_error(pointer, 'must be an object')
+      return
+    end
+
+    require_key(backend, pointer, 'type')
+
+    unknown_keys = backend.keys - KNOWN_ISSUE_BACKEND_KEYS
+    unknown_keys.each do |key|
+      add_error("#{pointer}.#{key}", 'is not allowed by schema')
+    end
+
+    type = backend['type']
+    unless type.is_a?(String) && ISSUE_BACKEND_TYPES.include?(type)
+      add_error("#{pointer}.type", "must be one of: #{ISSUE_BACKEND_TYPES.join(', ')}")
+      return
+    end
+
+    case type
+    when 'repo_issues'
+      require_non_empty_string(backend, pointer, 'repo')
+    when 'github_project'
+      require_non_empty_string(backend, pointer, 'project_id')
+    when 'external_tracker'
+      require_non_empty_string(backend, pointer, 'tracker')
+      validate_mapping(backend['mapping'], "#{pointer}.mapping")
+    end
+  end
+
+  def validate_mapping(mapping, pointer)
+    unless mapping.is_a?(Hash)
+      add_error(pointer, 'must be an object for external_tracker backends')
+      return
+    end
+
+    if mapping.empty?
+      add_error(pointer, 'must include at least one mapping entry')
+      return
+    end
+
+    mapping.each do |key, value|
+      add_error(pointer, "contains non-string key #{key.inspect}") unless key.is_a?(String)
+      validate_non_empty_string(value, "#{pointer}.#{key}")
+    end
+  end
+
+  def validate_ownership(ownership, pointer)
+    unless ownership.is_a?(Hash)
+      add_error(pointer, 'must be an object')
+      return
+    end
+
+    unknown_keys = ownership.keys - KNOWN_OWNERSHIP_KEYS
+    unknown_keys.each do |key|
+      add_error("#{pointer}.#{key}", 'is not allowed by schema')
+    end
+
+    if ownership.key?('team')
+      validate_non_empty_string(ownership['team'], "#{pointer}.team")
+    end
+
+    if ownership.key?('owners')
+      owners = ownership['owners']
+      unless owners.is_a?(Array)
+        add_error("#{pointer}.owners", 'must be an array of owner identifiers')
+        return
+      end
+
+      if owners.empty?
+        add_error("#{pointer}.owners", 'must not be empty when provided')
+        return
+      end
+
+      owners.each_with_index do |owner, index|
+        validate_non_empty_string(owner, "#{pointer}.owners[#{index}]")
+      end
+    end
+  end
+
+  def validate_policy_refs(policy_refs, pointer)
+    unless policy_refs.is_a?(Array)
+      add_error(pointer, 'must be an array')
+      return
+    end
+
+    policy_refs.each_with_index do |ref, index|
+      validate_non_empty_string(ref, "#{pointer}[#{index}]")
+    end
+  end
+
+  def validate_non_empty_string(value, pointer)
+    add_error(pointer, 'must be a non-empty string') unless value.is_a?(String) && !value.strip.empty?
+  end
+
+  def require_non_empty_string(hash, pointer, key)
+    require_key(hash, pointer, key)
+    validate_non_empty_string(hash[key], "#{pointer}.#{key}") if hash.key?(key)
+  end
+
+  def require_key(hash, pointer, key)
+    add_error(pointer, "missing required key '#{key}'") unless hash.key?(key)
+  end
+
+  def add_error(pointer, message)
+    @errors << "#{pointer}: #{message}"
+  end
+end
+
+def load_schema
+  raise ValidationError, "Schema file not found at #{SCHEMA_PATH}" unless SCHEMA_PATH.file?
+
+  JSON.parse(SCHEMA_PATH.read)
+rescue JSON::ParserError => e
+  raise ValidationError, "Schema file is not valid JSON: #{e.message}"
+end
+
+def load_manifest(manifest_path)
+  raise ValidationError, "Manifest file not found: #{manifest_path}" unless File.file?(manifest_path)
+
+  raw = File.read(manifest_path)
+  data = Psych.safe_load(raw, permitted_classes: [], permitted_symbols: [], aliases: false)
+  return data
+rescue Psych::SyntaxError => e
+  raise ValidationError, "Manifest YAML parse error: #{e.message.lines.first.strip}"
+end
+
+def schema_guardrails!(schema)
+  schema_version = schema.dig('properties', 'schema_version', 'const')
+  unless schema_version == 1
+    raise ValidationError, "Unsupported schema constant in #{SCHEMA_PATH}: expected schema_version const 1, found #{schema_version.inspect}"
+  end
+end
+
+def validate_manifest(path)
+  schema = load_schema
+  schema_guardrails!(schema)
+
+  manifest_data = load_manifest(path)
+  validator = ManifestValidator.new(manifest_data)
+
+  if validator.validate
+    puts "Manifest is valid: #{path}"
+    return 0
+  end
+
+  warn "Manifest validation failed for #{path}:"
+  validator.errors.each { |error| warn "  - #{error}" }
+  1
+rescue ValidationError => e
+  warn "Manifest validation failed for #{path}: #{e.message}"
+  1
+end
+
+if ARGV.empty?
+  warn 'Usage: scripts/validate-workspace-manifest.rb <manifest-path> [manifest-path...]'
+  exit 2
+end
+
+exit_code = 0
+ARGV.each do |manifest_path|
+  result = validate_manifest(manifest_path)
+  exit_code = 1 if result != 0
+end
+
+exit exit_code

--- a/scripts/validate-workspace-manifest.rb
+++ b/scripts/validate-workspace-manifest.rb
@@ -15,6 +15,178 @@ ISSUE_BACKEND_TYPES = %w[repo_issues github_project external_tracker none].freez
 
 class ValidationError < StandardError; end
 
+# Minimal schema evaluator for the subset of JSON Schema keywords used by this repo contract.
+class SimpleJsonSchemaValidator
+  def initialize(root_schema)
+    @root_schema = root_schema
+  end
+
+  def validate(data)
+    validate_node(@root_schema, data, '$')
+  end
+
+  private
+
+  def validate_node(schema, value, pointer)
+    schema = resolve_ref_schema(schema)
+    errors = []
+
+    if schema.key?('allOf')
+      schema['allOf'].each do |subschema|
+        errors.concat(validate_node(subschema, value, pointer))
+      end
+    end
+
+    if schema.key?('if')
+      if matches_subschema?(schema['if'], value)
+        errors.concat(validate_node(schema['then'], value, pointer)) if schema.key?('then')
+      elsif schema.key?('else')
+        errors.concat(validate_node(schema['else'], value, pointer))
+      end
+    end
+
+    if schema.key?('oneOf')
+      matches = schema['oneOf'].count { |subschema| matches_subschema?(subschema, value) }
+      errors << "#{pointer}: must match exactly one of the oneOf schema branches" unless matches == 1
+    end
+
+    if schema.key?('anyOf')
+      matches = schema['anyOf'].count { |subschema| matches_subschema?(subschema, value) }
+      errors << "#{pointer}: must match at least one of the anyOf schema branches" if matches.zero?
+    end
+
+    if schema.key?('not') && matches_subschema?(schema['not'], value)
+      errors << "#{pointer}: violates a forbidden schema condition"
+    end
+
+    if schema.key?('const') && value != schema['const']
+      errors << "#{pointer}: must equal #{schema['const'].inspect}"
+    end
+
+    if schema.key?('enum') && !schema['enum'].include?(value)
+      errors << "#{pointer}: must be one of #{schema['enum'].join(', ')}"
+    end
+
+    if schema.key?('type')
+      unless type_matches?(schema['type'], value)
+        errors << "#{pointer}: must be of type #{schema['type']}"
+        return errors
+      end
+    end
+
+    if value.is_a?(Hash)
+      errors.concat(validate_object_schema(schema, value, pointer))
+    elsif value.is_a?(Array)
+      errors.concat(validate_array_schema(schema, value, pointer))
+    elsif value.is_a?(String)
+      errors.concat(validate_string_schema(schema, value, pointer))
+    end
+
+    errors
+  end
+
+  def validate_object_schema(schema, value, pointer)
+    errors = []
+
+    if schema.key?('required')
+      schema['required'].each do |key|
+        errors << "#{pointer}: missing required key '#{key}'" unless value.key?(key)
+      end
+    end
+
+    if schema.key?('minProperties') && value.size < schema['minProperties']
+      errors << "#{pointer}: must contain at least #{schema['minProperties']} properties"
+    end
+
+    properties = schema['properties'] || {}
+    value.each do |key, nested_value|
+      child_pointer = "#{pointer}.#{key}"
+      if properties.key?(key)
+        errors.concat(validate_node(properties[key], nested_value, child_pointer))
+      elsif schema['additionalProperties'] == false
+        errors << "#{child_pointer}: is not allowed by schema"
+      elsif schema['additionalProperties'].is_a?(Hash)
+        errors.concat(validate_node(schema['additionalProperties'], nested_value, child_pointer))
+      end
+    end
+
+    errors
+  end
+
+  def validate_array_schema(schema, value, pointer)
+    errors = []
+
+    if schema.key?('minItems') && value.length < schema['minItems']
+      errors << "#{pointer}: must contain at least #{schema['minItems']} items"
+    end
+
+    if schema.key?('items')
+      value.each_with_index do |item, index|
+        errors.concat(validate_node(schema['items'], item, "#{pointer}[#{index}]"))
+      end
+    end
+
+    errors
+  end
+
+  def validate_string_schema(schema, value, pointer)
+    errors = []
+
+    if schema.key?('minLength') && value.length < schema['minLength']
+      errors << "#{pointer}: must be at least #{schema['minLength']} characters"
+    end
+
+    if schema.key?('pattern')
+      begin
+        regex = Regexp.new(schema['pattern'])
+        errors << "#{pointer}: must match #{schema['pattern']}" unless regex.match?(value)
+      rescue RegexpError
+        errors << "#{pointer}: invalid pattern in schema"
+      end
+    end
+
+    errors
+  end
+
+  def matches_subschema?(schema, value)
+    validate_node(schema, value, '$probe').empty?
+  end
+
+  def resolve_ref_schema(schema)
+    return schema unless schema.is_a?(Hash)
+    return schema unless schema.key?('$ref')
+
+    resolve_ref(schema['$ref'])
+  end
+
+  def resolve_ref(ref)
+    raise ValidationError, "Unsupported non-local schema reference: #{ref}" unless ref.start_with?('#/')
+
+    pointer_parts = ref[2..].split('/').map { |part| part.gsub('~1', '/').gsub('~0', '~') }
+    resolved = pointer_parts.reduce(@root_schema) do |memo, part|
+      memo.is_a?(Hash) ? memo[part] : nil
+    end
+
+    raise ValidationError, "Unable to resolve schema reference: #{ref}" if resolved.nil?
+
+    resolved
+  end
+
+  def type_matches?(type_name, value)
+    case type_name
+    when 'object' then value.is_a?(Hash)
+    when 'array' then value.is_a?(Array)
+    when 'string' then value.is_a?(String)
+    when 'integer' then value.is_a?(Integer)
+    when 'number' then value.is_a?(Numeric)
+    when 'boolean' then value == true || value == false
+    when 'null' then value.nil?
+    else
+      true
+    end
+  end
+end
+
 class ManifestValidator
   def initialize(data)
     @data = data
@@ -147,7 +319,7 @@ class ManifestValidator
     end
 
     unless has_path || has_remote
-      add_error(pointer, "must define one of 'path' or 'remote'")
+      add_error(pointer, "must define exactly one of 'path' or 'remote'")
       return
     end
 
@@ -172,6 +344,19 @@ class ManifestValidator
     unless type.is_a?(String) && ISSUE_BACKEND_TYPES.include?(type)
       add_error("#{pointer}.type", "must be one of: #{ISSUE_BACKEND_TYPES.join(', ')}")
       return
+    end
+
+    allowed_keys = case type
+                   when 'repo_issues' then %w[type repo]
+                   when 'github_project' then %w[type project_id]
+                   when 'external_tracker' then %w[type tracker mapping]
+                   when 'none' then %w[type]
+                   else KNOWN_ISSUE_BACKEND_KEYS
+                   end
+
+    incompatible_keys = backend.keys - allowed_keys
+    incompatible_keys.each do |key|
+      add_error("#{pointer}.#{key}", "is not allowed for type '#{type}'")
     end
 
     case type
@@ -291,18 +476,21 @@ end
 
 def validate_manifest(path)
   schema = load_schema
+  manifest_data = load_manifest(path)
   schema_guardrails!(schema)
 
-  manifest_data = load_manifest(path)
-  validator = ManifestValidator.new(manifest_data)
+  schema_errors = SimpleJsonSchemaValidator.new(schema).validate(manifest_data)
+  custom_validator = ManifestValidator.new(manifest_data)
+  custom_valid = custom_validator.validate
 
-  if validator.validate
+  if schema_errors.empty? && custom_valid
     puts "Manifest is valid: #{path}"
     return 0
   end
 
   warn "Manifest validation failed for #{path}:"
-  validator.errors.each { |error| warn "  - #{error}" }
+  schema_errors.each { |error| warn "  - #{error}" }
+  custom_validator.errors.each { |error| warn "  - #{error}" }
   1
 rescue ValidationError => e
   warn "Manifest validation failed for #{path}: #{e.message}"

--- a/scripts/validate-workspace-manifest.sh
+++ b/scripts/validate-workspace-manifest.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+if [[ $# -lt 1 ]]; then
+  echo "Usage: ./scripts/validate-workspace-manifest.sh <manifest-path> [manifest-path...]" >&2
+  exit 2
+fi
+
+ruby "$SCRIPT_DIR/validate-workspace-manifest.rb" "$@"

--- a/tests/fixtures/workspace-manifests/invalid/duplicate-repo-id.yaml
+++ b/tests/fixtures/workspace-manifests/invalid/duplicate-repo-id.yaml
@@ -1,0 +1,18 @@
+schema_version: 1
+workspace_id: atlas
+repos:
+  - id: shared
+    path: ../protocol
+    default_branch: main
+    role: protocol
+    build_system: foundry
+    issue_backend:
+      type: none
+
+  - id: shared
+    remote: git@github.com:example/web.git
+    default_branch: main
+    role: webapp
+    build_system: pnpm
+    issue_backend:
+      type: none

--- a/tests/fixtures/workspace-manifests/invalid/invalid-issue-backend.yaml
+++ b/tests/fixtures/workspace-manifests/invalid/invalid-issue-backend.yaml
@@ -1,13 +1,12 @@
-schema_version: 2
+schema_version: 1
 workspace_id: atlas
 repos:
   - id: infra
     path: ../infra
-    remote: git@github.com:example/infra.git
     default_branch: main
     role: devops
     build_system: terraform
     issue_backend:
       type: external_tracker
       tracker: jira
-      mapping: {}
+      repo: example/infra

--- a/tests/fixtures/workspace-manifests/invalid/invalid-issue-backend.yaml
+++ b/tests/fixtures/workspace-manifests/invalid/invalid-issue-backend.yaml
@@ -1,0 +1,13 @@
+schema_version: 2
+workspace_id: atlas
+repos:
+  - id: infra
+    path: ../infra
+    remote: git@github.com:example/infra.git
+    default_branch: main
+    role: devops
+    build_system: terraform
+    issue_backend:
+      type: external_tracker
+      tracker: jira
+      mapping: {}

--- a/tests/fixtures/workspace-manifests/invalid/missing-required-fields.yaml
+++ b/tests/fixtures/workspace-manifests/invalid/missing-required-fields.yaml
@@ -1,5 +1,5 @@
 schema_version: 1
-workspace_id: Bad Workspace
+workspace_id: bad-workspace
 repos:
   - id: protocol-core
     default_branch: main

--- a/tests/fixtures/workspace-manifests/invalid/missing-required-fields.yaml
+++ b/tests/fixtures/workspace-manifests/invalid/missing-required-fields.yaml
@@ -1,0 +1,9 @@
+schema_version: 1
+workspace_id: Bad Workspace
+repos:
+  - id: protocol-core
+    default_branch: main
+    role: protocol
+    build_system: foundry
+    issue_backend:
+      type: repo_issues

--- a/tests/fixtures/workspace-manifests/valid/federated-triple-stack.yaml
+++ b/tests/fixtures/workspace-manifests/valid/federated-triple-stack.yaml
@@ -12,7 +12,7 @@ repos:
     build_system: foundry
     issue_backend:
       type: repo_issues
-      repo: peakweb-team/protocol-core
+      repo: example/protocol-core
     ownership:
       team: protocol
       owners:

--- a/tests/fixtures/workspace-manifests/valid/federated-triple-stack.yaml
+++ b/tests/fixtures/workspace-manifests/valid/federated-triple-stack.yaml
@@ -1,0 +1,70 @@
+schema_version: 1
+workspace_id: atlas-x
+
+description: Cross-language feature delivery for protocol, infra, and clients.
+repos:
+  - id: protocol-core
+    remote: git@github.com:example/protocol-core.git
+    default_branch: main
+    role: protocol
+    language: solidity
+    runtime: evm
+    build_system: foundry
+    issue_backend:
+      type: repo_issues
+      repo: peakweb-team/protocol-core
+    ownership:
+      team: protocol
+      owners:
+        - team-protocol
+    policy_refs:
+      - policy://solidity/foundry-v1
+
+  - id: infra-live
+    path: ../infra-live
+    default_branch: main
+    role: devops
+    language: hcl
+    runtime: terraform
+    build_system: terraform
+    issue_backend:
+      type: external_tracker
+      tracker: jira
+      mapping:
+        project_key: INFRA
+        board: platform
+    ownership:
+      team: platform
+      owners:
+        - team-platform
+    policy_refs:
+      - policy://terraform/plan-apply-gates
+
+  - id: web-console
+    remote: https://github.com/example/web-console.git
+    default_branch: develop
+    role: webapp
+    language: typescript
+    runtime: node20
+    build_system: pnpm-workspace
+    issue_backend:
+      type: github_project
+      project_id: PVT_kwDOABC1234
+    ownership:
+      team: web
+      owners:
+        - team-web
+
+  - id: mobile-wallet
+    remote: git@github.com:example/mobile-wallet.git
+    default_branch: main
+    role: mobile
+    language: kotlin
+    runtime: jvm
+    build_system: gradle
+    issue_backend:
+      type: none
+    ownership:
+      team: mobile
+      owners:
+        - team-mobile

--- a/tests/test-workspace-manifest-validation.sh
+++ b/tests/test-workspace-manifest-validation.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 set -euo pipefail
+shopt -s nullglob
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 VALIDATOR="$ROOT_DIR/scripts/validate-workspace-manifest.sh"
@@ -31,11 +32,24 @@ run_expect_fail() {
   fi
 }
 
-for file in "$VALID_DIR"/*.yaml; do
+valid_files=("$VALID_DIR"/*.yaml)
+invalid_files=("$INVALID_DIR"/*.yaml)
+
+if [[ ${#valid_files[@]} -eq 0 ]]; then
+  echo "Missing workspace manifest validation fixtures in $VALID_DIR"
+  exit 1
+fi
+
+if [[ ${#invalid_files[@]} -eq 0 ]]; then
+  echo "Missing workspace manifest validation fixtures in $INVALID_DIR"
+  exit 1
+fi
+
+for file in "${valid_files[@]}"; do
   run_expect_pass "$file"
 done
 
-for file in "$INVALID_DIR"/*.yaml; do
+for file in "${invalid_files[@]}"; do
   run_expect_fail "$file"
 done
 

--- a/tests/test-workspace-manifest-validation.sh
+++ b/tests/test-workspace-manifest-validation.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+VALIDATOR="$ROOT_DIR/scripts/validate-workspace-manifest.sh"
+VALID_DIR="$ROOT_DIR/tests/fixtures/workspace-manifests/valid"
+INVALID_DIR="$ROOT_DIR/tests/fixtures/workspace-manifests/invalid"
+
+pass_count=0
+fail_count=0
+
+run_expect_pass() {
+  local file="$1"
+  if "$VALIDATOR" "$file" >/dev/null 2>&1; then
+    echo "PASS(valid): $file"
+    pass_count=$((pass_count + 1))
+  else
+    echo "FAIL(valid): $file"
+    fail_count=$((fail_count + 1))
+  fi
+}
+
+run_expect_fail() {
+  local file="$1"
+  if "$VALIDATOR" "$file" >/dev/null 2>&1; then
+    echo "FAIL(invalid accepted): $file"
+    fail_count=$((fail_count + 1))
+  else
+    echo "PASS(invalid rejected): $file"
+    pass_count=$((pass_count + 1))
+  fi
+}
+
+for file in "$VALID_DIR"/*.yaml; do
+  run_expect_pass "$file"
+done
+
+for file in "$INVALID_DIR"/*.yaml; do
+  run_expect_fail "$file"
+done
+
+echo "Workspace manifest validation tests: ${pass_count} passed, ${fail_count} failed"
+
+if [[ $fail_count -ne 0 ]]; then
+  exit 1
+fi


### PR DESCRIPTION
## Summary
- adds a new federated workspace manifest spec at `docs/federated-workspace-manifest-spec.md` with `superagents.workspace.yaml` contract details
- adds JSON schema at `docs/schemas/superagents.workspace.schema.json` (schema version `1`)
- adds CLI validator (`scripts/validate-workspace-manifest.sh` + `scripts/validate-workspace-manifest.rb`) with actionable field-path errors
- adds heterogeneous manifest example (`docs/examples/workspace-manifests/superagents.workspace.yaml`) spanning Solidity/Foundry, Terraform, TypeScript/pnpm, and Kotlin/Gradle
- adds validation fixtures/tests and CI workflow for manifest contract checks

## Why this first
This is the smallest-risk slice for Epic #85 because it locks data contracts before orchestration/runtime/integration behavior in #87-#91.

## Validation
- `ruby -c scripts/validate-workspace-manifest.rb`
- `./tests/test-workspace-manifest-validation.sh`
- `./scripts/validate-workspace-manifest.sh docs/examples/workspace-manifests/superagents.workspace.yaml`

## Assumptions
- `path` and `remote` are treated as mutually exclusive for v1 (exactly one required) to avoid ambiguity in source-of-truth routing.
- `role`, `language`, `runtime`, and `build_system` are intentionally open string fields to preserve heterogeneity and avoid prematurely constraining stacks.
- Existing repo-local flows remain valid when no workspace manifest is present (opt-in contract).

Closes #86


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Workspace manifest validation and a runnable validation command for federated multi-repo workspaces.
  * A repository runtime policy enforcement command to ensure a single non-shell runtime.

* **Documentation**
  * Federated workspace manifest specification, JSON schema, and example manifest; README updated with usage and validation instructions.

* **Tests**
  * Added valid/invalid manifest fixtures and an automated test runner for manifest validation.

* **Chores**
  * CI workflows to run manifest validation and runtime policy checks on pull requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->