### PR TITLE
Fix devcontainer apt GPG failures from APT sandbox keyring access

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,7 @@ Installed skill bundle:
 Reference docs:
 
 - [Anthropic devcontainer guide](https://code.claude.com/docs/en/devcontainer)
+- [Devcontainer rebuild runbook](REBUILD.md)
 
 ### 2c. Dogfood Superagents In This Source Repository (Optional)
 

--- a/REBUILD.md
+++ b/REBUILD.md
@@ -1,0 +1,68 @@
+# Devcontainer Rebuild Runbook
+
+This runbook captures common high-signal fixes for flaky devcontainer rebuilds in this repository.
+
+## 1) APT Sandbox Keyring Failure (Highest Priority)
+
+If Docker build fails during `apt-get update` with errors like:
+
+- `At least one invalid signature was encountered`
+- `E: The repository '...' is not signed`
+
+...across all Debian repos at once, treat it as an APT sandbox keyring-access issue first.
+
+Required Dockerfile pattern:
+
+```Dockerfile
+RUN apt-get -o APT::Sandbox::User=root update && apt-get install -y ...
+```
+
+Quick triage:
+
+- If all repos fail at once and manual `gpgv` validation succeeds, suspect APT sandbox keyring access.
+- If only one repo fails, suspect stale/missing key material for that repo.
+
+## 2) Keep Node Base Image Current
+
+- Prefer `node:24` (or current LTS major) over older majors like `node:20`.
+- Pin to a major tag (for example `node:24`), not an immutable image SHA, so rebuilds can pull keyring/security refreshes.
+
+## 3) Prefer `desktop-linux` Buildx Builder
+
+For local devcontainer rebuilds, prefer the local daemon-backed builder:
+
+```bash
+docker buildx use desktop-linux
+```
+
+Why:
+
+- The `multiplatform` (`docker-container` driver) builder runs in its own network namespace and can surface TLS/auth timeout errors to Docker Hub during rebuilds.
+- `desktop-linux` (`docker` driver) uses the local daemon directly and is typically more reliable for this workflow.
+
+## 4) Disk Hygiene (Periodic)
+
+When rebuilds begin failing randomly, check Docker VM disk pressure first:
+
+```bash
+docker run --rm alpine df -h /
+```
+
+If space is constrained, clean up:
+
+```bash
+docker system prune -f
+docker builder prune -f
+```
+
+If still full and `multiplatform` buildkit state is bloated:
+
+```bash
+docker rm -f buildx_buildkit_multiplatform0
+docker volume rm buildx_buildkit_multiplatform0_state
+```
+
+Notes:
+
+- The `buildx_buildkit_multiplatform0_state` volume can grow to multiple GB.
+- 100% Docker VM disk utilization often presents as intermittent, misleading build failures.

--- a/docs/isolated-devcontainer-bootstrap-workflow.md
+++ b/docs/isolated-devcontainer-bootstrap-workflow.md
@@ -74,6 +74,10 @@ APT diagnosis shortcut used for this patch:
 - If all Debian repos fail at once with `At least one invalid signature was encountered` / `repository is not signed` and manual `gpgv` succeeds, suspect APT sandbox keyring access.
 - If only one repo fails, suspect a stale or missing key for that specific repo.
 
+Framing correction:
+
+- What may look like a clock-skew-style signature issue in this scenario is actually an APT sandbox keyring access failure. Signature material can still be valid while APT's sandboxed verifier cannot read the keyring.
+
 Default source URL:
 
 - `https://raw.githubusercontent.com/anthropics/claude-code/main/.devcontainer`

--- a/docs/isolated-devcontainer-bootstrap-workflow.md
+++ b/docs/isolated-devcontainer-bootstrap-workflow.md
@@ -67,6 +67,12 @@ Then applies Superagents-specific container patches:
   - `npm_config_store_dir=/home/node/.pnpm-store`
 - Rewrites Dockerfile base image from `node:20` to `node:24` while preserving any tag suffix.
 - Updates Dockerfile global Claude Code install line to append `npm cache clean --force` if not already present, keeping image layers smaller without duplicating commands.
+- Rewrites `apt-get update` to `apt-get -o APT::Sandbox::User=root update` and inserts a Dockerfile comment documenting the reason, to avoid intermittent Debian repo GPG signature failures caused by APT sandbox keyring access in container builds.
+
+APT diagnosis shortcut used for this patch:
+
+- If all Debian repos fail at once with `At least one invalid signature was encountered` / `repository is not signed` and manual `gpgv` succeeds, suspect APT sandbox keyring access.
+- If only one repo fails, suspect a stale or missing key for that specific repo.
 
 Default source URL:
 

--- a/skills/devcontainer-bootstrap/templates/scaffold-devcontainer.sh
+++ b/skills/devcontainer-bootstrap/templates/scaffold-devcontainer.sh
@@ -63,10 +63,24 @@ const withUpdatedNode = dockerfile.replace(
   /(^\s*FROM\s+node:)20(\S*)/gim,
   '$124$2'
 );
-const updated = withUpdatedNode.replace(
+const withCleanNpmInstall = withUpdatedNode.replace(
   /npm install -g @anthropic-ai\/claude-code(@\S+)?(?!\s*&&\s*npm cache clean --force)/g,
   'npm install -g @anthropic-ai/claude-code$1 && npm cache clean --force'
 );
+const withAptSandboxOverride = withCleanNpmInstall.replace(
+  /\bapt-get\s+update\b/g,
+  'apt-get -o APT::Sandbox::User=root update'
+);
+let updated = withAptSandboxOverride;
+if (
+  updated.includes('apt-get -o APT::Sandbox::User=root update') &&
+  !updated.includes('APT sandbox keyring access workaround')
+) {
+  updated = updated.replace(
+    /(RUN\s+apt-get\s+-o APT::Sandbox::User=root update\b)/,
+    '# APT sandbox keyring access workaround: prevents intermittent Debian GPG signature failures.\n$1'
+  );
+}
 fs.writeFileSync(file, updated);
 NODE
 


### PR DESCRIPTION
## Summary
- patch devcontainer scaffold Dockerfile rewrite to force apt-get -o APT::Sandbox::User=root update
- inject a Dockerfile comment documenting why the override exists
- document the failure signature and diagnosis shortcut in the isolated devcontainer workflow doc

## Validation
- ran skills/devcontainer-bootstrap/templates/scaffold-devcontainer.sh against a mocked upstream devcontainer source
- verified output Dockerfile includes Node 24 rewrite, apt sandbox override/comment, and npm cache cleanup

Closes #114


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a REBUILD runbook with a checklist for devcontainer rebuild failures, expanded APT sandbox keyring troubleshooting, guidance on Node LTS tagging, buildx usage, and disk-pressure cleanup steps.

* **Chores**
  * Devcontainer scaffolding now injects an APT sandbox workaround (uses APT::Sandbox::User=root) and adds explanatory comments when generating container setup files.

* **Documentation**
  * README updated to reference the new rebuild runbook.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->