### PR TITLE
Update devcontainer scaffold networking and package cache storage

### DIFF
--- a/docs/isolated-devcontainer-bootstrap-workflow.md
+++ b/docs/isolated-devcontainer-bootstrap-workflow.md
@@ -64,7 +64,7 @@ Then applies Superagents-specific container patches:
   - `source=superagents-pnpm-store,target=/home/node/.pnpm-store,type=volume`
 - Sets package manager cache env vars in `containerEnv`:
   - `npm_config_cache=/home/node/.npm-cache`
-  - `PNPM_HOME=/home/node/.pnpm-store`
+  - `npm_config_store_dir=/home/node/.pnpm-store`
 - Updates Dockerfile global Claude Code install line to also run `npm cache clean --force` to keep image layers smaller.
 
 Default source URL:

--- a/docs/isolated-devcontainer-bootstrap-workflow.md
+++ b/docs/isolated-devcontainer-bootstrap-workflow.md
@@ -55,7 +55,17 @@ The scaffold script pulls baseline files from Anthropic reference source:
 
 - `devcontainer.json`
 - `Dockerfile`
-- `init-firewall.sh`
+
+Then applies Superagents-specific container patches:
+
+- Removes firewall bootstrap wiring from `devcontainer.json` (`postStartCommand`, `waitFor: "postStartCommand"` when present, and `NET_ADMIN` / `NET_RAW` capability flags in `runArgs`).
+- Adds named Docker volumes for package caches:
+  - `source=superagents-npm-cache,target=/home/node/.npm-cache,type=volume`
+  - `source=superagents-pnpm-store,target=/home/node/.pnpm-store,type=volume`
+- Sets package manager cache env vars in `containerEnv`:
+  - `npm_config_cache=/home/node/.npm-cache`
+  - `PNPM_HOME=/home/node/.pnpm-store`
+- Updates Dockerfile global Claude Code install line to also run `npm cache clean --force` to keep image layers smaller.
 
 Default source URL:
 

--- a/docs/isolated-devcontainer-bootstrap-workflow.md
+++ b/docs/isolated-devcontainer-bootstrap-workflow.md
@@ -58,14 +58,14 @@ The scaffold script pulls baseline files from Anthropic reference source:
 
 Then applies Superagents-specific container patches:
 
-- Removes firewall bootstrap wiring from `devcontainer.json` (`postStartCommand`, `waitFor: "postStartCommand"` when present, and `NET_ADMIN` / `NET_RAW` capability flags in `runArgs`).
+- Removes `init-firewall.sh` usage and firewall bootstrap wiring from startup (`postStartCommand`, `waitFor: "postStartCommand"` when present, and `NET_ADMIN` / `NET_RAW` capability flags in `runArgs`).
 - Adds named Docker volumes for package caches:
   - `source=superagents-npm-cache,target=/home/node/.npm-cache,type=volume`
   - `source=superagents-pnpm-store,target=/home/node/.pnpm-store,type=volume`
 - Sets package manager cache env vars in `containerEnv`:
   - `npm_config_cache=/home/node/.npm-cache`
   - `npm_config_store_dir=/home/node/.pnpm-store`
-- Updates Dockerfile global Claude Code install line to also run `npm cache clean --force` to keep image layers smaller.
+- Updates Dockerfile global Claude Code install line to append `npm cache clean --force` if not already present, keeping image layers smaller without duplicating commands.
 
 Default source URL:
 

--- a/skills/devcontainer-bootstrap/SKILL.md
+++ b/skills/devcontainer-bootstrap/SKILL.md
@@ -45,7 +45,9 @@ After installation, this skill's templates are expected at:
 
 ## Success Criteria
 
-- `.devcontainer/` exists and is based on Anthropic's reference assets (`devcontainer.json`, `Dockerfile`, `init-firewall.sh`).
+- `.devcontainer/` exists and is based on Anthropic's reference assets (`devcontainer.json`, `Dockerfile`) with superagents-specific patches applied.
+- Generated `devcontainer.json` does not require firewall bootstrap (`postStartCommand`/`waitFor` coupling removed, no `NET_ADMIN`/`NET_RAW` capability additions).
+- npm and pnpm cache storage is configured to use named Docker volumes mounted at `/home/node/.npm-cache` and `/home/node/.pnpm-store`.
 - `postCreateCommand` installs Superagents with user-level scope inside the container.
 - Smoke test passes after container creation.
 

--- a/skills/devcontainer-bootstrap/templates/scaffold-devcontainer.sh
+++ b/skills/devcontainer-bootstrap/templates/scaffold-devcontainer.sh
@@ -30,9 +30,6 @@ if (Array.isArray(doc.runArgs)) {
     if ((arg === '--cap-add' || arg === '--cap-drop') && (arr[idx + 1] === 'NET_ADMIN' || arr[idx + 1] === 'NET_RAW')) {
       return false;
     }
-    if ((arg === 'NET_ADMIN' || arg === 'NET_RAW') && (arr[idx - 1] === '--cap-add' || arr[idx - 1] === '--cap-drop')) {
-      return false;
-    }
     return true;
   });
 }
@@ -52,7 +49,7 @@ doc.mounts = mounts;
 doc.containerEnv = {
   ...(doc.containerEnv || {}),
   npm_config_cache: '/home/node/.npm-cache',
-  PNPM_HOME: '/home/node/.pnpm-store'
+  npm_config_store_dir: '/home/node/.pnpm-store'
 };
 doc.postCreateCommand = '.devcontainer/post-create-superagents.sh';
 fs.writeFileSync(file, `${JSON.stringify(doc, null, 2)}\n`);

--- a/skills/devcontainer-bootstrap/templates/scaffold-devcontainer.sh
+++ b/skills/devcontainer-bootstrap/templates/scaffold-devcontainer.sh
@@ -8,8 +8,6 @@ mkdir -p "$TARGET_DIR"
 
 curl -fsSL "$BASE_URL/devcontainer.json" -o "$TARGET_DIR/devcontainer.json"
 curl -fsSL "$BASE_URL/Dockerfile" -o "$TARGET_DIR/Dockerfile"
-curl -fsSL "$BASE_URL/init-firewall.sh" -o "$TARGET_DIR/init-firewall.sh"
-chmod +x "$TARGET_DIR/init-firewall.sh"
 
 TEMPLATE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 cp "$TEMPLATE_DIR/post-create-superagents.sh" "$TARGET_DIR/post-create-superagents.sh"
@@ -20,8 +18,55 @@ node - "$TARGET_DIR/devcontainer.json" <<'NODE'
 const fs = require('fs');
 const file = process.argv[2];
 const doc = JSON.parse(fs.readFileSync(file, 'utf8'));
+delete doc.postStartCommand;
+if (doc.waitFor === 'postStartCommand') {
+  delete doc.waitFor;
+}
+if (Array.isArray(doc.runArgs)) {
+  doc.runArgs = doc.runArgs.filter((arg, idx, arr) => {
+    if (arg === 'NET_ADMIN' || arg === 'NET_RAW') {
+      return false;
+    }
+    if ((arg === '--cap-add' || arg === '--cap-drop') && (arr[idx + 1] === 'NET_ADMIN' || arr[idx + 1] === 'NET_RAW')) {
+      return false;
+    }
+    if ((arg === 'NET_ADMIN' || arg === 'NET_RAW') && (arr[idx - 1] === '--cap-add' || arr[idx - 1] === '--cap-drop')) {
+      return false;
+    }
+    return true;
+  });
+}
+
+const mounts = Array.isArray(doc.mounts) ? [...doc.mounts] : [];
+const requiredMounts = [
+  'source=superagents-npm-cache,target=/home/node/.npm-cache,type=volume',
+  'source=superagents-pnpm-store,target=/home/node/.pnpm-store,type=volume'
+];
+for (const mount of requiredMounts) {
+  if (!mounts.includes(mount)) {
+    mounts.push(mount);
+  }
+}
+doc.mounts = mounts;
+
+doc.containerEnv = {
+  ...(doc.containerEnv || {}),
+  npm_config_cache: '/home/node/.npm-cache',
+  PNPM_HOME: '/home/node/.pnpm-store'
+};
 doc.postCreateCommand = '.devcontainer/post-create-superagents.sh';
 fs.writeFileSync(file, `${JSON.stringify(doc, null, 2)}\n`);
+NODE
+
+node - "$TARGET_DIR/Dockerfile" <<'NODE'
+const fs = require('fs');
+const file = process.argv[2];
+const dockerfile = fs.readFileSync(file, 'utf8');
+const updated = dockerfile.replace(
+  /npm install -g @anthropic-ai\/claude-code(?!\s*&&\s*npm cache clean --force)/g,
+  'npm install -g @anthropic-ai/claude-code && npm cache clean --force'
+);
+fs.writeFileSync(file, updated);
 NODE
 
 echo "Scaffolded Anthropic-based devcontainer into $TARGET_DIR"


### PR DESCRIPTION
## Summary
- remove firewall bootstrap fetching/usage from the devcontainer scaffold
- patch generated devcontainer config to drop firewall-oriented startup/capability settings
- add persistent npm/pnpm named volume cache mounts and container env wiring
- update generated Dockerfile install line to clean npm cache after global Claude Code install
- refresh docs for the isolated devcontainer bootstrap workflow and success criteria

Closes #109

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated devcontainer bootstrap workflow and success criteria to reflect the new devcontainer setup.

* **Improvements**
  * Removed automatic firewall bootstrap behavior from generated container configs.
  * Added persistent npm and pnpm cache/store persistence and preserved container environment settings.
  * Ensured npm cache is cleaned during the global tool installation to improve build reliability and image size.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->