### PR TITLE
Add dogfooding guardrails for in-repo Superagents usage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,6 +63,12 @@ notes/
 TODO.md
 NOTES.md
 
+# Dogfooding artifacts (local-only; do not commit)
+.claude/
+.agency/
+.codex/
+.superagents-dogfood/
+
 # Generated integration files — run scripts/convert.sh to regenerate locally
 # The scripts/ and integrations/*/README.md files ARE committed; only generated
 # agent/skill files are excluded.

--- a/README.md
+++ b/README.md
@@ -202,6 +202,15 @@ Reference docs:
 
 - [Anthropic devcontainer guide](https://code.claude.com/docs/en/devcontainer)
 
+### 2c. Dogfood Superagents In This Source Repository (Optional)
+
+If you are developing Superagents and dogfooding it at the same time, use a two-workspace setup (source + sandbox) to avoid recursive edits and runtime artifact pollution.
+
+Quick reference:
+
+- [docs/dogfooding-superagents-in-source-repo.md](docs/dogfooding-superagents-in-source-repo.md)
+- Guardrail check: `./scripts/check-dogfooding-guardrails.sh`
+
 ### 3. Use Skills Day-To-Day
 
 Typical loop:
@@ -271,6 +280,7 @@ Validate locally:
 - [docs/install-packaging-skill-fragments-contract.md](docs/install-packaging-skill-fragments-contract.md)
 - [docs/runtime-context-budgeting-and-repo-reading.md](docs/runtime-context-budgeting-and-repo-reading.md)
 - [docs/isolated-devcontainer-bootstrap-workflow.md](docs/isolated-devcontainer-bootstrap-workflow.md)
+- [docs/dogfooding-superagents-in-source-repo.md](docs/dogfooding-superagents-in-source-repo.md)
 - [docs/federated-workspace-manifest-spec.md](docs/federated-workspace-manifest-spec.md)
 - [examples/generated-skills/README.md](examples/generated-skills/README.md)
 

--- a/docs/dogfooding-superagents-in-source-repo.md
+++ b/docs/dogfooding-superagents-in-source-repo.md
@@ -1,0 +1,79 @@
+# Dogfooding Superagents In Its Own Source Repo
+
+This guide defines a safe dogfooding workflow for developing Superagents while using Superagents + Claude in parallel.
+
+## Goal
+
+Allow contributors to validate real workflows without polluting the source repository or creating recursive execution loops.
+
+## Core Guardrails
+
+1. Keep one workspace for source edits and one separate workspace for agent execution.
+2. Treat generated agent artifacts as local runtime output, not source files for this repo.
+3. Keep watch/build scopes pointed at committed source paths only.
+4. Verify guardrails before and after a dogfooding run.
+
+## Recommended Two-Workspace Setup
+
+Run this from your local machine and adjust paths as needed:
+
+```bash
+# 1) Source workspace (where you edit Superagents itself)
+git clone git@github.com:peakweb-team/superagents.git ~/dev/superagents-src
+
+# 2) Sandbox workspace (where Claude executes tasks)
+git clone git@github.com:peakweb-team/superagents.git ~/dev/superagents-dogfood
+```
+
+Use the source workspace to install/update your user-level Claude bundle:
+
+```bash
+cd ~/dev/superagents-src
+./scripts/install.sh --tool claude-code --no-interactive
+```
+
+Run day-to-day Claude execution in the sandbox workspace:
+
+```bash
+cd ~/dev/superagents-dogfood
+# Activate superagents skills in Claude and run issue/task prompts here.
+```
+
+## In-Repo Dogfooding (When You Intentionally Use Source Repo Directly)
+
+If you intentionally run Claude inside the source repo, apply these rules:
+
+1. Run `./scripts/check-dogfooding-guardrails.sh` before starting.
+2. Keep active task scope explicit (single issue, explicit paths, no broad autorewrite prompts).
+3. Avoid recursive watch loops by excluding runtime folders:
+   - `.claude/`
+   - `.agency/`
+   - `.codex/`
+4. Re-run `./scripts/check-dogfooding-guardrails.sh` after the session.
+5. Before committing, inspect untracked files and only stage intentional source changes.
+
+## Do / Don't
+
+Do:
+
+- Keep source changes in tracked directories (`agents/`, `skills/`, `docs/`, `scripts/`, `tests/`).
+- Use dedicated issue branches and clean commit boundaries.
+- Run existing repo checks before opening a PR.
+
+Don't:
+
+- Commit generated runtime artifacts from `.claude/`, `.agency/`, or `.codex/`.
+- Use wildcard watch scopes that include local runtime output roots.
+- Mix long-lived dogfooding output with source history.
+
+## Validation Checklist
+
+Run:
+
+```bash
+./scripts/check-dogfooding-guardrails.sh
+./tests/test-doc-link-integrity.sh
+./tests/test-install-smoke.sh
+```
+
+Expected result: all commands exit with status `0`.

--- a/integrations/claude-code/README.md
+++ b/integrations/claude-code/README.md
@@ -50,3 +50,7 @@ Install/packaging and migration contract:
 Builder usage flow, repo-local precedence rules, and generated-skill review/versioning guidance:
 
 - [`docs/builder-usage-and-repo-local-precedence-contract.md`](../../docs/builder-usage-and-repo-local-precedence-contract.md)
+
+Dogfooding Superagents while developing this repository:
+
+- [`docs/dogfooding-superagents-in-source-repo.md`](../../docs/dogfooding-superagents-in-source-repo.md)

--- a/scripts/check-dogfooding-guardrails.sh
+++ b/scripts/check-dogfooding-guardrails.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+GITIGNORE="$ROOT_DIR/.gitignore"
+
+required_patterns=(
+  ".claude/"
+  ".agency/"
+  ".codex/"
+)
+
+for pattern in "${required_patterns[@]}"; do
+  if ! rg -qxF "$pattern" "$GITIGNORE"; then
+    echo "Missing required dogfooding ignore pattern in .gitignore: $pattern"
+    exit 1
+  fi
+done
+
+if git -C "$ROOT_DIR" ls-files -- ".claude/*" ".agency/*" ".codex/*" | rg -q "."; then
+  echo "Tracked runtime artifacts detected under .claude/, .agency/, or .codex/"
+  exit 1
+fi
+
+if ! git -C "$ROOT_DIR" check-ignore -q ".claude/skills/superagents/SKILL.md"; then
+  echo "Expected .claude/ paths to be ignored by git"
+  exit 1
+fi
+
+if ! git -C "$ROOT_DIR" check-ignore -q ".agency/skills/superagents/SKILL.md"; then
+  echo "Expected .agency/ paths to be ignored by git"
+  exit 1
+fi
+
+if ! git -C "$ROOT_DIR" check-ignore -q ".codex/sessions/runtime.log"; then
+  echo "Expected .codex/ paths to be ignored by git"
+  exit 1
+fi
+
+echo "Dogfooding guardrails check: passed"

--- a/tests/test-dogfooding-guardrails.sh
+++ b/tests/test-dogfooding-guardrails.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+"$ROOT_DIR/scripts/check-dogfooding-guardrails.sh"
+
+echo "Dogfooding guardrails tests: passed"


### PR DESCRIPTION
## Summary
- add a dedicated dogfooding guide for safe in-repo Superagents development
- add local runtime artifact ignore defaults (`.claude/`, `.agency/`, `.codex/`, `.superagents-dogfood/`)
- add a guardrail validation script and test wrapper
- link the dogfooding guidance from top-level and Claude integration docs

## Validation
- `./tests/test-dogfooding-guardrails.sh`
- `./tests/test-doc-link-integrity.sh`
- `./tests/test-install-smoke.sh`

Closes #104

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive guide for safe development workflow with improved setup recommendations.
  * Enhanced repository documentation with best practices for collaborative development.

* **Chores**
  * Updated repository configuration to exclude additional development directories.
  * Added automated checks to maintain repository integrity during development.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->