### PR TITLE
Docs: federated multi-repo mode for cross-language programs (#91)

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ Supported install targets include:
 Superagents supports a federated workspace contract for coordinating multiple repositories across different language/toolchain stacks, plus an optional cross-repo feature graph for shared delivery work.
 
 - Spec: [docs/federated-workspace-manifest-spec.md](docs/federated-workspace-manifest-spec.md)
+- Operator guide (decision + walkthrough + migration): [docs/federated-multi-repo-cross-language-guide.md](docs/federated-multi-repo-cross-language-guide.md)
 - Schema: [docs/schemas/superagents.workspace.schema.json](docs/schemas/superagents.workspace.schema.json)
 - Example: [docs/examples/workspace-manifests/superagents.workspace.yaml](docs/examples/workspace-manifests/superagents.workspace.yaml)
 

--- a/docs/federated-multi-repo-cross-language-guide.md
+++ b/docs/federated-multi-repo-cross-language-guide.md
@@ -1,0 +1,181 @@
+# Federated Multi-Repo Cross-Language Guide
+
+This guide covers the operator workflow for federated multi-repo mode delivered by issues [#86](https://github.com/peakweb-team/pw-agency-agents/issues/86), [#87](https://github.com/peakweb-team/pw-agency-agents/issues/87), [#88](https://github.com/peakweb-team/pw-agency-agents/issues/88), [#89](https://github.com/peakweb-team/pw-agency-agents/issues/89), and [#90](https://github.com/peakweb-team/pw-agency-agents/issues/90).
+
+It is intended for programs that span heterogeneous repositories (for example Solidity + Terraform + TypeScript + Kotlin) while preserving repo-local ownership.
+
+## 1) Decision Guide: Federated Mode vs Turborepo-Style Single Repo
+
+Use this quick decision matrix:
+
+| Program shape | Preferred mode | Why |
+| --- | --- | --- |
+| One JavaScript/TypeScript repository with many packages and one CI policy | Turborepo-style single-repo orchestration | Package graph and workspace dependency management are primary concerns. |
+| Multiple repositories with different languages, runtimes, and build systems | Federated multi-repo mode | Control plane is workspace-level while execution remains repo-local. |
+| Shared feature delivery where each repo must keep its own issue tracking and release policy | Federated multi-repo mode | `feature_id` links cross-repo work without collapsing ownership boundaries. |
+
+Federated mode is explicitly not a replacement for Turborepo/Nx package orchestration inside a single Node.js repository.
+
+## 2) Clean Workspace Setup (Reproducible)
+
+From a clean workspace root:
+
+```bash
+mkdir -p /tmp/superagents-federated-demo
+cd /tmp/superagents-federated-demo
+
+# Bring in a starter manifest and adapt repo remotes/paths for your org.
+cp /path/to/pw-agency-agents/docs/examples/workspace-manifests/superagents.workspace.yaml ./superagents.workspace.yaml
+
+# Validate manifest contract before orchestration.
+/path/to/pw-agency-agents/scripts/validate-workspace-manifest.sh ./superagents.workspace.yaml
+```
+
+Expected behavior:
+
+- Validation exits `0` and prints one success line per manifest path.
+- Failures include deterministic field pointers (for example `$.repos[1].issue_backend.project_id`).
+
+## 3) End-To-End Walkthrough: One Feature Across Infra + Backend + Web/Mobile
+
+The shipped fixture `tests/fixtures/workspace-manifests/valid/feature-graph-multi-repo.yaml` models one feature (`rollout-bridge`) spanning backend, infra, and web repositories with cross-repo dependency links.
+
+### 3.1 Feature Rollup Query
+
+```bash
+./scripts/query-workspace-feature-graph.sh \
+  tests/fixtures/workspace-manifests/valid/feature-graph-multi-repo.yaml \
+  --feature-id rollout-bridge
+```
+
+Expected JSON contract highlights:
+
+- `view: "feature"`
+- `feature_id: "rollout-bridge"`
+- `rollup.overall_status` and `rollup.progress_pct`
+- `rollup.blocking` with blocker ids/reasons
+- `rollup.execution_order` with deterministic `sequence` and `wave`
+- `rollup.gate_status` counts (`blocked`, `ready`, `running`, `waiting_on_signal`, `satisfied`)
+- `by_repo[]` rollups for each participating repo
+
+### 3.2 Repo Ownership View
+
+```bash
+./scripts/query-workspace-feature-graph.sh \
+  tests/fixtures/workspace-manifests/valid/feature-graph-multi-repo.yaml \
+  --view repo --repo-id web --feature-id rollout-bridge
+```
+
+Use this view for repo-local planning while keeping feature context:
+
+- returns only `web` tasks
+- retains cross-repo gate/dependency evaluation from the full feature graph
+- includes repo integration expectations (for example `integration.expected_issue_repo`)
+
+### 3.3 GitHub Mapping View (Issues + Project Rollup)
+
+```bash
+./scripts/query-workspace-feature-graph.sh \
+  tests/fixtures/workspace-manifests/valid/feature-graph-multi-repo.yaml \
+  --view integration --feature-id rollout-bridge
+```
+
+This view is the source of truth for:
+
+- feature-level project rollup mapping (`feature_mapping.github.project`)
+- child issue linkage (`feature_mapping.github.child_issue_links`)
+- task-level issue/PR/project item mappings (`tasks[].mapping.github`)
+- retry-safe sync metadata (`rollup.sync.dedupe_keys`)
+
+### 3.4 Dependency Gates and Deterministic Execution Ordering
+
+Execution order:
+
+```bash
+./scripts/query-workspace-feature-graph.sh \
+  tests/fixtures/workspace-manifests/valid/feature-graph-multi-repo.yaml \
+  --view execution-order --feature-id rollout-bridge
+```
+
+Gate status:
+
+```bash
+./scripts/query-workspace-feature-graph.sh \
+  tests/fixtures/workspace-manifests/valid/feature-graph-multi-repo.yaml \
+  --view gate-status --feature-id rollout-bridge
+```
+
+Operator rule:
+
+- run tasks in `execution_order` sequence/wave order
+- only dispatch tasks whose gate state is `ready`
+- treat `blocked` and `waiting_on_signal` as non-dispatchable until blockers clear
+
+### 3.5 Per-Repo Policy Plugin Resolution (Heterogeneous Toolchains)
+
+```bash
+./scripts/query-workspace-feature-graph.sh \
+  tests/fixtures/workspace-manifests/valid/policy-plugins-heterogeneous.yaml \
+  --view policy --feature-id policy-rollout
+```
+
+Policy view guarantees:
+
+- resolution order is deterministic: first supported `policy_refs` entry, then toolchain fallback, then default plugin
+- phase contract is stable: `preflight` -> `build` -> `test` -> `publish`
+- violations are isolated to owning repo/task
+
+## 4) Operational Playbook
+
+### 4.1 Issue Routing
+
+1. Set `repos[].issue_backend` per repo (`repo_issues`, `github_project`, `external_tracker`, or `none`).
+2. For GitHub issue-backed repos, set the canonical repo in `issue_backend.repo`.
+3. Populate `features[].tasks[].integration.github.issue` for created/linked issues.
+4. Use integration view to audit mapping coverage and dedupe keys before retrying sync.
+
+### 4.2 Project Rollups
+
+1. Set `features[].integration.github.project` for the feature rollup target.
+2. Track explicit feature-to-child issue links in `child_issue_links`.
+3. Re-run integration view after sync attempts; treat `sync.status: error|partial` as actionable.
+
+### 4.3 Dependency Gates
+
+1. Declare dependency edges via `parent_ids`, `child_ids`, and `blocked_by_ids`.
+2. Use `--view gate-status` to identify `ready_task_ids` for dispatch.
+3. Use `--view execution-order` to preserve deterministic order when multiple tasks become ready.
+4. After status changes, re-run queries instead of manually inferring graph state.
+
+## 5) Migration and Backward Compatibility
+
+Federated support is additive and preserves existing repo-centric workflows.
+
+- Existing repositories can remain repo-local with no `features` block.
+- Existing issue routing remains valid (`repo_issues`, external tracker mappings, or `none`).
+- Feature graph/query views are optional until a workspace adds `features`.
+- Mixed adoption is supported: one workspace can onboard only selected repos/features first.
+- No single language or build system is required; orchestration remains toolchain-agnostic.
+
+Recommended migration path:
+
+1. Start with `schema_version: 1`, `workspace_id`, and `repos` only.
+2. Validate with `validate-workspace-manifest.sh` until clean.
+3. Add one `feature_id` with a minimal task graph and verify `feature`, `repo`, and `integration` views.
+4. Add dependency gates and confirm `gate-status` + `execution-order` behavior.
+5. Add `policy_refs` per repo as needed and verify `policy` output.
+
+## 6) API/CLI Contract Notes
+
+`query-workspace-feature-graph.sh` is the CLI entrypoint for the same deterministic JSON contract consumed by automation.
+
+Stable view names:
+
+- `feature`
+- `repo`
+- `integration`
+- `execution-order`
+- `gate-status`
+- `policy`
+
+All views include `api_version: 1` and `workspace_id` for explicit contract/version handling.

--- a/docs/federated-workspace-manifest-spec.md
+++ b/docs/federated-workspace-manifest-spec.md
@@ -8,6 +8,10 @@ The goal is to coordinate multiple repositories under one workspace-level contro
 
 This is explicitly **not** a Turborepo/Nx single-stack package-graph format.
 
+For operator-focused usage guidance (decision framework, end-to-end walkthrough, issue/project routing playbook, dependency gate operations, and migration/backward-compatibility notes), see:
+
+- `docs/federated-multi-repo-cross-language-guide.md`
+
 ## Manifest File Name
 
 Workspace manifests should be stored at the workspace root as:

--- a/tests/test-federated-cross-language-docs.sh
+++ b/tests/test-federated-cross-language-docs.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+VALIDATOR="$ROOT_DIR/scripts/validate-workspace-manifest.sh"
+QUERY="$ROOT_DIR/scripts/query-workspace-feature-graph.sh"
+MANIFEST_FIXTURE="$ROOT_DIR/tests/fixtures/workspace-manifests/valid/federated-triple-stack.yaml"
+FEATURE_FIXTURE="$ROOT_DIR/tests/fixtures/workspace-manifests/valid/feature-graph-multi-repo.yaml"
+POLICY_FIXTURE="$ROOT_DIR/tests/fixtures/workspace-manifests/valid/policy-plugins-heterogeneous.yaml"
+
+feature_json="$(mktemp)"
+repo_json="$(mktemp)"
+integration_json="$(mktemp)"
+execution_json="$(mktemp)"
+gate_json="$(mktemp)"
+policy_json="$(mktemp)"
+trap 'rm -f "$feature_json" "$repo_json" "$integration_json" "$execution_json" "$gate_json" "$policy_json"' EXIT
+
+"$VALIDATOR" "$MANIFEST_FIXTURE" >/dev/null
+
+"$QUERY" "$FEATURE_FIXTURE" --feature-id rollout-bridge >"$feature_json"
+"$QUERY" "$FEATURE_FIXTURE" --view repo --repo-id web --feature-id rollout-bridge >"$repo_json"
+"$QUERY" "$FEATURE_FIXTURE" --view integration --feature-id rollout-bridge >"$integration_json"
+"$QUERY" "$FEATURE_FIXTURE" --view execution-order --feature-id rollout-bridge >"$execution_json"
+"$QUERY" "$FEATURE_FIXTURE" --view gate-status --feature-id rollout-bridge >"$gate_json"
+"$QUERY" "$POLICY_FIXTURE" --view policy --feature-id policy-rollout >"$policy_json"
+
+ruby -rjson -e '
+  feature = JSON.parse(File.read(ARGV[0]))
+  repo = JSON.parse(File.read(ARGV[1]))
+  integration = JSON.parse(File.read(ARGV[2]))
+  execution = JSON.parse(File.read(ARGV[3]))
+  gate = JSON.parse(File.read(ARGV[4]))
+  policy = JSON.parse(File.read(ARGV[5]))
+
+  [feature, repo, integration, execution, gate, policy].each do |payload|
+    raise "expected api_version 1" unless payload["api_version"] == 1
+    raise "expected workspace_id" unless payload["workspace_id"].is_a?(String) && !payload["workspace_id"].empty?
+  end
+
+  raise "expected feature view" unless feature["view"] == "feature"
+  raise "expected rollout-bridge feature" unless feature["feature_id"] == "rollout-bridge"
+  raise "expected by_repo rollups" unless feature["by_repo"].is_a?(Array) && feature["by_repo"].length == 3
+  raise "expected execution order in feature rollup" unless feature.dig("rollup", "execution_order").is_a?(Array)
+  raise "expected gate-status rollup in feature view" unless feature.dig("rollup", "gate_status", "state_counts").is_a?(Hash)
+
+  raise "expected repo view" unless repo["view"] == "repo"
+  raise "expected web repo id" unless repo["repo_id"] == "web"
+  raise "expected expected_issue_repo" unless repo.dig("integration", "expected_issue_repo") == "example/web"
+
+  raise "expected integration view" unless integration["view"] == "integration"
+  raise "expected integration project mapping" unless integration.dig("feature_mapping", "github", "project", "project_id") == "PVT_kwDOXYZ123"
+  raise "expected child issue links" unless integration.dig("feature_mapping", "github", "child_issue_links").is_a?(Array)
+  raise "expected sync dedupe keys" unless integration.dig("rollup", "sync", "dedupe_keys").is_a?(Array)
+
+  raise "expected execution-order view" unless execution["view"] == "execution-order"
+  expected_order = ["api-prepare", "infra-gates", "ops-signoff", "web-release", "web-smoke"]
+  actual_order = execution.fetch("execution_order").map { |row| row.fetch("task_id") }
+  raise "expected deterministic execution order" unless actual_order == expected_order
+
+  raise "expected gate-status view" unless gate["view"] == "gate-status"
+  raise "expected ready task ids" unless gate.dig("gate_status", "ready_task_ids") == ["ops-signoff"]
+  raise "expected waiting_on_signal count" unless gate.dig("gate_status", "state_counts", "waiting_on_signal") == 1
+
+  raise "expected policy view" unless policy["view"] == "policy"
+  raise "expected two repos in policy view" unless policy.fetch("repos").length == 2
+  raise "expected deterministic policy repo ordering" unless policy.fetch("repos").map { |row| row.fetch("repo_id") } == ["infra", "web"]
+  web_repo = policy.fetch("repos").find { |row| row.fetch("repo_id") == "web" }
+  raise "expected node plugin resolution" unless web_repo.dig("resolution", "plugin_id") == "policy://node/pnpm-v1"
+' "$feature_json" "$repo_json" "$integration_json" "$execution_json" "$gate_json" "$policy_json"
+
+echo "Federated cross-language docs validation: passed"


### PR DESCRIPTION
## Summary
Implements issue #91 with docs-only scope for federated multi-repo mode across heterogeneous toolchains.

### What changed
- Added a new operator guide for federated cross-language programs:
  - decision guide: federated mode vs Turborepo-style single-repo setups
  - clean-workspace reproducible setup steps
  - end-to-end walkthrough for infra + backend/protocol + web/mobile flows
  - operational playbook for issue routing, project rollups, and dependency gates
  - migration/backward-compatibility guidance
- Linked the new guide from existing federated docs entry points in `README.md` and `docs/federated-workspace-manifest-spec.md`.
- Added docs validation test coverage to keep examples deterministic and aligned with current CLI output contracts.

## Assumptions
- #91 is docs-focused and should not introduce new runtime behavior beyond shipped contracts from #86/#87/#88/#89/#90.
- Query/API examples should reference existing fixtures and currently shipped view contracts (`feature`, `repo`, `integration`, `execution-order`, `gate-status`, `policy`).

## Validation
- `./tests/test-workspace-manifest-validation.sh`
- `./tests/test-workspace-feature-graph-query.sh`
- `./tests/test-federated-cross-language-docs.sh`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive operator guide for federated multi-repo workspace management, covering setup, validation, querying, dependency gates, and migration strategies
  * Added cross-reference links in existing specifications directing users to the new guide

* **Tests**
  * Added validation tests for federated workspace configurations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->