### PR TITLE
Add GitHub Projects provider fragment for cross-repo tracking

### DIFF
--- a/docs/builder-inventory-workflow.md
+++ b/docs/builder-inventory-workflow.md
@@ -74,9 +74,11 @@ Example normalized signals:
 - `input.direct_brief`
 - `input.batch_planning_object`
 - `forge.github`
+- `task_tracker.github_projects`
 - `task_tracker.github_issues`
 - `task_tracker.jira`
 - `repo.monorepo`
+- `repo.no_individual_repo_issues`
 - `workflow.pull_requests`
 - `workflow.parallel_agents`
 - `workflow.sprint_kickoff_planning`
@@ -211,6 +213,7 @@ These drive provider-fragment selection when the generated skill should integrat
 
 Common signals:
 
+- `task_tracker.github_projects`
 - `task_tracker.github_issues`
 - `task_tracker.jira`
 - `task_tracker.linear`
@@ -252,6 +255,7 @@ These affect runtime and orchestration guidance.
 Common signals:
 
 - `repo.monorepo`
+- `repo.no_individual_repo_issues`
 - `repo.large`
 - `repo.multi_package`
 - `repo.multi_language`
@@ -345,6 +349,7 @@ Use `high` when the repository provides direct or converging evidence that clear
 
 Examples:
 
+- an org-level GitHub Project workflow with no repo-local issue references supports `task_tracker.github_projects` and `repo.no_individual_repo_issues`
 - a GitHub remote plus `.github/` workflows plus issue references in PR templates support `forge.github` and likely `task_tracker.github_issues`
 - repeated Jira ticket keys in docs and branch conventions support `task_tracker.jira`
 - a root workspace manifest plus multiple app/package directories support `repo.monorepo`
@@ -493,14 +498,15 @@ inventory:
       conflicts_with: []
       assumption: The repository looks delivery-oriented, but no authoritative tracker was detected, so direct-brief intake remains available.
     primary_task_tracker:
-      value: github-issues
+      value: github-projects
       confidence: medium
       supported_by:
         - forge.github
-        - workflow.pull_requests
-        - repo.references_issue_numbers
+        - repo.monorepo
+        - repo.no_individual_repo_issues
+        - task_tracker.github_projects
       conflicts_with: []
-      assumption: GitHub Issues appears primary, but no explicit issue-policy doc was found.
+      assumption: The repository appears to run org-level planning in GitHub Projects with no strong per-repo issue authority signal.
     review_path:
       value: human-pr-review
       confidence: high
@@ -513,8 +519,8 @@ inventory:
       prompt: Should the generated skill start from tracked tasks, direct briefs, or both?
       why: The repository shows delivery workflow signals, but does not make the intake mode explicit.
     - id: task-tracker-authority
-      prompt: Is GitHub Issues the primary tracker, or is another system authoritative?
-      why: The repository shows GitHub delivery flow, but issue authority is not explicit.
+      prompt: Is GitHub Projects, GitHub Issues, or another tracker authoritative for task intake and status updates?
+      why: The repository shows GitHub delivery flow, but authoritative tracker policy is not explicit.
 ```
 
 The exact serialization can evolve, but the content should remain stable.
@@ -534,16 +540,18 @@ Below is a sample Markdown-form inventory summary suitable for an MVP builder ha
   - source: `.github/PULL_REQUEST_TEMPLATE.md`
 - `repo.monorepo` — high confidence
   - source: root workspace manifest and multiple package directories
+- `repo.no_individual_repo_issues` — medium confidence
+  - source: contribution and workflow docs point to org-level project boards instead of per-repo issue intake
 - `workflow.model_budget_matters` — medium confidence
   - source: monorepo shape and multiple specialist-oriented workflow docs
-- `task_tracker.github_issues` — medium confidence
-  - source: issue-number references in docs and PR flow, but no explicit task-policy file
+- `task_tracker.github_projects` — medium confidence
+  - source: project-board-oriented workflow language and cross-repo intake conventions
 
 ### Inferred Decisions
 
 - Primary forge: GitHub (`high`)
 - Work intake mode: both tracked-task and direct-brief (`medium`)
-- Primary task tracker: GitHub Issues (`medium`)
+- Primary task tracker: GitHub Projects (`medium`)
 - Delivery model: PR-based review (`high`)
 - Team sizing guidance needed: yes (`high`)
 - Runtime/model-routing guidance needed: yes (`high`)
@@ -551,13 +559,13 @@ Below is a sample Markdown-form inventory summary suitable for an MVP builder ha
 ### Assumptions
 
 - Direct-brief intake remains available because no authoritative tracker policy was found.
-- GitHub Issues is assumed to be the primary tracker until contradicted.
+- GitHub Projects is assumed primary because monorepo and no-individual-issues signals were detected.
 - No review automation provider is assumed because none was directly detected.
 
 ### Follow-Up Questions
 
 - Confirm whether the generated skill should start from tracked tasks, direct briefs, or both.
-- Confirm whether GitHub Issues is the authoritative tracker or just a mirror for another system.
+- Confirm whether GitHub Projects is authoritative, or if per-repo Issues/Jira should be treated as the source of truth.
 ```
 
 ## Recommended Priority Order For Inventory

--- a/docs/builder-questionnaire-flow.md
+++ b/docs/builder-questionnaire-flow.md
@@ -406,7 +406,7 @@ unresolved_decisions:
     safe_to_proceed: false
   - id: task-tracker-authority
     topic: primary task tracker for tracked-task intake
-    why_unresolved: GitHub Issues and Jira are both referenced, but authority is not explicit.
+    why_unresolved: GitHub Projects, GitHub Issues, and Jira are all referenced, but authority is not explicit.
     impact: high
     recommended_question: Which system should the builder treat as authoritative for task intake and status updates?
     safe_to_proceed: false
@@ -461,7 +461,7 @@ decisions:
     value: null
     confidence: low
     source: conflicting-evidence
-    why_unresolved: GitHub Issues and Jira both appear active, but neither is clearly primary.
+    why_unresolved: GitHub Projects, GitHub Issues, and Jira all appear active, but none is clearly primary.
 questions:
   - id: primary-task-tracker
     status: pending
@@ -470,7 +470,7 @@ questions:
 unresolved_decisions:
   - id: task-tracker-authority
     topic: primary task tracker for tracked-task intake
-    why_unresolved: GitHub Issues and Jira both appear active, but authority is unclear.
+    why_unresolved: GitHub Projects, GitHub Issues, and Jira all appear active, but authority is unclear.
     impact: high
     recommended_question: Which system should the builder treat as authoritative?
     safe_to_proceed: false

--- a/docs/task-system-provider-fragment-set.md
+++ b/docs/task-system-provider-fragment-set.md
@@ -25,6 +25,7 @@ This keeps task-system behavior capability-oriented and avoids mixing provider d
 
 This document defines task-system provider fragments for:
 
+- GitHub Projects
 - GitHub Issues
 - Jira
 
@@ -69,14 +70,27 @@ No repository should be forced to use an external task tracker as a precondition
 
 | Fragment id | Provider | Fragment type | Layer | Canonical capabilities | Primary role |
 | --- | --- | --- | --- | --- | --- |
+| `project-management/github-projects` | GitHub Projects | `provider` | `project-management` | `task-tracker.read`, `task-tracker.update` | Read project items for org-level and cross-repo workflows, then post durable status updates through GitHub Projects item fields. |
 | `project-management/github-issues` | GitHub Issues | `provider` | `project-management` | `task-tracker.lookup`, `task-tracker.read`, `task-tracker.create`, `task-tracker.update` | Resolve issue references, read issue context, create spec-backed implementation issues, and post durable status updates in GitHub Issues. |
 | `project-management/jira` | Jira | `provider` | `project-management` | `task-tracker.lookup`, `task-tracker.read`, `task-tracker.create`, `task-tracker.update` | Resolve Jira keys/URLs, read Jira ticket context, create spec-backed implementation tickets, and post durable status updates in Jira. |
 
-Both fragments should use `composition.exclusive_within: primary-task-tracker` so assembly chooses at most one tracker-of-record path.
+All tracker fragments should use `composition.exclusive_within: primary-task-tracker` so assembly chooses at most one tracker-of-record path.
 
-Both fragments may suggest direct-brief and assumption-capture fragments for dual-intake compatibility, but they should not require tracker-only intake.
+Tracker fragments may suggest direct-brief and assumption-capture fragments for dual-intake compatibility, but they should not require tracker-only intake.
 
 ## Provider Responsibilities By Capability
+
+### GitHub Projects Fragment Responsibilities
+
+- `task-tracker.read`
+  - Read project item title/body/status context, including linked issue details when present.
+  - Support both linked-issue items and draft items with explicit branching behavior.
+  - Parse canonical cross-repo shape (`## Repos` plus `## Acceptance Criteria`) into repo-scoped implementation specs when present.
+- `task-tracker.update`
+  - Discover field IDs and option IDs at runtime before status writes.
+  - Use `gh project field-list <N> --owner <org> --format json` before `gh project item-edit`.
+  - Never hardcode, persist, or reuse GitHub Projects node IDs across sessions.
+  - If metadata lookup fails, continue implementation and provide exact manual status-update commands to the operator.
 
 ### GitHub Issues Fragment Responsibilities
 
@@ -191,7 +205,9 @@ capability_bindings:
 Inventory and questionnaire phases should keep these behaviors consistent with existing contracts:
 
 - infer candidate tracker fragments from repository/task-reference signals
-- ask follow-up questions when both GitHub Issues and Jira are plausible primary trackers
+- include `task_tracker.github_projects` and `repo.no_individual_repo_issues` as first-class selection signals
+- prefer GitHub Projects over GitHub Issues when both are plausible and `repo.monorepo` plus `repo.no_individual_repo_issues` are present
+- ask follow-up questions when GitHub Projects, GitHub Issues, and Jira are all plausible primary trackers
 - preserve unresolved state instead of forcing a tracker winner when source-of-truth is unclear
 - keep direct-brief path available when selected, even if a tracker fragment is also selected
 

--- a/skills/fragments/orchestration/team-sizing.md
+++ b/skills/fragments/orchestration/team-sizing.md
@@ -19,6 +19,7 @@ composition:
   requires: []
   suggests:
     - project-management/github-issues
+    - project-management/github-projects
     - project-management/jira
     - delivery/pull-request-review
     - runtime/context-and-model-routing

--- a/skills/fragments/project-management/github-issues.md
+++ b/skills/fragments/project-management/github-issues.md
@@ -15,7 +15,8 @@ selection:
     - task_tracker.github_issues
     - repo.references_issue_numbers
   evidence_all: []
-  evidence_none: []
+  evidence_none:
+    - repo.no_individual_repo_issues
   requires_confirmation:
     - forge.github_without_confirmed_issue_workflow
   preference: 85
@@ -25,6 +26,7 @@ composition:
     - orchestration/team-sizing
     - delivery/pull-request-review
   conflicts:
+    - project-management/github-projects
     - project-management/jira
   exclusive_within:
     - primary-task-tracker
@@ -57,4 +59,5 @@ Use GitHub Issues as the tracked-task system of record when the project manages 
 
 - Pair well with `orchestration/team-sizing.md`.
 - Pair well with `delivery/pull-request-review.md`.
+- Exclude this fragment when repo evidence indicates GitHub Projects is authoritative and per-repo issue workflow is not.
 - If GitHub is present but issues are not authoritative, omit this fragment and prefer direct-brief or lighter PR-only workflow guidance.

--- a/skills/fragments/project-management/github-projects.md
+++ b/skills/fragments/project-management/github-projects.md
@@ -1,0 +1,108 @@
+---
+schema_version: 1
+id: project-management/github-projects
+title: GitHub Projects
+fragment_type: provider
+layer: project-management
+summary: Use GitHub Projects as the tracked-task system of record for org-level and cross-repo delivery workflows.
+provider: github
+capabilities:
+  - task-tracker.read
+  - task-tracker.update
+selection:
+  evidence_any:
+    - forge.github
+    - task_tracker.github_projects
+    - repo.monorepo
+    - repo.no_individual_repo_issues
+  evidence_all: []
+  evidence_none: []
+  requires_confirmation:
+    - forge.github_without_confirmed_projects_workflow
+  preference: 88
+composition:
+  requires: []
+  suggests:
+    - orchestration/team-sizing
+    - delivery/pull-request-review
+    - runtime/context-and-model-routing
+  conflicts:
+    - project-management/github-issues
+    - project-management/jira
+  exclusive_within:
+    - primary-task-tracker
+  emits:
+    - task-intake
+    - task-status-updates
+    - cross-repo-spec
+  order: 20
+---
+
+# Fragment: GitHub Projects
+
+## Purpose
+
+Use GitHub Projects as the tracked-task system of record when the team coordinates delivery at org level or across multiple repositories.
+
+## Include When
+
+- The repository uses GitHub and delivery is tracked primarily in GitHub Projects instead of per-repo Issues.
+- Work commonly spans multiple repositories or packages with one shared planning board.
+- The team needs project-item status updates that respect dynamic field and option IDs.
+
+## Expected Behaviors
+
+### Field And Option ID Discovery Is Mandatory Before Status Writes
+
+Before any status write, discover node IDs at runtime for the specific project:
+
+1. Run `gh project field-list <N> --owner <org> --format json`.
+2. Resolve the status field id (`PVF_*`).
+3. Resolve the status option id (`PVSO_*`) for the target value.
+4. Resolve item id (`PVTI_*`) and project id (`PVT_*`) from item/project context.
+
+Do not hardcode or cross-session cache GitHub Projects node IDs.
+
+### Cross-Repo Spec Extraction
+
+When item content includes this canonical shape:
+
+- `## Repos`
+- repo-scoped bullets
+- `## Acceptance Criteria`
+
+extract one scoped implementation spec per repository before routing execution.
+
+When the shape is missing, infer scope from the item title/body and surface the inferred scope to a human reviewer before implementation starts.
+
+### Draft Item And Linked-Issue Handling
+
+- Linked issue item: read both the project item and the linked issue before planning.
+- Draft item: rely on project item title/body only and do not attempt to follow issue URLs.
+
+### Degraded Mode For Status Updates
+
+If metadata discovery fails, do not block implementation.
+
+- Surface exact commands for manual recovery:
+  - `gh project list --owner <org> --format json`
+  - `gh project item-list <N> --owner <org> --format json`
+  - `gh project field-list <N> --owner <org> --format json`
+  - `gh project item-edit --id <PVTI_*> --field-id <PVF_*> --project-id <PVT_*> --single-select-option-id <PVSO_*>`
+- Continue implementation cycle without automated status write.
+- Mark status update as degraded/manual in review metadata.
+
+## CLI Reference
+
+Use these commands as the baseline GitHub Projects workflow:
+
+- `gh project list --owner <org> --format json`
+- `gh project item-list <N> --owner <org> --format json`
+- `gh project field-list <N> --owner <org> --format json`
+- `gh project item-edit --id <PVTI_*> --field-id <PVF_*> --project-id <PVT_*> --single-select-option-id <PVSO_*>`
+- `gh project item-create <N> --owner <org> --title "<title>"`
+
+## Builder Notes
+
+- Prefer this fragment over `project-management/github-issues` when signals indicate monorepo/cross-repo delivery with no authoritative per-repo issue workflow.
+- Pair with orchestration and review fragments so cross-repo scoped specs become executable handoffs.

--- a/skills/fragments/project-management/jira.md
+++ b/skills/fragments/project-management/jira.md
@@ -26,6 +26,7 @@ composition:
     - delivery/pull-request-review
   conflicts:
     - project-management/github-issues
+    - project-management/github-projects
   exclusive_within:
     - primary-task-tracker
   emits:
@@ -56,4 +57,5 @@ Use Jira as the tracked-task source of truth when the project manages delivery t
 ## Builder Notes
 
 - Prefer this over the GitHub Issues fragment when Jira is the authoritative tracker for tracked-task intake.
+- Prefer this over the GitHub Projects fragment only when Jira, not GitHub Projects, is the authoritative source of truth.
 - If both Jira and GitHub Issues are used, define one as primary and the other as reference-only.

--- a/skills/skill-builder/SKILL.md
+++ b/skills/skill-builder/SKILL.md
@@ -48,7 +48,7 @@ Ask only the unresolved questions that materially affect skill composition. Prio
 
 - Work intake mode: direct brief, tracked task, or both
 - Spec intake shape for direct brief: single-item flow, planning-batch flow, or both
-- Project management system when tracked-task intake is in scope: GitHub Issues, Jira, Linear, or other
+- Project management system when tracked-task intake is in scope: GitHub Projects, GitHub Issues, Jira, Linear, or other
 - Review tooling: CodeRabbit, human-only review, custom CI gates
 - Whether tasks should default to solo execution or team orchestration
 - Worktree isolation strategy: `off`, `manual`, or `auto`, plus whether per-task override is allowed


### PR DESCRIPTION
## Summary
- add new provider fragment `project-management/github-projects`
- document runtime GitHub Projects ID discovery (`field-list`) as a hard prerequisite before status writes
- add draft-vs-linked-item handling and cross-repo spec extraction (`## Repos` + `## Acceptance Criteria`)
- document degraded mode for status writes when metadata lookup fails
- add builder evidence vocabulary and selection guidance for `task_tracker.github_projects` and `repo.no_individual_repo_issues`
- update existing tracker fragments/docs for primary-task-tracker exclusivity and conflicts

## Validation
- ./scripts/validate-fragments.sh
- tests/test-install-smoke.sh

Closes #99


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**Documentation**
* Added GitHub Projects as a supported task management system option for tracking and managing work
* Updated builder questionnaire and guidance to include GitHub Projects selection alongside GitHub Issues and Jira
* Clarified when GitHub Projects should be preferred based on workflow requirements (e.g., cross-repository or monorepo scenarios)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->