### PR TITLE
Fix runtime-target ambiguity handling and Claude SKILL.md entrypoint contract

### DIFF
--- a/docs/builder-questionnaire-flow.md
+++ b/docs/builder-questionnaire-flow.md
@@ -151,7 +151,25 @@ The builder should ask questions in priority order, not all at once.
 
 The initial MVP questionnaire should focus on the smallest set of decisions that most strongly affect fragment selection.
 
-### Priority 1: Work Intake Mode
+### Priority 1: Runtime Target
+
+Question goal:
+
+- determine which AI runtime/platform shape the generated execution-facing output must follow
+- prevent entrypoint/path mismatches (for example a Claude run without `SKILL.md`)
+
+Ask when:
+
+- runtime signals are mixed (for example both `.claude/` and `.cursor/` assets)
+- runtime signals are weak or missing
+- existing local skill artifacts conflict with detected runtime conventions
+
+Examples:
+
+- Which runtime should this generated skill bundle target first: Claude Code, Cursor, Codex, Gemini CLI, or another platform?
+- Should this run publish Claude-compatible skill folders (`.claude/skills/superagents/<name>/SKILL.md`)?
+
+### Priority 2: Work Intake Mode
 
 Question goal:
 
@@ -173,7 +191,7 @@ Examples:
 - If both GitHub Issues and Jira are used, which one should the builder treat as the source of truth for tracked-task intake?
 - Should a greenfield repo support a direct-brief bootstrap mode even if GitHub Issues exists?
 
-### Priority 2: Review Path
+### Priority 3: Review Path
 
 Question goal:
 
@@ -189,7 +207,7 @@ Examples:
 - Should the builder assume human PR review, CodeRabbit, or a layered review path?
 - Is reviewer automation active in this repo, or are reviews human-only?
 
-### Priority 3: Orchestration Default
+### Priority 4: Orchestration Default
 
 Question goal:
 
@@ -205,7 +223,7 @@ Examples:
 - Should bounded parallel implementation default to `sub-agent` before `agent-team`?
 - Are there recurring tasks in this repo where active peer-to-peer coordination materially improves outcomes?
 
-### Priority 4: Worktree Isolation Strategy
+### Priority 5: Worktree Isolation Strategy
 
 Question goal:
 
@@ -224,7 +242,7 @@ Examples:
 - Should a task be allowed to override the repository default worktree strategy?
 - If `auto` is selected, should deterministic task worktree paths use a sibling root or a custom root?
 
-### Priority 5: Runtime / Budget Constraints
+### Priority 6: Runtime / Budget Constraints
 
 Question goal:
 
@@ -242,7 +260,7 @@ Examples:
 - Are there model, reasoning-effort, or budget constraints the builder should encode in runtime guidance?
 - Should this repo default to small-task `narrow` context budgets, or start at large-repo `medium` budgeting with package-mapping first?
 
-### Priority 6: PR And Branching Conventions
+### Priority 7: PR And Branching Conventions
 
 Question goal:
 
@@ -439,6 +457,12 @@ inventory:
         path: CONTRIBUTING.md
         detail: Jira ticket keys appear in workflow examples
 decisions:
+  runtime_target:
+    state: unresolved
+    value: null
+    confidence: low
+    source: conflicting-evidence
+    why_unresolved: Both Claude and non-Claude runtime markers appear, and output layout differs by runtime target.
   work_intake_mode:
     state: assumed
     value: both
@@ -463,11 +487,21 @@ decisions:
     source: conflicting-evidence
     why_unresolved: GitHub Projects, GitHub Issues, and Jira all appear active, but none is clearly primary.
 questions:
+  - id: runtime-target
+    status: pending
+    prompt: Which runtime should the generated bundle target first (Claude Code, Cursor, Codex, Gemini CLI, or another)?
+    why: This determines output paths and canonical entrypoint filenames.
   - id: primary-task-tracker
     status: pending
     prompt: Which system should the builder treat as the primary task tracker for tracked-task intake?
     why: This changes the generated project-management fragment.
 unresolved_decisions:
+  - id: runtime-target
+    topic: runtime target for generated skill output
+    why_unresolved: Runtime markers are mixed and the canonical entrypoint format differs by target platform.
+    impact: high
+    recommended_question: Which runtime should this generated bundle target first?
+    safe_to_proceed: false
   - id: task-tracker-authority
     topic: primary task tracker for tracked-task intake
     why_unresolved: GitHub Projects, GitHub Issues, and Jira all appear active, but authority is unclear.

--- a/docs/generated-skill-layout.md
+++ b/docs/generated-skill-layout.md
@@ -42,20 +42,40 @@ This document defines:
 - make repo-local Superagents output the authoritative layer for that repository
 - preserve enough builder metadata for review, debugging, and regeneration
 - avoid name collisions with user-authored or third-party skills
+- prevent runtime-entrypoint mismatches by requiring an explicit runtime target before assembly
+
+## Runtime Target Decision
+
+Before writing any execution-facing files, the builder should resolve and record a `runtime_target` decision in `decisions.yaml`.
+
+- if confidence is high, the builder may confirm the target from repo evidence
+- if confidence is below high and output layout would change, the builder should ask a focused follow-up question before writing files
+- if runtime target remains unresolved, do not publish execution-facing skill files
+
+For the current Claude-first MVP, the required canonical mapping is:
+
+| runtime_target | Execution root | Primary entrypoint |
+|---|---|---|
+| `claude-code` | `.claude/skills/superagents/<skill-name>/` | `SKILL.md` |
+
+Invariant for Claude mode:
+
+- do not publish the primary skill as `.claude/skills/superagents/<name>.md`
+- each generated skill folder must contain `SKILL.md`
 
 ## Output Roots
 
 The builder should write generated output under two project-local roots.
 
-### 1. Execution-Facing Skill Root
+### 1. Execution-Facing Skill Root (Claude Mode)
 
-The primary skill output root is:
+When `runtime_target` is `claude-code`, the primary skill output root is:
 
 - `.claude/skills/superagents/`
 
 This is the directory that should contain generated skills in the shape the Claude-first MVP is expected to consume directly.
 
-Each generated skill lives in its own folder under that root.
+Each generated skill lives in its own folder under that root and must contain `SKILL.md` as the runtime entrypoint.
 
 Examples:
 
@@ -222,6 +242,9 @@ Recommended decision keys:
 - `worktree_root_strategy` (optional)
   - examples: `sibling`, `custom-path`
   - purpose: explain expected path-root strategy for deterministic worktree placement
+- `runtime_target`
+  - examples: `claude-code`, `cursor`, `codex`, `gemini-cli`, `antigravity`, `other`
+  - purpose: binds generated execution-facing output paths and entrypoint filename contract
 
 Task-level override resolution should follow the precedence contract in [`docs/orchestration-execution-rubric.md`](./orchestration-execution-rubric.md).
 

--- a/skills/skill-builder/SKILL.md
+++ b/skills/skill-builder/SKILL.md
@@ -18,7 +18,8 @@ You are the Superagents skill builder. Your job is to generate project-specific 
 1. Detect as much of the project environment as possible from the repository itself.
 2. Ask only the minimum follow-up questions needed to resolve uncertainty.
 3. Choose fragment strategies that match the team's actual workflow.
-4. Generate project-local skills that are concise, versionable, and higher priority than user-level defaults.
+4. Select an explicit runtime target and emit only that runtime's canonical skill entrypoint format.
+5. Generate project-local skills that are concise, versionable, and higher priority than user-level defaults.
 
 ## Workflow
 
@@ -31,6 +32,7 @@ Inspect the repository for signals such as:
 - Monorepo/package-manager structure
 - Language, framework, test, and deployment signals
 - Existing local agent or skill files
+- Runtime and toolchain markers (for example `.claude/`, `CLAUDE.md`, `.cursor/`, `.codex/`, `.gemini/`)
 
 Normalize those findings into explicit builder signals and assign confidence to the resulting project choices. Follow the contract in `docs/builder-inventory-workflow.md`.
 
@@ -40,6 +42,8 @@ Use the resulting decisions to declare repo-local provider and capability bindin
 
 Use `docs/capability-fallback-behavior.md` to decide whether degraded capability support should continue, warn, switch to manual mode, or fail.
 
+Determine a `runtime_target` decision with confidence and evidence before assembly. Use values such as `claude-code`, `cursor`, `codex`, `gemini-cli`, `antigravity`, or `other`.
+
 Summarize what was detected and what is still unknown.
 
 ### Phase 2: Targeted Questionnaire
@@ -47,6 +51,7 @@ Summarize what was detected and what is still unknown.
 Ask only the unresolved questions that materially affect skill composition. Prioritize:
 
 - Work intake mode: direct brief, tracked task, or both
+- Runtime target and output format when repository signals are mixed or incomplete
 - Spec intake shape for direct brief: single-item flow, planning-batch flow, or both
 - Project management system when tracked-task intake is in scope: GitHub Projects, GitHub Issues, Jira, Linear, or other
 - Review tooling: CodeRabbit, human-only review, custom CI gates
@@ -57,6 +62,7 @@ Ask only the unresolved questions that materially affect skill composition. Prio
 
 If the repository already answers a question with high confidence, do not ask it again.
 If a high-impact workflow decision remains below high confidence, ask a focused follow-up question instead of guessing silently.
+Treat `runtime_target` as high impact because it determines output paths and entrypoint filenames.
 Record each resulting decision as confirmed, assumed, unresolved, or not-applicable. Follow `docs/builder-questionnaire-flow.md` for questionnaire priority and unresolved-decision handling.
 
 Be explicit about whether the generated skill should rely on direct-brief intake, tracked-task capabilities, or both.
@@ -75,7 +81,7 @@ When describing selected fragments, use the canonical capability vocabulary from
 
 ### Phase 4: Skill Assembly
 
-Generate one primary skill and any needed companion skills under `.claude/skills/superagents/`, and write builder metadata under `.agency/skills/superagents/`. Favor:
+Generate one primary skill and any needed companion skills using the selected runtime-target layout contract in `docs/generated-skill-layout.md`, and write builder metadata under `.agency/skills/superagents/`. Favor:
 
 - one primary orchestration skill for task execution
 - small companion skills only when they reduce complexity
@@ -93,6 +99,8 @@ The builder metadata bundle must include the inventory record, decision record, 
 When integrations are in scope, the metadata bundle must also include `integrations.yaml` so provider mappings are reviewable and versioned with the project.
 
 If a capability is degraded or unavailable, the metadata bundle must make the fallback mode and any manual steps visible.
+
+For `runtime_target: claude-code`, generated execution-facing skills must use `SKILL.md` as the canonical skill entrypoint in each skill folder. Do not emit a primary entrypoint as `<skill-name>.md`.
 
 ### Phase 5: Handoff
 
@@ -112,3 +120,5 @@ Provide:
 - Keep the generated output editable by humans.
 - Treat project-local skills as the authoritative override layer for that repository.
 - Keep generated skill names in the `superagents-` namespace so repo-local overrides stay explicit and predictable.
+- Do not write mixed-runtime output layouts in one run.
+- If runtime target is ambiguous at assembly time, ask a focused question and resolve the target before writing files.


### PR DESCRIPTION
Summary:\nThis PR fixes a builder contract gap that allowed a Claude-incompatible generated skill entrypoint filename.\n\nChanges:\n- adds explicit runtime_target decision requirements in the skill-builder instructions\n- makes runtime-target ambiguity a required follow-up question before assembly\n- codifies Claude-mode entrypoint invariant: generated skills must use SKILL.md in each skill folder\n- updates questionnaire priorities to include runtime target as Priority 1\n- updates generated-layout contract to record runtime target in decisions.yaml\n\nWhy:\nIssue #107 reported generated output using superagents-execute.md instead of Claude SKILL.md, causing the skill not to be auto-discovered.\n\nCloses #107

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Runtime Target as the highest-priority questionnaire decision to specify how generated skill bundles conform to target AI runtimes/platforms
  * Updated skill generation documentation to include runtime target validation before creating execution-facing artifacts
  * Documented skill layout and entrypoint requirements based on selected runtime target
  * Renumbered subsequent questionnaire priorities

<!-- end of auto-generated comment: release notes by coderabbit.ai -->