### PR TITLE
Support host-injected GH_TOKEN for scaffolded devcontainers

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,6 +202,24 @@ Reference docs:
 
 - [Anthropic devcontainer guide](https://code.claude.com/docs/en/devcontainer)
 - [Devcontainer rebuild runbook](REBUILD.md)
+- [Isolated devcontainer bootstrap workflow](docs/isolated-devcontainer-bootstrap-workflow.md)
+
+Host secret onboarding (recommended before first container reopen):
+
+1. Create a GitHub fine-grained token (`https://github.com/settings/tokens`) with at least:
+   - Contents: read/write
+   - Pull requests: read/write
+   - Metadata: read
+   - Workflows: read/write (if needed)
+2. Export host env vars in your shell startup file (`~/.zshrc` or `~/.zshenv`), for example:
+
+```bash
+export GH_TOKEN=ghp_xxx
+export ANTHROPIC_API_KEY=...
+export VERCEL_TOKEN=...
+```
+
+The scaffolded devcontainer forwards these via `${localEnv:...}` so secrets stay host-managed and `gh` can work in-container without repeated interactive login.
 
 ### 2c. Dogfood Superagents In This Source Repository (Optional)
 

--- a/docs/isolated-devcontainer-bootstrap-workflow.md
+++ b/docs/isolated-devcontainer-bootstrap-workflow.md
@@ -65,9 +65,40 @@ Then applies Superagents-specific container patches:
 - Sets package manager cache env vars in `containerEnv`:
   - `npm_config_cache=/home/node/.npm-cache`
   - `npm_config_store_dir=/home/node/.pnpm-store`
+- Forwards host-managed secrets into `containerEnv` using `localEnv`:
+  - `GH_TOKEN=${localEnv:GH_TOKEN}`
+  - `ANTHROPIC_API_KEY=${localEnv:ANTHROPIC_API_KEY}`
+  - `VERCEL_TOKEN=${localEnv:VERCEL_TOKEN}`
 - Rewrites Dockerfile base image from `node:20` to `node:24` while preserving any tag suffix.
 - Updates Dockerfile global Claude Code install line to append `npm cache clean --force` if not already present, keeping image layers smaller without duplicating commands.
 - Rewrites `apt-get update` to `apt-get -o APT::Sandbox::User=root update` and inserts a Dockerfile comment documenting the reason, to avoid intermittent Debian repo GPG signature failures caused by APT sandbox keyring access in container builds.
+
+## Host Secret Onboarding Checklist
+
+Before reopening in container, create host-side environment variables (never commit raw secrets into repo files or Dockerfiles).
+
+GitHub token setup:
+
+1. Create a fine-grained PAT at `https://github.com/settings/tokens`.
+2. Typical repo permissions:
+   - Contents: read/write
+   - Pull requests: read/write
+   - Workflows: read/write (only if needed)
+   - Metadata: read
+3. Export on host shell startup (for example in `~/.zshrc` or `~/.zshenv`):
+
+```bash
+export GH_TOKEN=ghp_xxx
+```
+
+Optional host-side exports for other tools:
+
+```bash
+export ANTHROPIC_API_KEY=...
+export VERCEL_TOKEN=...
+```
+
+After setting host vars, reopen/rebuild the devcontainer. `gh` reads `GH_TOKEN` automatically, so repeated in-container `gh auth login` should not be required.
 
 APT diagnosis shortcut used for this patch:
 

--- a/skills/devcontainer-bootstrap/templates/scaffold-devcontainer.sh
+++ b/skills/devcontainer-bootstrap/templates/scaffold-devcontainer.sh
@@ -48,6 +48,9 @@ doc.mounts = mounts;
 
 doc.containerEnv = {
   ...(doc.containerEnv || {}),
+  GH_TOKEN: '${localEnv:GH_TOKEN}',
+  ANTHROPIC_API_KEY: '${localEnv:ANTHROPIC_API_KEY}',
+  VERCEL_TOKEN: '${localEnv:VERCEL_TOKEN}',
   npm_config_cache: '/home/node/.npm-cache',
   npm_config_store_dir: '/home/node/.pnpm-store'
 };


### PR DESCRIPTION
## Summary
- forward host-managed secrets into scaffolded `containerEnv` via `${localEnv:...}`
- add `GH_TOKEN` support so `gh` can run non-interactively in-container
- document host-side setup checklist and security guidance

## Changes
- update `scaffold-devcontainer.sh` to inject:
  - `GH_TOKEN=${localEnv:GH_TOKEN}`
  - `ANTHROPIC_API_KEY=${localEnv:ANTHROPIC_API_KEY}`
  - `VERCEL_TOKEN=${localEnv:VERCEL_TOKEN}`
- expand isolated devcontainer workflow doc with token setup and permissions guidance
- add README onboarding snippet for host-side secret exports

## Validation
- `bash -n skills/devcontainer-bootstrap/templates/scaffold-devcontainer.sh`

Closes #116


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive host secret onboarding instructions for devcontainer bootstrap workflow, including GitHub fine-grained token setup guidance.
  * Enhanced documentation detailing how host environment variables are securely passed into the devcontainer.

* **Chores**
  * Updated devcontainer scaffolding to automatically inject authentication tokens (GitHub, Anthropic, Vercel) from host environment, enabling seamless tool access within containers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->