### PR TITLE
Update devcontainer scaffold to Node 24

### DIFF
--- a/docs/isolated-devcontainer-bootstrap-workflow.md
+++ b/docs/isolated-devcontainer-bootstrap-workflow.md
@@ -65,6 +65,7 @@ Then applies Superagents-specific container patches:
 - Sets package manager cache env vars in `containerEnv`:
   - `npm_config_cache=/home/node/.npm-cache`
   - `npm_config_store_dir=/home/node/.pnpm-store`
+- Rewrites Dockerfile base image from `node:20` to `node:24` while preserving any tag suffix.
 - Updates Dockerfile global Claude Code install line to append `npm cache clean --force` if not already present, keeping image layers smaller without duplicating commands.
 
 Default source URL:

--- a/skills/devcontainer-bootstrap/templates/scaffold-devcontainer.sh
+++ b/skills/devcontainer-bootstrap/templates/scaffold-devcontainer.sh
@@ -60,7 +60,7 @@ const fs = require('fs');
 const file = process.argv[2];
 const dockerfile = fs.readFileSync(file, 'utf8');
 const withUpdatedNode = dockerfile.replace(
-  /(^\s*FROM\s+node:)20(\S*)/im,
+  /(^\s*FROM\s+node:)20(\S*)/gim,
   '$124$2'
 );
 const updated = withUpdatedNode.replace(

--- a/skills/devcontainer-bootstrap/templates/scaffold-devcontainer.sh
+++ b/skills/devcontainer-bootstrap/templates/scaffold-devcontainer.sh
@@ -59,9 +59,13 @@ node - "$TARGET_DIR/Dockerfile" <<'NODE'
 const fs = require('fs');
 const file = process.argv[2];
 const dockerfile = fs.readFileSync(file, 'utf8');
-const updated = dockerfile.replace(
-  /npm install -g @anthropic-ai\/claude-code(?!\s*&&\s*npm cache clean --force)/g,
-  'npm install -g @anthropic-ai/claude-code && npm cache clean --force'
+const withUpdatedNode = dockerfile.replace(
+  /(^\s*FROM\s+node:)20(\S*)/im,
+  '$124$2'
+);
+const updated = withUpdatedNode.replace(
+  /npm install -g @anthropic-ai\/claude-code(@\S+)?(?!\s*&&\s*npm cache clean --force)/g,
+  'npm install -g @anthropic-ai/claude-code$1 && npm cache clean --force'
 );
 fs.writeFileSync(file, updated);
 NODE


### PR DESCRIPTION
## Summary
- update `scaffold-devcontainer.sh` to rewrite Anthropic Dockerfile base image from `node:20` to `node:24` (preserving suffix tags)
- harden the existing Claude Code install-line patch to preserve optional `@...` version suffixes when appending `npm cache clean --force`
- document the Node 24 rewrite behavior in the isolated devcontainer workflow doc

## Validation
- ran scaffold end-to-end into a temp directory and verified generated Dockerfile starts with `FROM node:24`
- verified generated install line remains correct:
  - `RUN npm install -g @anthropic-ai/claude-code@${CLAUDE_CODE_VERSION} && npm cache clean --force`

Closes #112


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated development container configuration to use Node.js 24 (replacing Node 20).
  * Added automatic npm cache cleanup during container bootstrap to improve efficiency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->