### PR TITLE
Implement #89: cross-repo dependency gates and execution ordering

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,18 @@ Query GitHub integration mapping rollups (feature + repo-local issue/project lin
 ./scripts/query-workspace-feature-graph.sh superagents.workspace.yaml --view integration --feature-id crosschain-wallet-v2
 ```
 
+Query deterministic execution order for a feature graph:
+
+```bash
+./scripts/query-workspace-feature-graph.sh superagents.workspace.yaml --view execution-order --feature-id crosschain-wallet-v2
+```
+
+Query per-task dependency gate states (`blocked`, `ready`, `running`, `waiting_on_signal`) with readiness details:
+
+```bash
+./scripts/query-workspace-feature-graph.sh superagents.workspace.yaml --view gate-status --feature-id crosschain-wallet-v2
+```
+
 ## How Superagents Relates To Superpowers
 
 ### What Is Shared

--- a/docs/federated-workspace-manifest-spec.md
+++ b/docs/federated-workspace-manifest-spec.md
@@ -179,7 +179,27 @@ Query GitHub integration mapping rollups for one feature:
 ./scripts/query-workspace-feature-graph.sh superagents.workspace.yaml --view integration --feature-id crosschain-wallet-v2
 ```
 
-Rollups include aggregate child progression (`progress_pct`, status counts), blocking state (`blocking.blocked`, blocker details), and integration mapping state (issue/project coverage, sync status counts, dedupe keys, and retryable failures).
+Query deterministic execution ordering for one feature:
+
+```bash
+./scripts/query-workspace-feature-graph.sh superagents.workspace.yaml --view execution-order --feature-id crosschain-wallet-v2
+```
+
+Query per-task dependency gate status for one feature:
+
+```bash
+./scripts/query-workspace-feature-graph.sh superagents.workspace.yaml --view gate-status --feature-id crosschain-wallet-v2
+```
+
+Rollups include aggregate child progression (`progress_pct`, status counts), blocking state (`blocking.blocked`, blocker details), deterministic dependency graph metadata (`dependency_graph`), gate-state rollups (`blocked`, `ready`, `running`, `waiting_on_signal`, `satisfied`), and deterministic execution ordering (`execution_order` with `sequence` + `wave`).
+
+Execution-order tie-breaking is deterministic for equal dependency depth: task id ascending.
+
+Failure and recovery are deterministic:
+
+- dependency cycles fail validation and must be resolved before execution-order views are considered valid.
+- gate blockers include explicit reasons (`status_blocked`, `waiting_on_dependency`, `dependency_cycle`) and blocking task ids where applicable.
+- recovery path is resumable: update task status/dependency links, then re-run query views to compute the next ready set from the same rules.
 
 ## Error Message Examples
 

--- a/scripts/query-workspace-feature-graph.rb
+++ b/scripts/query-workspace-feature-graph.rb
@@ -3,11 +3,14 @@
 
 require 'json'
 require 'optparse'
+require 'set'
 require_relative 'validate-workspace-manifest'
 
 class FeatureGraphQueryError < StandardError; end
 
 class FeatureGraphQuery
+  TERMINAL_TASK_STATUSES = %w[done cancelled].freeze
+
   def initialize(manifest)
     @manifest = manifest
     @repos = manifest.fetch('repos', [])
@@ -27,7 +30,7 @@ class FeatureGraphQuery
       feature_id: feature_id,
       title: feature['title'],
       description: feature['description'],
-      rollup: build_rollup(tasks),
+      rollup: build_rollup(tasks, dependency_context_tasks: tasks),
       by_repo: build_repo_rollups(tasks),
       integration: build_feature_integration_view(feature, tasks),
       tasks: tasks
@@ -37,14 +40,16 @@ class FeatureGraphQuery
   def repo_view(repo_id, feature_id: nil)
     raise FeatureGraphQueryError, "Repository not found: #{repo_id}" unless @repo_by_id.key?(repo_id)
 
-    tasks = if feature_id
-              feature = @features.find { |item| item['feature_id'] == feature_id }
-              raise FeatureGraphQueryError, "Feature not found: #{feature_id}" unless feature
+    context_tasks, tasks = if feature_id
+                             feature = @features.find { |item| item['feature_id'] == feature_id }
+                             raise FeatureGraphQueryError, "Feature not found: #{feature_id}" unless feature
 
-              normalized_tasks(feature).select { |task| task['repo_id'] == repo_id }
-            else
-              @features.flat_map { |feature| normalized_tasks(feature) }.select { |task| task['repo_id'] == repo_id }
-            end
+                             all_feature_tasks = normalized_tasks(feature)
+                             [all_feature_tasks, all_feature_tasks.select { |task| task['repo_id'] == repo_id }]
+                           else
+                             repo_tasks = @features.flat_map { |feature| normalized_tasks(feature) }.select { |task| task['repo_id'] == repo_id }
+                             [repo_tasks, repo_tasks]
+                           end
 
     {
       api_version: 1,
@@ -52,7 +57,7 @@ class FeatureGraphQuery
       workspace_id: @manifest['workspace_id'],
       repo_id: repo_id,
       feature_id: feature_id,
-      rollup: build_rollup(tasks),
+      rollup: build_rollup(tasks, dependency_context_tasks: context_tasks),
       integration: build_repo_integration_view(repo_id, tasks),
       tasks: tasks
     }
@@ -77,6 +82,50 @@ class FeatureGraphQuery
       rollup: build_integration_rollup(tasks),
       by_repo: build_repo_integration_rollups(tasks),
       tasks: build_task_integration_rows(tasks)
+    }
+  end
+
+  def execution_order_view(feature_id, repo_id: nil)
+    feature = @features.find { |item| item['feature_id'] == feature_id }
+    raise FeatureGraphQueryError, "Feature not found: #{feature_id}" unless feature
+    raise FeatureGraphQueryError, "Repository not found: #{repo_id}" if repo_id && !@repo_by_id.key?(repo_id)
+
+    all_tasks = normalized_tasks(feature)
+    rollup = build_rollup(all_tasks, dependency_context_tasks: all_tasks)
+    ordered = rollup[:execution_order]
+    ordered = ordered.select { |row| row[:repo_id] == repo_id } if repo_id
+
+    {
+      api_version: 1,
+      view: 'execution-order',
+      workspace_id: @manifest['workspace_id'],
+      feature_id: feature_id,
+      repo_id: repo_id,
+      execution_order: ordered,
+      gate_status: rollup[:gate_status],
+      dependency_graph: rollup[:dependency_graph]
+    }
+  end
+
+  def gate_status_view(feature_id, repo_id: nil)
+    feature = @features.find { |item| item['feature_id'] == feature_id }
+    raise FeatureGraphQueryError, "Feature not found: #{feature_id}" unless feature
+    raise FeatureGraphQueryError, "Repository not found: #{repo_id}" if repo_id && !@repo_by_id.key?(repo_id)
+
+    all_tasks = normalized_tasks(feature)
+    orchestration = build_orchestration(all_tasks, dependency_context_tasks: all_tasks)
+    task_gates = orchestration[:task_gates]
+    task_gates = task_gates.select { |row| row[:repo_id] == repo_id } if repo_id
+
+    {
+      api_version: 1,
+      view: 'gate-status',
+      workspace_id: @manifest['workspace_id'],
+      feature_id: feature_id,
+      repo_id: repo_id,
+      gate_status: orchestration[:gate_status],
+      dependency_graph: orchestration[:dependency_graph],
+      tasks: task_gates
     }
   end
 
@@ -106,7 +155,7 @@ class FeatureGraphQuery
     grouped.keys.sort.map do |repo_id|
       {
         repo_id: repo_id,
-        rollup: build_rollup(grouped[repo_id])
+        rollup: build_rollup(grouped[repo_id], dependency_context_tasks: tasks)
       }
     end
   end
@@ -226,32 +275,21 @@ class FeatureGraphQuery
     repo.dig('issue_backend', 'repo')
   end
 
-  def build_rollup(tasks)
+  def build_rollup(tasks, dependency_context_tasks:)
     counts = Hash.new(0)
-    task_by_id = tasks.each_with_object({}) { |task, memo| memo[task['id']] = task }
-    blockers = []
+    orchestration = build_orchestration(tasks, dependency_context_tasks: dependency_context_tasks)
+    blockers = orchestration[:gate_status][:blocking_tasks]
 
     tasks.each do |task|
       status = task['status']
       counts[status] += 1 if status
-
-      if status == 'blocked'
-        blockers << { task_id: task['id'], reason: 'status_blocked' }
-      end
-
-      task.fetch('blocked_by_ids', []).each do |blocking_id|
-        blocking_task = task_by_id[blocking_id]
-        next unless blocking_task
-        next if %w[done cancelled].include?(blocking_task['status'])
-
-        blockers << { task_id: task['id'], reason: 'waiting_on_task', blocking_task_id: blocking_id }
-      end
     end
 
     total = tasks.length
     done = counts['done']
     in_progress = counts['in_progress']
     blocked_count = counts['blocked']
+    has_blockers = blockers.any? || blocked_count.positive?
     completion_pct = total.zero? ? 0.0 : ((done.to_f / total) * 100).round(2)
 
     {
@@ -260,11 +298,169 @@ class FeatureGraphQuery
       progress_pct: completion_pct,
       status_counts: WORK_ITEM_STATUSES.each_with_object({}) { |status, memo| memo[status] = counts[status] },
       blocking: {
-        blocked: blockers.any? || blocked_count.positive?,
+        blocked: has_blockers,
         blocker_count: blockers.length,
         blockers: blockers
       },
-      overall_status: compute_overall_status(total, done, in_progress, blocked_count, blockers.any?)
+      gate_status: orchestration[:gate_status],
+      dependency_graph: orchestration[:dependency_graph],
+      execution_order: orchestration[:execution_order],
+      overall_status: compute_overall_status(total, done, in_progress, blocked_count, has_blockers)
+    }
+  end
+
+  def build_orchestration(tasks, dependency_context_tasks:)
+    task_by_id = dependency_context_tasks.each_with_object({}) { |task, memo| memo[task['id']] = task }
+    relevant_task_ids = tasks.map { |task| task['id'] }.to_set
+    dependency_ids_by_task = {}
+    dependents_by_task = Hash.new { |memo, key| memo[key] = [] }
+    indegree = {}
+
+    tasks.sort_by { |task| task['id'] }.each do |task|
+      deps = dependency_ids_for(task).select { |id| task_by_id.key?(id) }
+      relevant_deps = deps.select { |id| relevant_task_ids.include?(id) }
+      dependency_ids_by_task[task['id']] = deps
+      indegree[task['id']] = relevant_deps.length
+      relevant_deps.each { |dep| dependents_by_task[dep] << task['id'] }
+    end
+
+    dependents_by_task.each_value(&:sort!)
+    queue = indegree.select { |_id, degree| degree.zero? }.keys.sort
+    wave_by_task_id = {}
+    processed_ids = {}
+    execution_rows = []
+
+    until queue.empty?
+      task_id = queue.shift
+      task = task_by_id[task_id]
+      deps = dependency_ids_by_task.fetch(task_id, [])
+      wave = deps.empty? ? 0 : deps.map { |id| wave_by_task_id[id] || 0 }.max + 1
+      wave_by_task_id[task_id] = wave
+
+      gate = evaluate_gate(task, deps, task_by_id)
+      execution_rows << build_execution_row(
+        task,
+        gate: gate,
+        sequence: execution_rows.length + 1,
+        wave: wave,
+        dependency_ids: deps
+      )
+      processed_ids[task_id] = true
+
+      dependents_by_task.fetch(task_id, []).each do |dependent_id|
+        indegree[dependent_id] -= 1
+        queue << dependent_id if indegree[dependent_id].zero?
+      end
+      queue.sort!
+    end
+
+    cycle_task_ids = indegree.keys.reject { |id| processed_ids[id] }.sort
+    cycle_task_ids.each do |task_id|
+      task = task_by_id[task_id]
+      deps = dependency_ids_by_task.fetch(task_id, [])
+      gate = {
+        gate_state: 'blocked',
+        ready_for_execution: false,
+        blockers: [{ task_id: task_id, reason: 'dependency_cycle', cycle_task_ids: cycle_task_ids }]
+      }
+      execution_rows << build_execution_row(
+        task,
+        gate: gate,
+        sequence: execution_rows.length + 1,
+        wave: nil,
+        dependency_ids: deps
+      )
+    end
+
+    {
+      execution_order: execution_rows,
+      task_gates: execution_rows,
+      dependency_graph: {
+        total_tasks: tasks.length,
+        edge_count: dependency_ids_by_task.values.map(&:length).sum,
+        has_cycles: cycle_task_ids.any?,
+        cycle_task_ids: cycle_task_ids
+      },
+      gate_status: build_gate_status_rollup(execution_rows)
+    }
+  end
+
+  def dependency_ids_for(task)
+    (task.fetch('blocked_by_ids', []) + task.fetch('parent_ids', [])).uniq.sort
+  end
+
+  def evaluate_gate(task, dependency_ids, task_by_id)
+    status = task['status']
+    blockers = []
+
+    unsatisfied_dependency_ids = dependency_ids.select do |dependency_id|
+      dependency_task = task_by_id[dependency_id]
+      dependency_task && !TERMINAL_TASK_STATUSES.include?(dependency_task['status'])
+    end
+
+    unsatisfied_dependency_ids.each do |dependency_id|
+      blockers << {
+        task_id: task['id'],
+        reason: 'waiting_on_dependency',
+        blocking_task_id: dependency_id,
+        blocking_status: task_by_id.dig(dependency_id, 'status')
+      }
+    end
+
+    if status == 'blocked'
+      blockers << { task_id: task['id'], reason: 'status_blocked' }
+      gate_state = 'blocked'
+    elsif TERMINAL_TASK_STATUSES.include?(status)
+      gate_state = 'satisfied'
+    elsif !unsatisfied_dependency_ids.empty?
+      gate_state = 'waiting_on_signal'
+    elsif status == 'in_progress'
+      gate_state = 'running'
+    else
+      gate_state = 'ready'
+    end
+
+    {
+      gate_state: gate_state,
+      ready_for_execution: gate_state == 'ready',
+      blockers: blockers.sort_by { |entry| [entry[:reason].to_s, entry[:blocking_task_id].to_s] }
+    }
+  end
+
+  def build_execution_row(task, gate:, sequence:, wave:, dependency_ids:)
+    {
+      sequence: sequence,
+      wave: wave,
+      task_id: task['id'],
+      repo_id: task['repo_id'],
+      status: task['status'],
+      gate_state: gate[:gate_state],
+      ready_for_execution: gate[:ready_for_execution],
+      dependency_ids: dependency_ids,
+      blockers: gate[:blockers]
+    }
+  end
+
+  def build_gate_status_rollup(task_rows)
+    gate_counts = Hash.new(0)
+    blocker_rows = []
+
+    task_rows.each do |row|
+      gate_counts[row[:gate_state]] += 1 if row[:gate_state].is_a?(String)
+      blocker_rows.concat(row[:blockers])
+    end
+
+    {
+      total_tasks: task_rows.length,
+      state_counts: {
+        blocked: gate_counts['blocked'],
+        ready: gate_counts['ready'],
+        running: gate_counts['running'],
+        waiting_on_signal: gate_counts['waiting_on_signal'],
+        satisfied: gate_counts['satisfied']
+      },
+      ready_task_ids: task_rows.select { |row| row[:ready_for_execution] }.map { |row| row[:task_id] },
+      blocking_tasks: blocker_rows
     }
   end
 
@@ -281,8 +477,8 @@ end
 def parse_options(argv)
   options = { format: 'json' }
   parser = OptionParser.new do |opts|
-    opts.banner = 'Usage: scripts/query-workspace-feature-graph.rb <manifest-path> (--feature-id ID | --repo-id ID) [--view feature|repo|integration] [--format json]'
-    opts.on('--view VIEW', 'View to render: feature, repo, or integration') { |value| options[:view] = value }
+    opts.banner = 'Usage: scripts/query-workspace-feature-graph.rb <manifest-path> (--feature-id ID | --repo-id ID) [--view feature|repo|integration|execution-order|gate-status] [--format json]'
+    opts.on('--view VIEW', 'View to render: feature, repo, integration, execution-order, or gate-status') { |value| options[:view] = value }
     opts.on('--feature-id ID', 'Feature id to query') { |value| options[:feature_id] = value }
     opts.on('--repo-id ID', 'Repo id to query') { |value| options[:repo_id] = value }
     opts.on('--format FORMAT', 'Output format (json only currently)') { |value| options[:format] = value }
@@ -302,15 +498,16 @@ end
 
 def validate_query_options!(options)
   raise FeatureGraphQueryError, "Unsupported format '#{options[:format]}'. Only 'json' is supported." unless options[:format] == 'json'
-  raise FeatureGraphQueryError, "Unsupported view '#{options[:view]}'. Use 'feature', 'repo', or 'integration'." unless %w[feature repo integration].include?(options[:view])
+  allowed_views = %w[feature repo integration execution-order gate-status]
+  raise FeatureGraphQueryError, "Unsupported view '#{options[:view]}'. Use #{allowed_views.join(', ')}." unless allowed_views.include?(options[:view])
 
   case options[:view]
   when 'feature'
     raise FeatureGraphQueryError, '--feature-id is required for feature view' unless options[:feature_id]
   when 'repo'
     raise FeatureGraphQueryError, '--repo-id is required for repo view' unless options[:repo_id]
-  when 'integration'
-    raise FeatureGraphQueryError, '--feature-id is required for integration view' unless options[:feature_id]
+  else
+    raise FeatureGraphQueryError, "--feature-id is required for #{options[:view]} view" unless options[:feature_id]
   end
 end
 
@@ -340,6 +537,10 @@ def run_query_cli(argv)
              query.feature_view(options[:feature_id])
            when 'repo'
              query.repo_view(options[:repo_id], feature_id: options[:feature_id])
+           when 'execution-order'
+             query.execution_order_view(options[:feature_id], repo_id: options[:repo_id])
+           when 'gate-status'
+             query.gate_status_view(options[:feature_id], repo_id: options[:repo_id])
            else
              query.integration_view(options[:feature_id], repo_id: options[:repo_id])
            end

--- a/scripts/query-workspace-feature-graph.sh
+++ b/scripts/query-workspace-feature-graph.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 if [[ $# -lt 1 ]]; then
-  echo "Usage: ./scripts/query-workspace-feature-graph.sh <manifest-path> (--feature-id ID | --repo-id ID) [--view feature|repo|integration] [--format json]" >&2
+  echo "Usage: ./scripts/query-workspace-feature-graph.sh <manifest-path> (--feature-id ID | --repo-id ID) [--view feature|repo|integration|execution-order|gate-status] [--format json]" >&2
   exit 2
 fi
 

--- a/scripts/validate-workspace-manifest.rb
+++ b/scripts/validate-workspace-manifest.rb
@@ -380,6 +380,7 @@ class ManifestValidator
       validate_task_link_array(task['blocked_by_ids'], "#{task_pointer}.blocked_by_ids", task_ids, task['id']) if task.key?('blocked_by_ids')
       validate_parent_child_consistency(task, task_pointer, tasks, task_ids)
     end
+    validate_task_dependency_cycles(tasks, pointer, task_ids)
 
     task_by_id
   end
@@ -680,6 +681,59 @@ class ManifestValidator
 
       add_error("#{pointer}.child_ids", "declares child '#{child_id}' but #{child_id} does not include '#{task['id']}' in parent_ids")
     end
+  end
+
+  def validate_task_dependency_cycles(tasks, pointer, known_task_ids)
+    graph = {}
+    tasks.each_with_index do |task, index|
+      next unless task.is_a?(Hash) && task['id'].is_a?(String)
+
+      task_pointer = "#{pointer}[#{index}]"
+      dependencies = extract_dependency_ids(task).select { |dependency_id| known_task_ids.key?(dependency_id) }
+      graph[task['id']] = { dependencies: dependencies, pointer: task_pointer }
+    end
+
+    color_by_task_id = Hash.new(:white)
+    stack = []
+    cycle = nil
+
+    dfs_visit = lambda do |task_id|
+      return if cycle
+
+      color_by_task_id[task_id] = :gray
+      stack << task_id
+
+      graph.fetch(task_id, { dependencies: [] })[:dependencies].each do |dependency_id|
+        case color_by_task_id[dependency_id]
+        when :white
+          dfs_visit.call(dependency_id)
+        when :gray
+          start_index = stack.index(dependency_id)
+          cycle = stack[start_index..] + [dependency_id]
+          return
+        end
+        return if cycle
+      end
+
+      stack.pop
+      color_by_task_id[task_id] = :black
+    end
+
+    graph.keys.sort.each do |task_id|
+      next unless color_by_task_id[task_id] == :white
+
+      dfs_visit.call(task_id)
+      break if cycle
+    end
+
+    return unless cycle
+
+    cycle_path = cycle.join(' -> ')
+    add_error(pointer, "contains dependency cycle in feature task graph: #{cycle_path}")
+  end
+
+  def extract_dependency_ids(task)
+    (Array(task['blocked_by_ids']) + Array(task['parent_ids'])).uniq.sort
   end
 
   def validate_work_item_id(value, pointer, field_name:)

--- a/tests/fixtures/workspace-manifests/invalid/feature-task-dependency-cycle.yaml
+++ b/tests/fixtures/workspace-manifests/invalid/feature-task-dependency-cycle.yaml
@@ -1,0 +1,36 @@
+schema_version: 1
+workspace_id: orbit
+repos:
+  - id: api
+    remote: git@github.com:example/api.git
+    default_branch: main
+    role: backend
+    build_system: bundler
+    issue_backend:
+      type: repo_issues
+      repo: example/api
+features:
+  - feature_id: cyclic-rollout
+    title: Cyclic rollout
+    tasks:
+      - id: task-a
+        feature_id: cyclic-rollout
+        repo_id: api
+        title: Task A
+        status: todo
+        blocked_by_ids:
+          - task-c
+      - id: task-b
+        feature_id: cyclic-rollout
+        repo_id: api
+        title: Task B
+        status: todo
+        blocked_by_ids:
+          - task-a
+      - id: task-c
+        feature_id: cyclic-rollout
+        repo_id: api
+        title: Task C
+        status: todo
+        blocked_by_ids:
+          - task-b

--- a/tests/fixtures/workspace-manifests/valid/feature-graph-multi-repo.yaml
+++ b/tests/fixtures/workspace-manifests/valid/feature-graph-multi-repo.yaml
@@ -113,3 +113,17 @@ features:
           - infra-gates
         blocked_by_ids:
           - infra-gates
+      - id: ops-signoff
+        feature_id: rollout-bridge
+        repo_id: infra
+        title: Confirm rollout signoff
+        status: todo
+        blocked_by_ids:
+          - api-prepare
+      - id: web-smoke
+        feature_id: rollout-bridge
+        repo_id: web
+        title: Smoke test web flow
+        status: todo
+        blocked_by_ids:
+          - web-release

--- a/tests/test-workspace-feature-graph-query.sh
+++ b/tests/test-workspace-feature-graph-query.sh
@@ -8,29 +8,39 @@ FIXTURE="$ROOT_DIR/tests/fixtures/workspace-manifests/valid/feature-graph-multi-
 feature_json="$(mktemp)"
 repo_json="$(mktemp)"
 integration_json="$(mktemp)"
-trap 'rm -f "$feature_json" "$repo_json" "$integration_json"' EXIT
+execution_order_json="$(mktemp)"
+gate_status_json="$(mktemp)"
+trap 'rm -f "$feature_json" "$repo_json" "$integration_json" "$execution_order_json" "$gate_status_json"' EXIT
 
 "$QUERY" "$FIXTURE" --feature-id rollout-bridge >"$feature_json"
 "$QUERY" "$FIXTURE" --view repo --repo-id web --feature-id rollout-bridge >"$repo_json"
 "$QUERY" "$FIXTURE" --view integration --feature-id rollout-bridge >"$integration_json"
+"$QUERY" "$FIXTURE" --view execution-order --feature-id rollout-bridge >"$execution_order_json"
+"$QUERY" "$FIXTURE" --view gate-status --feature-id rollout-bridge >"$gate_status_json"
 
 ruby -rjson -e '
   feature = JSON.parse(File.read(ARGV[0]))
   repo = JSON.parse(File.read(ARGV[1]))
   integration = JSON.parse(File.read(ARGV[2]))
+  execution_order = JSON.parse(File.read(ARGV[3]))
+  gate_status = JSON.parse(File.read(ARGV[4]))
 
   raise "expected feature view" unless feature["view"] == "feature"
   raise "expected feature id" unless feature["feature_id"] == "rollout-bridge"
   raise "expected blocked rollup status" unless feature.dig("rollup", "overall_status") == "blocked"
   raise "expected three repo rollups" unless feature["by_repo"].length == 3
-  raise "expected blocked blocker count" unless feature.dig("rollup", "blocking", "blocker_count") == 2
+  raise "expected blocked blocker count" unless feature.dig("rollup", "blocking", "blocker_count") == 3
+  raise "expected ready gate count" unless feature.dig("rollup", "gate_status", "state_counts", "ready") == 1
+  raise "expected waiting gate count" unless feature.dig("rollup", "gate_status", "state_counts", "waiting_on_signal") == 1
+  raise "expected execution order task count" unless feature.dig("rollup", "execution_order").length == 5
   raise "expected feature integration mapping" unless feature.dig("integration", "mapping", "github", "project", "project_id") == "PVT_kwDOXYZ123"
 
   raise "expected repo view" unless repo["view"] == "repo"
   raise "expected repo id" unless repo["repo_id"] == "web"
-  raise "expected one web task" unless repo["tasks"].length == 1
+  raise "expected two web tasks" unless repo["tasks"].length == 2
   raise "expected blocked repo rollup" unless repo.dig("rollup", "overall_status") == "blocked"
   raise "expected blocked status count" unless repo.dig("rollup", "status_counts", "blocked") == 1
+  raise "expected waiting gate for repo rollup" unless repo.dig("rollup", "gate_status", "state_counts", "waiting_on_signal") == 1
   raise "expected expected_issue_repo in repo integration view" unless repo.dig("integration", "expected_issue_repo") == "example/web"
 
   raise "expected integration view" unless integration["view"] == "integration"
@@ -38,6 +48,22 @@ ruby -rjson -e '
   raise "expected integration dedupe keys" unless integration.dig("rollup", "sync", "dedupe_keys").length == 2
   raise "expected per-repo integration rollups" unless integration["by_repo"].length == 3
   raise "expected integration task mapping payload" unless integration["tasks"].any? { |item| item["id"] == "api-prepare" && item.dig("mapping", "github", "issue", "number") == 101 }
-' "$feature_json" "$repo_json" "$integration_json"
+
+  raise "expected execution-order view" unless execution_order["view"] == "execution-order"
+  raise "expected no dependency cycles" unless execution_order.dig("dependency_graph", "has_cycles") == false
+  expected_order = ["api-prepare", "infra-gates", "ops-signoff", "web-release", "web-smoke"]
+  actual_order = execution_order["execution_order"].map { |item| item["task_id"] }
+  raise "expected deterministic task order" unless actual_order == expected_order
+
+  raise "expected gate-status view" unless gate_status["view"] == "gate-status"
+  raise "expected ready task id" unless gate_status.dig("gate_status", "ready_task_ids") == ["ops-signoff"]
+  raise "expected blocked state count" unless gate_status.dig("gate_status", "state_counts", "blocked") == 1
+  raise "expected running state count" unless gate_status.dig("gate_status", "state_counts", "running") == 1
+  raise "expected waiting state count" unless gate_status.dig("gate_status", "state_counts", "waiting_on_signal") == 1
+  web_smoke = gate_status["tasks"].find { |item| item["task_id"] == "web-smoke" }
+  raise "expected web-smoke task in gate status output" unless web_smoke
+  raise "expected web-smoke waiting gate state" unless web_smoke["gate_state"] == "waiting_on_signal"
+  raise "expected web-smoke blocking dependency" unless web_smoke["blockers"].any? { |entry| entry["blocking_task_id"] == "web-release" }
+' "$feature_json" "$repo_json" "$integration_json" "$execution_order_json" "$gate_status_json"
 
 echo "Workspace feature graph query tests: passed"


### PR DESCRIPTION
## Summary
- adds deterministic cross-repo dependency gate evaluation for federated feature task graphs
- adds deterministic execution ordering (topological with stable tie-breakers) and explicit gate-state rollups
- extends query CLI/API with new views: `execution-order` and `gate-status`
- keeps existing `feature`/`repo`/`integration` views backward compatible while adding additive fields (`gate_status`, `dependency_graph`, `execution_order`)
- adds validation for dependency cycles in task graphs to keep orchestration deterministic
- updates docs and fixtures/tests for the new behavior

## Scope Guard
- implements only Issue #89 orchestration gate/order behavior
- does not start runtime policy plugin work (#90) or docs-only epic closeout work (#91)

## Assumptions
- dependency edges for execution ordering come from `blocked_by_ids` and `parent_ids`
- deterministic ordering tie-breaker for equal dependency depth is task id ascending
- gate status `satisfied` is used for terminal task statuses (`done`, `cancelled`) so readiness counts remain explicit without changing the existing task status contract

## Testing
- `tests/test-workspace-manifest-validation.sh`
- `tests/test-workspace-feature-graph-query.sh`

Closes #89


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added two new query view modes (`execution-order` and `gate-status`) to analyze task execution order and gate readiness status
  * Added dependency cycle detection for workspace manifests with validation error reporting

* **Documentation**
  * Updated CLI help text and specification with examples of the new query view modes
  * Added details on execution-order and gate-status output formats

* **Tests**
  * Extended test coverage for new query views and cycle detection validation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->