### PR TITLE
Implement #87: cross-repo feature model and linked task graph

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ Supported install targets include:
 
 ### 8. Federated Multi-Repo Workspace Manifest
 
-Superagents supports a federated workspace contract for coordinating multiple repositories across different language/toolchain stacks.
+Superagents supports a federated workspace contract for coordinating multiple repositories across different language/toolchain stacks, plus an optional cross-repo feature graph for shared delivery work.
 
 - Spec: [docs/federated-workspace-manifest-spec.md](docs/federated-workspace-manifest-spec.md)
 - Schema: [docs/schemas/superagents.workspace.schema.json](docs/schemas/superagents.workspace.schema.json)
@@ -91,6 +91,18 @@ Validate a manifest:
 
 ```bash
 ./scripts/validate-workspace-manifest.sh superagents.workspace.yaml
+```
+
+Query cross-repo feature rollups:
+
+```bash
+./scripts/query-workspace-feature-graph.sh superagents.workspace.yaml --feature-id crosschain-wallet-v2
+```
+
+Query repo-level rollups:
+
+```bash
+./scripts/query-workspace-feature-graph.sh superagents.workspace.yaml --view repo --repo-id web-console
 ```
 
 ## How Superagents Relates To Superpowers

--- a/docs/examples/workspace-manifests/superagents.workspace.yaml
+++ b/docs/examples/workspace-manifests/superagents.workspace.yaml
@@ -68,3 +68,45 @@ repos:
       team: mobile
       owners:
         - team-mobile
+
+features:
+  - feature_id: crosschain-wallet-v2
+    title: Cross-chain wallet v2
+    description: Coordinate protocol, infra, web, and mobile work items under one release feature.
+    tasks:
+      - id: protocol-risk-review
+        feature_id: crosschain-wallet-v2
+        repo_id: protocol-core
+        title: Finalize protocol risk review
+        status: done
+        child_ids:
+          - infra-rollout-plan
+
+      - id: infra-rollout-plan
+        feature_id: crosschain-wallet-v2
+        repo_id: infra-live
+        title: Define rollout plan and deployment gates
+        status: in_progress
+        parent_ids:
+          - protocol-risk-review
+        child_ids:
+          - web-release-controls
+          - mobile-release-controls
+
+      - id: web-release-controls
+        feature_id: crosschain-wallet-v2
+        repo_id: web-console
+        title: Add web release controls and observability hooks
+        status: blocked
+        parent_ids:
+          - infra-rollout-plan
+        blocked_by_ids:
+          - infra-rollout-plan
+
+      - id: mobile-release-controls
+        feature_id: crosschain-wallet-v2
+        repo_id: mobile-wallet
+        title: Add mobile release controls and staged rollout toggles
+        status: todo
+        parent_ids:
+          - infra-rollout-plan

--- a/docs/federated-workspace-manifest-spec.md
+++ b/docs/federated-workspace-manifest-spec.md
@@ -48,6 +48,19 @@ repos:
         - team-protocol
     policy_refs:
       - policy://solidity/foundry-v1
+
+# optional cross-repo feature graph
+features:
+  - feature_id: crosschain-wallet-v2
+    title: Cross-chain wallet v2
+    tasks:
+      - id: protocol-risk-review
+        feature_id: crosschain-wallet-v2
+        repo_id: protocol-core
+        title: Finalize protocol risk review
+        status: done
+        child_ids:
+          - infra-rollout-plan
 ```
 
 ## Required Fields
@@ -57,6 +70,7 @@ repos:
 - `schema_version` (integer): currently must equal `1`.
 - `workspace_id` (string): lowercase identifier matching `^[a-z0-9][a-z0-9_-]*$`.
 - `repos` (array): must include at least one repository entry.
+- `features` (array): optional. When provided, must include at least one cross-repo feature.
 
 ### Per-repo
 
@@ -74,6 +88,21 @@ repos:
 - `ownership.team` (string)
 - `ownership.owners` (string array)
 - `policy_refs` (string array)
+
+### Optional Cross-Repo Features
+
+- `features[].feature_id` (string): feature identifier matching `^[a-z0-9][a-z0-9_-]*$`.
+- `features[].title` (string): human-readable feature title.
+- `features[].description` (string): optional feature context.
+- `features[].tasks` (array): at least one task, each with:
+  - `id` (string): work item id matching `^[a-z0-9][a-z0-9_-]*$`.
+  - `feature_id` (string): must match parent `features[].feature_id`.
+  - `repo_id` (string): must reference one of `repos[].id`.
+  - `title` (string)
+  - `status` (enum): `todo`, `in_progress`, `blocked`, `done`, `cancelled`.
+  - optional link arrays: `parent_ids`, `child_ids`, `blocked_by_ids`.
+
+`parent_ids`/`child_ids` provide explicit parent-child work item links. `blocked_by_ids` provides dependency blockers used by rollup status queries.
 
 ## Issue Backend Contract
 
@@ -100,6 +129,28 @@ Use the built-in validator:
 ```
 
 The validator checks schema contract rules and reports actionable field-level errors.
+
+## Feature Graph Query CLI/API
+
+Query feature-level rollups (JSON output suitable for CLI automation or API ingestion):
+
+```bash
+./scripts/query-workspace-feature-graph.sh superagents.workspace.yaml --feature-id crosschain-wallet-v2
+```
+
+Query repo-level rollups across all features:
+
+```bash
+./scripts/query-workspace-feature-graph.sh superagents.workspace.yaml --view repo --repo-id web-console
+```
+
+Query repo-level rollups scoped to one feature:
+
+```bash
+./scripts/query-workspace-feature-graph.sh superagents.workspace.yaml --view repo --repo-id web-console --feature-id crosschain-wallet-v2
+```
+
+Rollups include aggregate child progression (`progress_pct`, status counts) and blocking state (`blocking.blocked`, blocker details).
 
 ## Error Message Examples
 
@@ -169,4 +220,5 @@ repos:
 
 - This is an additive, opt-in manifest contract.
 - Existing repo-local workflows can continue without a workspace manifest.
+- Existing workspace manifests that omit `features` remain valid.
 - Future schema changes should increment `schema_version` and preserve v1 parsing behavior where practical.

--- a/docs/schemas/superagents.workspace.schema.json
+++ b/docs/schemas/superagents.workspace.schema.json
@@ -28,9 +28,110 @@
       "items": {
         "$ref": "#/$defs/repo"
       }
+    },
+    "features": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/$defs/feature"
+      }
     }
   },
   "$defs": {
+    "feature": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "feature_id",
+        "title",
+        "tasks"
+      ],
+      "properties": {
+        "feature_id": {
+          "type": "string",
+          "pattern": "^[a-z0-9][a-z0-9_-]*$"
+        },
+        "title": {
+          "type": "string",
+          "minLength": 1
+        },
+        "description": {
+          "type": "string",
+          "minLength": 1
+        },
+        "tasks": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "$ref": "#/$defs/feature_task"
+          }
+        }
+      }
+    },
+    "feature_task": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "feature_id",
+        "repo_id",
+        "title",
+        "status"
+      ],
+      "properties": {
+        "id": {
+          "type": "string",
+          "pattern": "^[a-z0-9][a-z0-9_-]*$"
+        },
+        "feature_id": {
+          "type": "string",
+          "pattern": "^[a-z0-9][a-z0-9_-]*$"
+        },
+        "repo_id": {
+          "type": "string",
+          "pattern": "^[a-z0-9][a-z0-9_-]*$"
+        },
+        "title": {
+          "type": "string",
+          "minLength": 1
+        },
+        "description": {
+          "type": "string",
+          "minLength": 1
+        },
+        "status": {
+          "type": "string",
+          "enum": [
+            "todo",
+            "in_progress",
+            "blocked",
+            "done",
+            "cancelled"
+          ]
+        },
+        "parent_ids": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "pattern": "^[a-z0-9][a-z0-9_-]*$"
+          }
+        },
+        "child_ids": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "pattern": "^[a-z0-9][a-z0-9_-]*$"
+          }
+        },
+        "blocked_by_ids": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "pattern": "^[a-z0-9][a-z0-9_-]*$"
+          }
+        }
+      }
+    },
     "repo": {
       "type": "object",
       "additionalProperties": false,

--- a/scripts/query-workspace-feature-graph.rb
+++ b/scripts/query-workspace-feature-graph.rb
@@ -1,0 +1,208 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require 'json'
+require 'optparse'
+require_relative 'validate-workspace-manifest'
+
+class FeatureGraphQueryError < StandardError; end
+
+class FeatureGraphQuery
+  def initialize(manifest)
+    @manifest = manifest
+    @repos = manifest.fetch('repos', [])
+    @features = manifest.fetch('features', [])
+    @repo_by_id = @repos.each_with_object({}) { |repo, memo| memo[repo['id']] = repo if repo.is_a?(Hash) && repo['id'].is_a?(String) }
+  end
+
+  def feature_view(feature_id)
+    feature = @features.find { |item| item['feature_id'] == feature_id }
+    raise FeatureGraphQueryError, "Feature not found: #{feature_id}" unless feature
+
+    tasks = normalized_tasks(feature)
+    {
+      api_version: 1,
+      view: 'feature',
+      workspace_id: @manifest['workspace_id'],
+      feature_id: feature_id,
+      title: feature['title'],
+      description: feature['description'],
+      rollup: build_rollup(tasks),
+      by_repo: build_repo_rollups(tasks),
+      tasks: tasks
+    }
+  end
+
+  def repo_view(repo_id, feature_id: nil)
+    raise FeatureGraphQueryError, "Repository not found: #{repo_id}" unless @repo_by_id.key?(repo_id)
+
+    tasks = if feature_id
+              feature = @features.find { |item| item['feature_id'] == feature_id }
+              raise FeatureGraphQueryError, "Feature not found: #{feature_id}" unless feature
+
+              normalized_tasks(feature).select { |task| task['repo_id'] == repo_id }
+            else
+              @features.flat_map { |feature| normalized_tasks(feature) }.select { |task| task['repo_id'] == repo_id }
+            end
+
+    {
+      api_version: 1,
+      view: 'repo',
+      workspace_id: @manifest['workspace_id'],
+      repo_id: repo_id,
+      feature_id: feature_id,
+      rollup: build_rollup(tasks),
+      tasks: tasks
+    }
+  end
+
+  private
+
+  def normalized_tasks(feature)
+    tasks = feature.fetch('tasks', [])
+    tasks.map do |task|
+      {
+        'id' => task['id'],
+        'feature_id' => task['feature_id'],
+        'repo_id' => task['repo_id'],
+        'title' => task['title'],
+        'description' => task['description'],
+        'status' => task['status'],
+        'parent_ids' => task.fetch('parent_ids', []),
+        'child_ids' => task.fetch('child_ids', []),
+        'blocked_by_ids' => task.fetch('blocked_by_ids', [])
+      }
+    end
+  end
+
+  def build_repo_rollups(tasks)
+    grouped = tasks.group_by { |task| task['repo_id'] }
+    grouped.keys.sort.map do |repo_id|
+      {
+        repo_id: repo_id,
+        rollup: build_rollup(grouped[repo_id])
+      }
+    end
+  end
+
+  def build_rollup(tasks)
+    counts = Hash.new(0)
+    task_by_id = tasks.each_with_object({}) { |task, memo| memo[task['id']] = task }
+    blockers = []
+
+    tasks.each do |task|
+      status = task['status']
+      counts[status] += 1 if status
+
+      if status == 'blocked'
+        blockers << { task_id: task['id'], reason: 'status_blocked' }
+      end
+
+      task.fetch('blocked_by_ids', []).each do |blocking_id|
+        blocking_task = task_by_id[blocking_id]
+        next unless blocking_task
+        next if %w[done cancelled].include?(blocking_task['status'])
+
+        blockers << { task_id: task['id'], reason: 'waiting_on_task', blocking_task_id: blocking_id }
+      end
+    end
+
+    total = tasks.length
+    done = counts['done']
+    in_progress = counts['in_progress']
+    blocked_count = counts['blocked']
+    completion_pct = total.zero? ? 0.0 : ((done.to_f / total) * 100).round(2)
+
+    {
+      total_tasks: total,
+      done_tasks: done,
+      progress_pct: completion_pct,
+      status_counts: WORK_ITEM_STATUSES.each_with_object({}) { |status, memo| memo[status] = counts[status] },
+      blocking: {
+        blocked: blockers.any? || blocked_count.positive?,
+        blocker_count: blockers.length,
+        blockers: blockers
+      },
+      overall_status: compute_overall_status(total, done, in_progress, blocked_count, blockers.any?)
+    }
+  end
+
+  def compute_overall_status(total, done, in_progress, blocked_count, has_blockers)
+    return 'empty' if total.zero?
+    return 'blocked' if has_blockers || blocked_count.positive?
+    return 'complete' if done == total
+    return 'in_progress' if in_progress.positive? || done.positive?
+
+    'not_started'
+  end
+end
+
+def parse_options(argv)
+  options = { format: 'json' }
+  parser = OptionParser.new do |opts|
+    opts.banner = 'Usage: scripts/query-workspace-feature-graph.rb <manifest-path> (--feature-id ID | --repo-id ID) [--view feature|repo] [--format json]'
+    opts.on('--view VIEW', 'View to render: feature or repo') { |value| options[:view] = value }
+    opts.on('--feature-id ID', 'Feature id to query') { |value| options[:feature_id] = value }
+    opts.on('--repo-id ID', 'Repo id to query') { |value| options[:repo_id] = value }
+    opts.on('--format FORMAT', 'Output format (json only currently)') { |value| options[:format] = value }
+    opts.on('-h', '--help', 'Show this help') do
+      puts opts
+      exit 0
+    end
+  end
+
+  remaining = parser.parse(argv)
+  raise FeatureGraphQueryError, parser.to_s if remaining.empty?
+
+  options[:manifest_path] = remaining.first
+  options[:view] ||= options[:repo_id] ? 'repo' : 'feature'
+  options
+end
+
+def validate_query_options!(options)
+  raise FeatureGraphQueryError, "Unsupported format '#{options[:format]}'. Only 'json' is supported." unless options[:format] == 'json'
+  raise FeatureGraphQueryError, "Unsupported view '#{options[:view]}'. Use 'feature' or 'repo'." unless %w[feature repo].include?(options[:view])
+
+  case options[:view]
+  when 'feature'
+    raise FeatureGraphQueryError, '--feature-id is required for feature view' unless options[:feature_id]
+  when 'repo'
+    raise FeatureGraphQueryError, '--repo-id is required for repo view' unless options[:repo_id]
+  end
+end
+
+def load_and_validate_manifest!(manifest_path)
+  schema = load_schema
+  manifest_data = load_manifest(manifest_path)
+  schema_guardrails!(schema)
+
+  schema_errors = SimpleJsonSchemaValidator.new(schema).validate(manifest_data)
+  custom_validator = ManifestValidator.new(manifest_data)
+  custom_valid = custom_validator.validate
+
+  return manifest_data if schema_errors.empty? && custom_valid
+
+  errors = schema_errors + custom_validator.errors
+  raise FeatureGraphQueryError, "Manifest validation failed for #{manifest_path}:\n  - #{errors.join("\n  - ")}"
+end
+
+def run_query_cli(argv)
+  options = parse_options(argv)
+  validate_query_options!(options)
+  manifest_data = load_and_validate_manifest!(options[:manifest_path])
+  query = FeatureGraphQuery.new(manifest_data)
+
+  result = if options[:view] == 'feature'
+             query.feature_view(options[:feature_id])
+           else
+             query.repo_view(options[:repo_id], feature_id: options[:feature_id])
+           end
+
+  puts JSON.pretty_generate(result)
+  0
+rescue OptionParser::ParseError, FeatureGraphQueryError, ValidationError => e
+  warn e.message
+  1
+end
+
+exit(run_query_cli(ARGV)) if $PROGRAM_NAME == __FILE__

--- a/scripts/query-workspace-feature-graph.sh
+++ b/scripts/query-workspace-feature-graph.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+if [[ $# -lt 1 ]]; then
+  echo "Usage: ./scripts/query-workspace-feature-graph.sh <manifest-path> (--feature-id ID | --repo-id ID) [--view feature|repo] [--format json]" >&2
+  exit 2
+fi
+
+ruby "$SCRIPT_DIR/query-workspace-feature-graph.rb" "$@"

--- a/scripts/validate-workspace-manifest.rb
+++ b/scripts/validate-workspace-manifest.rb
@@ -7,11 +7,15 @@ require 'psych'
 
 SCHEMA_PATH = Pathname.new(__dir__).join('../docs/schemas/superagents.workspace.schema.json').expand_path
 REPO_ID_REGEX = /\A[a-z0-9][a-z0-9_-]*\z/
-KNOWN_TOP_LEVEL_KEYS = %w[schema_version workspace_id description repos].freeze
+KNOWN_TOP_LEVEL_KEYS = %w[schema_version workspace_id description repos features].freeze
 KNOWN_REPO_KEYS = %w[id path remote default_branch role language runtime build_system issue_backend ownership policy_refs].freeze
 KNOWN_ISSUE_BACKEND_KEYS = %w[type repo project_id tracker mapping].freeze
 KNOWN_OWNERSHIP_KEYS = %w[team owners].freeze
 ISSUE_BACKEND_TYPES = %w[repo_issues github_project external_tracker none].freeze
+WORK_ITEM_ID_REGEX = /\A[a-z0-9][a-z0-9_-]*\z/
+KNOWN_FEATURE_KEYS = %w[feature_id title description tasks].freeze
+KNOWN_TASK_KEYS = %w[id feature_id repo_id title description status parent_ids child_ids blocked_by_ids].freeze
+WORK_ITEM_STATUSES = %w[todo in_progress blocked done cancelled].freeze
 
 class ValidationError < StandardError; end
 
@@ -220,7 +224,8 @@ class ManifestValidator
     validate_schema_version(@data['schema_version'])
     validate_workspace_id(@data['workspace_id'])
     validate_description(@data['description']) if @data.key?('description')
-    validate_repos(@data['repos'])
+    repo_ids = validate_repos(@data['repos'])
+    validate_features(@data['features'], repo_ids) if @data.key?('features')
   end
 
   def validate_schema_version(value)
@@ -246,14 +251,16 @@ class ManifestValidator
   end
 
   def validate_repos(repos)
+    repo_id_set = {}
+
     unless repos.is_a?(Array)
       add_error('$.repos', 'must be an array')
-      return
+      return repo_id_set
     end
 
     if repos.empty?
       add_error('$.repos', 'must contain at least one repository entry')
-      return
+      return repo_id_set
     end
 
     repo_ids = {}
@@ -267,8 +274,182 @@ class ManifestValidator
         add_error("#{pointer}.id", "duplicates repository id '#{repo['id']}' used at $.repos[#{repo_ids[repo['id']]}].id")
       else
         repo_ids[repo['id']] = index
+        repo_id_set[repo['id']] = true
       end
     end
+
+    repo_id_set
+  end
+
+  def validate_features(features, repo_ids)
+    unless features.is_a?(Array)
+      add_error('$.features', 'must be an array')
+      return
+    end
+
+    if features.empty?
+      add_error('$.features', 'must contain at least one feature when provided')
+      return
+    end
+
+    feature_index_by_id = {}
+    features.each_with_index do |feature, index|
+      pointer = "$.features[#{index}]"
+      feature_id = validate_feature(feature, pointer, repo_ids)
+      next unless feature_id
+
+      if feature_index_by_id.key?(feature_id)
+        prior_pointer = "$.features[#{feature_index_by_id[feature_id]}].feature_id"
+        add_error("#{pointer}.feature_id", "duplicates feature_id '#{feature_id}' used at #{prior_pointer}")
+      else
+        feature_index_by_id[feature_id] = index
+      end
+    end
+  end
+
+  def validate_feature(feature, pointer, repo_ids)
+    unless feature.is_a?(Hash)
+      add_error(pointer, 'must be an object')
+      return nil
+    end
+
+    %w[feature_id title tasks].each do |key|
+      require_key(feature, pointer, key)
+    end
+
+    unknown_feature_keys = feature.keys - KNOWN_FEATURE_KEYS
+    unknown_feature_keys.each do |key|
+      add_error("#{pointer}.#{key}", 'is not allowed by schema')
+    end
+
+    feature_id = feature['feature_id']
+    validate_work_item_id(feature_id, "#{pointer}.feature_id", field_name: 'feature_id')
+    validate_non_empty_string(feature['title'], "#{pointer}.title")
+    validate_non_empty_string(feature['description'], "#{pointer}.description") if feature.key?('description')
+    validate_feature_tasks(feature['tasks'], "#{pointer}.tasks", feature_id, repo_ids)
+
+    feature_id if feature_id.is_a?(String) && !feature_id.strip.empty?
+  end
+
+  def validate_feature_tasks(tasks, pointer, feature_id, repo_ids)
+    unless tasks.is_a?(Array)
+      add_error(pointer, 'must be an array')
+      return
+    end
+
+    if tasks.empty?
+      add_error(pointer, 'must contain at least one task')
+      return
+    end
+
+    task_ids = {}
+    tasks.each_with_index do |task, index|
+      task_pointer = "#{pointer}[#{index}]"
+      task_id = validate_feature_task(task, task_pointer, feature_id, repo_ids)
+      next unless task_id
+
+      if task_ids.key?(task_id)
+        prior_pointer = "#{pointer}[#{task_ids[task_id]}].id"
+        add_error("#{task_pointer}.id", "duplicates task id '#{task_id}' used at #{prior_pointer}")
+      else
+        task_ids[task_id] = index
+      end
+    end
+
+    tasks.each_with_index do |task, index|
+      next unless task.is_a?(Hash)
+
+      task_pointer = "#{pointer}[#{index}]"
+      validate_task_link_array(task['parent_ids'], "#{task_pointer}.parent_ids", task_ids, task['id']) if task.key?('parent_ids')
+      validate_task_link_array(task['child_ids'], "#{task_pointer}.child_ids", task_ids, task['id']) if task.key?('child_ids')
+      validate_task_link_array(task['blocked_by_ids'], "#{task_pointer}.blocked_by_ids", task_ids, task['id']) if task.key?('blocked_by_ids')
+      validate_parent_child_consistency(task, task_pointer, tasks, task_ids)
+    end
+  end
+
+  def validate_feature_task(task, pointer, feature_id, repo_ids)
+    unless task.is_a?(Hash)
+      add_error(pointer, 'must be an object')
+      return nil
+    end
+
+    %w[id feature_id repo_id title status].each do |key|
+      require_key(task, pointer, key)
+    end
+
+    unknown_task_keys = task.keys - KNOWN_TASK_KEYS
+    unknown_task_keys.each do |key|
+      add_error("#{pointer}.#{key}", 'is not allowed by schema')
+    end
+
+    task_id = task['id']
+    validate_work_item_id(task_id, "#{pointer}.id", field_name: 'id')
+    validate_work_item_id(task['feature_id'], "#{pointer}.feature_id", field_name: 'feature_id')
+    validate_work_item_id(task['repo_id'], "#{pointer}.repo_id", field_name: 'repo_id')
+    validate_non_empty_string(task['title'], "#{pointer}.title")
+    validate_non_empty_string(task['description'], "#{pointer}.description") if task.key?('description')
+    validate_task_status(task['status'], "#{pointer}.status")
+
+    if task['feature_id'].is_a?(String) && feature_id.is_a?(String) && task['feature_id'] != feature_id
+      add_error("#{pointer}.feature_id", "must match parent feature_id '#{feature_id}'")
+    end
+
+    if task['repo_id'].is_a?(String) && !repo_ids.key?(task['repo_id'])
+      add_error("#{pointer}.repo_id", "references unknown repo id '#{task['repo_id']}'")
+    end
+
+    task_id if task_id.is_a?(String) && !task_id.strip.empty?
+  end
+
+  def validate_task_status(status, pointer)
+    unless status.is_a?(String) && WORK_ITEM_STATUSES.include?(status)
+      add_error(pointer, "must be one of: #{WORK_ITEM_STATUSES.join(', ')}")
+    end
+  end
+
+  def validate_task_link_array(value, pointer, known_task_ids, current_task_id)
+    unless value.is_a?(Array)
+      add_error(pointer, 'must be an array of task ids')
+      return
+    end
+
+    value.each_with_index do |linked_id, index|
+      link_pointer = "#{pointer}[#{index}]"
+      validate_work_item_id(linked_id, link_pointer, field_name: 'task id')
+      next unless linked_id.is_a?(String)
+
+      add_error(link_pointer, "cannot reference itself '#{linked_id}'") if current_task_id.is_a?(String) && linked_id == current_task_id
+      add_error(link_pointer, "references unknown task id '#{linked_id}'") unless known_task_ids.key?(linked_id)
+    end
+  end
+
+  def validate_parent_child_consistency(task, pointer, tasks, known_task_ids)
+    return unless task.is_a?(Hash)
+    return unless task.key?('child_ids')
+
+    child_ids = task['child_ids']
+    return unless child_ids.is_a?(Array)
+
+    child_ids.each do |child_id|
+      next unless child_id.is_a?(String) && known_task_ids.key?(child_id)
+
+      child_task = tasks[known_task_ids[child_id]]
+      child_parent_ids = child_task['parent_ids']
+      next if child_parent_ids.is_a?(Array) && child_parent_ids.include?(task['id'])
+
+      add_error("#{pointer}.child_ids", "declares child '#{child_id}' but #{child_id} does not include '#{task['id']}' in parent_ids")
+    end
+  end
+
+  def validate_work_item_id(value, pointer, field_name:)
+    unless value.is_a?(String) && !value.strip.empty?
+      add_error(pointer, "must be a non-empty string for #{field_name}")
+      return
+    end
+
+    return if value.match?(WORK_ITEM_ID_REGEX)
+
+    add_error(pointer, 'must match ^[a-z0-9][a-z0-9_-]*$')
   end
 
   def validate_repo(repo, pointer)
@@ -497,15 +678,19 @@ rescue ValidationError => e
   1
 end
 
-if ARGV.empty?
-  warn 'Usage: scripts/validate-workspace-manifest.rb <manifest-path> [manifest-path...]'
-  exit 2
+def run_cli(argv)
+  if argv.empty?
+    warn 'Usage: scripts/validate-workspace-manifest.rb <manifest-path> [manifest-path...]'
+    return 2
+  end
+
+  exit_code = 0
+  argv.each do |manifest_path|
+    result = validate_manifest(manifest_path)
+    exit_code = 1 if result != 0
+  end
+
+  exit_code
 end
 
-exit_code = 0
-ARGV.each do |manifest_path|
-  result = validate_manifest(manifest_path)
-  exit_code = 1 if result != 0
-end
-
-exit exit_code
+exit(run_cli(ARGV)) if $PROGRAM_NAME == __FILE__

--- a/tests/fixtures/workspace-manifests/invalid/feature-task-child-parent-link-mismatch.yaml
+++ b/tests/fixtures/workspace-manifests/invalid/feature-task-child-parent-link-mismatch.yaml
@@ -1,0 +1,27 @@
+schema_version: 1
+workspace_id: orbit
+repos:
+  - id: api
+    remote: git@github.com:example/api.git
+    default_branch: main
+    role: backend
+    build_system: bundler
+    issue_backend:
+      type: repo_issues
+      repo: example/api
+features:
+  - feature_id: rollout-bridge
+    title: Bridge rollout
+    tasks:
+      - id: task-a
+        feature_id: rollout-bridge
+        repo_id: api
+        title: Task A
+        status: in_progress
+        child_ids:
+          - task-b
+      - id: task-b
+        feature_id: rollout-bridge
+        repo_id: api
+        title: Task B
+        status: todo

--- a/tests/fixtures/workspace-manifests/invalid/feature-task-mismatched-feature-id.yaml
+++ b/tests/fixtures/workspace-manifests/invalid/feature-task-mismatched-feature-id.yaml
@@ -1,0 +1,20 @@
+schema_version: 1
+workspace_id: orbit
+repos:
+  - id: api
+    remote: git@github.com:example/api.git
+    default_branch: main
+    role: backend
+    build_system: bundler
+    issue_backend:
+      type: repo_issues
+      repo: example/api
+features:
+  - feature_id: rollout-bridge
+    title: Bridge rollout
+    tasks:
+      - id: api-prepare
+        feature_id: wrong-feature
+        repo_id: api
+        title: Prepare backend contract
+        status: todo

--- a/tests/fixtures/workspace-manifests/invalid/feature-task-unknown-repo.yaml
+++ b/tests/fixtures/workspace-manifests/invalid/feature-task-unknown-repo.yaml
@@ -1,0 +1,20 @@
+schema_version: 1
+workspace_id: orbit
+repos:
+  - id: api
+    remote: git@github.com:example/api.git
+    default_branch: main
+    role: backend
+    build_system: bundler
+    issue_backend:
+      type: repo_issues
+      repo: example/api
+features:
+  - feature_id: rollout-bridge
+    title: Bridge rollout
+    tasks:
+      - id: api-prepare
+        feature_id: rollout-bridge
+        repo_id: web
+        title: Prepare backend contract
+        status: todo

--- a/tests/fixtures/workspace-manifests/valid/feature-graph-multi-repo.yaml
+++ b/tests/fixtures/workspace-manifests/valid/feature-graph-multi-repo.yaml
@@ -1,0 +1,68 @@
+schema_version: 1
+workspace_id: orbit
+description: Multi-repo feature graph validation fixture.
+repos:
+  - id: api
+    remote: git@github.com:example/api.git
+    default_branch: main
+    role: backend
+    language: ruby
+    runtime: ruby3.3
+    build_system: bundler
+    issue_backend:
+      type: repo_issues
+      repo: example/api
+
+  - id: web
+    remote: git@github.com:example/web.git
+    default_branch: main
+    role: webapp
+    language: typescript
+    runtime: node20
+    build_system: pnpm
+    issue_backend:
+      type: github_project
+      project_id: PVT_kwDOXYZ123
+
+  - id: infra
+    path: ../infra
+    default_branch: main
+    role: devops
+    language: hcl
+    runtime: terraform
+    build_system: terraform
+    issue_backend:
+      type: external_tracker
+      tracker: jira
+      mapping:
+        project_key: INFRA
+
+features:
+  - feature_id: rollout-bridge
+    title: Bridge rollout
+    tasks:
+      - id: api-prepare
+        feature_id: rollout-bridge
+        repo_id: api
+        title: Prepare backend contract
+        status: done
+        child_ids:
+          - infra-gates
+      - id: infra-gates
+        feature_id: rollout-bridge
+        repo_id: infra
+        title: Define infra gates
+        status: in_progress
+        parent_ids:
+          - api-prepare
+        child_ids:
+          - web-release
+      - id: web-release
+        feature_id: rollout-bridge
+        repo_id: web
+        title: Release web flow
+        status: blocked
+        parent_ids:
+          - infra-gates
+        blocked_by_ids:
+          - infra-gates

--- a/tests/test-workspace-feature-graph-query.sh
+++ b/tests/test-workspace-feature-graph-query.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+QUERY="$ROOT_DIR/scripts/query-workspace-feature-graph.sh"
+FIXTURE="$ROOT_DIR/tests/fixtures/workspace-manifests/valid/feature-graph-multi-repo.yaml"
+
+feature_json="$(mktemp)"
+repo_json="$(mktemp)"
+trap 'rm -f "$feature_json" "$repo_json"' EXIT
+
+"$QUERY" "$FIXTURE" --feature-id rollout-bridge >"$feature_json"
+"$QUERY" "$FIXTURE" --view repo --repo-id web --feature-id rollout-bridge >"$repo_json"
+
+ruby -rjson -e '
+  feature = JSON.parse(File.read(ARGV[0]))
+  repo = JSON.parse(File.read(ARGV[1]))
+
+  raise "expected feature view" unless feature["view"] == "feature"
+  raise "expected feature id" unless feature["feature_id"] == "rollout-bridge"
+  raise "expected blocked rollup status" unless feature.dig("rollup", "overall_status") == "blocked"
+  raise "expected three repo rollups" unless feature["by_repo"].length == 3
+  raise "expected blocked blocker count" unless feature.dig("rollup", "blocking", "blocker_count") == 2
+
+  raise "expected repo view" unless repo["view"] == "repo"
+  raise "expected repo id" unless repo["repo_id"] == "web"
+  raise "expected one web task" unless repo["tasks"].length == 1
+  raise "expected blocked repo rollup" unless repo.dig("rollup", "overall_status") == "blocked"
+  raise "expected blocked status count" unless repo.dig("rollup", "status_counts", "blocked") == 1
+' "$feature_json" "$repo_json"
+
+echo "Workspace feature graph query tests: passed"


### PR DESCRIPTION
## Summary
- add an optional first-class `features` model to `superagents.workspace.yaml` for cross-repo feature coordination
- add task-level `feature_id`, `repo_id`, and parent/child/blocking links (`parent_ids`, `child_ids`, `blocked_by_ids`)
- extend validation with cross-reference checks (repo existence, feature consistency, task link consistency) while keeping feature-less manifests valid
- add `query-workspace-feature-graph` CLI returning JSON rollups for both feature-level and repo-level views
- update docs/examples/schema and add validation/query tests and fixtures

## Scope Guardrails
- implements only Issue #87 (feature graph model + rollup query)
- does not implement tracker integration (#88), orchestration gates (#89), per-repo policy plugins (#90), or docs-only epic closeout (#91)

## Assumptions
- `features` remains optional for backward compatibility in schema v1
- JSON output from query CLI is the API surface for automation consumers at this phase
- rollup blocking is reported when a task is `blocked` or waits on an unfinished `blocked_by_ids` dependency

## Validation
- `./tests/test-workspace-manifest-validation.sh`
- `./tests/test-workspace-feature-graph-query.sh`

Closes #87


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for cross-repo feature graphs in workspace manifests, allowing you to define features with interdependent tasks across multiple repositories.
  * New query tool enables you to retrieve feature-scoped and repository-scoped rollups, including task progress aggregates and blocking status.

* **Documentation**
  * Updated workspace manifest specification with feature graph schema and validation requirements.
  * Added usage examples showing how to query feature and repository rollups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->