### PR TITLE
Docs follow-up: tighten runtime_target ambiguity gate wording

### DIFF
--- a/docs/generated-skill-layout.md
+++ b/docs/generated-skill-layout.md
@@ -52,7 +52,7 @@ Before writing any execution-facing files, the builder should resolve and record
 - if confidence is below high and output layout would change, the builder should ask a focused follow-up question before writing files
 - if runtime target remains unresolved, do not publish execution-facing skill files
 
-For the current Claude-first MVP, the required canonical mapping is:
+For the current Claude-first MVP, the required canonical mapping is (execution-facing output is defined only for `claude-code`):
 
 | runtime_target | Execution root | Primary entrypoint |
 |---|---|---|
@@ -62,6 +62,7 @@ Invariant for Claude mode:
 
 - do not publish the primary skill as `.claude/skills/superagents/<name>.md`
 - each generated skill folder must contain `SKILL.md`
+- only `runtime_target = claude-code` may publish execution-facing output; any other `runtime_target` must remain unresolved and must not publish execution-facing files until a canonical output-root and entrypoint contract is defined.
 
 ## Output Roots
 
@@ -245,6 +246,7 @@ Recommended decision keys:
 - `runtime_target`
   - examples: `claude-code`, `cursor`, `codex`, `gemini-cli`, `antigravity`, `other`
   - purpose: binds generated execution-facing output paths and entrypoint filename contract
+  - unresolved behavior: if `runtime_target` is unresolved/empty, apply `safe_to_proceed: false` (from questionnaire flow) and do not publish execution-facing files
 
 Task-level override resolution should follow the precedence contract in [`docs/orchestration-execution-rubric.md`](./orchestration-execution-rubric.md).
 

--- a/skills/skill-builder/SKILL.md
+++ b/skills/skill-builder/SKILL.md
@@ -121,4 +121,4 @@ Provide:
 - Treat project-local skills as the authoritative override layer for that repository.
 - Keep generated skill names in the `superagents-` namespace so repo-local overrides stay explicit and predictable.
 - Do not write mixed-runtime output layouts in one run.
-- If runtime target is ambiguous at assembly time, ask a focused question and resolve the target before writing files.
+- If `runtime_target` is ambiguous at assembly time, ask the focused `runtime-target` follow-up question, record the answer in `decisions.yaml` under `runtime_target`, and only then write files.


### PR DESCRIPTION
Summary:\nSmall doc-only follow-up after PR #108 merge, addressing CodeRabbit nits.\n\nChanges:\n- clarify that only runtime_target=claude-code may publish execution-facing output in current MVP\n- explicitly block non-mapped runtime_target values from publishing execution-facing files\n- add safe_to_proceed linkage for unresolved/empty runtime_target\n- tighten guardrail wording to reference runtime-target question id and decisions.yaml runtime_target key\n\nScope:\n- docs/generated-skill-layout.md\n- skills/skill-builder/SKILL.md\n\nContext:\nThis is a fresh PR because #108 was merged before these follow-up doc nits were committed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Clarified execution-facing output constraints tied to runtime target specification
  * Updated skill-building workflow requirements to ensure runtime target resolution before publication
  * Added validation safeguards to prevent execution with unresolved runtime targets

<!-- end of auto-generated comment: release notes by coderabbit.ai -->