### PR TITLE
Add dogfooding guardrail checks to CI

### DIFF
--- a/.github/workflows/contract-and-pipeline-tests.yml
+++ b/.github/workflows/contract-and-pipeline-tests.yml
@@ -34,6 +34,11 @@ jobs:
           chmod +x scripts/validate-doc-links.sh tests/test-doc-link-integrity.sh
           ./tests/test-doc-link-integrity.sh
 
+      - name: Run dogfooding guardrail checks
+        run: |
+          chmod +x scripts/check-dogfooding-guardrails.sh tests/test-dogfooding-guardrails.sh
+          ./tests/test-dogfooding-guardrails.sh
+
   conversion-determinism:
     name: Conversion determinism (${{ matrix.os }})
     runs-on: ${{ matrix.os }}

--- a/scripts/check-dogfooding-guardrails.sh
+++ b/scripts/check-dogfooding-guardrails.sh
@@ -10,14 +10,31 @@ required_patterns=(
   ".codex/"
 )
 
+has_line_match() {
+  local literal="$1" file="$2"
+  if command -v rg >/dev/null 2>&1; then
+    rg -qxF "$literal" "$file"
+  else
+    grep -Fxq "$literal" "$file"
+  fi
+}
+
+has_any_output() {
+  if command -v rg >/dev/null 2>&1; then
+    rg -q "."
+  else
+    grep -q "."
+  fi
+}
+
 for pattern in "${required_patterns[@]}"; do
-  if ! rg -qxF "$pattern" "$GITIGNORE"; then
+  if ! has_line_match "$pattern" "$GITIGNORE"; then
     echo "Missing required dogfooding ignore pattern in .gitignore: $pattern"
     exit 1
   fi
 done
 
-if git -C "$ROOT_DIR" ls-files -- ".claude/*" ".agency/*" ".codex/*" | rg -q "."; then
+if git -C "$ROOT_DIR" ls-files -- ".claude/*" ".agency/*" ".codex/*" | has_any_output; then
   echo "Tracked runtime artifacts detected under .claude/, .agency/, or .codex/"
   exit 1
 fi


### PR DESCRIPTION
## Summary
- add dogfooding guardrail validation to the contract-and-pipeline CI workflow
- run `tests/test-dogfooding-guardrails.sh` as part of PR checks

## Validation
- `./tests/test-dogfooding-guardrails.sh`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Enhanced pipeline validation with an added dogfooding guardrail verification step.
  * Improved guardrail checking scripts for more portable and reliable runtime validations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->