### PR TITLE
Add regression checks for skill-builder runtime-target contract

### DIFF
--- a/.github/workflows/contract-and-pipeline-tests.yml
+++ b/.github/workflows/contract-and-pipeline-tests.yml
@@ -39,6 +39,11 @@ jobs:
           chmod +x scripts/check-dogfooding-guardrails.sh tests/test-dogfooding-guardrails.sh
           ./tests/test-dogfooding-guardrails.sh
 
+      - name: Run skill-builder runtime target contract checks
+        run: |
+          chmod +x tests/test-skill-builder-runtime-target-contract.sh
+          ./tests/test-skill-builder-runtime-target-contract.sh
+
   conversion-determinism:
     name: Conversion determinism (${{ matrix.os }})
     runs-on: ${{ matrix.os }}

--- a/tests/test-skill-builder-runtime-target-contract.sh
+++ b/tests/test-skill-builder-runtime-target-contract.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SKILL_BUILDER_FILE="$ROOT_DIR/skills/skill-builder/SKILL.md"
+LAYOUT_CONTRACT_FILE="$ROOT_DIR/docs/generated-skill-layout.md"
+QUESTIONNAIRE_FILE="$ROOT_DIR/docs/builder-questionnaire-flow.md"
+
+assert_contains() {
+  local file="$1"
+  local pattern="$2"
+  local description="$3"
+  if ! grep -Eq "$pattern" "$file"; then
+    echo "Missing contract requirement: $description" >&2
+    echo "Checked file: $file" >&2
+    exit 1
+  fi
+}
+
+# Enforce Claude-mode entrypoint contract.
+assert_contains "$SKILL_BUILDER_FILE" 'runtime_target: claude-code.*SKILL\.md.*<skill-name>\.md' \
+  "Claude runtime target uses SKILL.md and disallows <skill-name>.md primary entrypoint"
+assert_contains "$LAYOUT_CONTRACT_FILE" '\| `claude-code` \| `.claude/skills/superagents/<skill-name>/` \| `SKILL\.md` \|' \
+  "Generated layout maps claude-code runtime target to SKILL.md entrypoint"
+assert_contains "$LAYOUT_CONTRACT_FILE" 'do not publish the primary skill as `.claude/skills/superagents/<name>\.md`' \
+  "Generated layout forbids orphan top-level .md primary skill entrypoint in Claude mode"
+
+# Enforce runtime-target ambiguity gate.
+assert_contains "$SKILL_BUILDER_FILE" 'If `runtime_target` is ambiguous at assembly time, ask the focused `runtime-target` follow-up question' \
+  "Builder asks runtime-target follow-up when runtime target is ambiguous"
+assert_contains "$LAYOUT_CONTRACT_FILE" 'if confidence is below high and output layout would change, the builder should ask a focused follow-up question before writing files' \
+  "Generated layout requires ambiguity follow-up before writing files"
+
+# Enforce runtime target decision-state recording (confirmed/assumed/unresolved).
+assert_contains "$SKILL_BUILDER_FILE" 'Record each resulting decision as confirmed, assumed, unresolved, or not-applicable' \
+  "Builder records decision state in metadata"
+assert_contains "$QUESTIONNAIRE_FILE" 'state: unresolved' \
+  "Questionnaire flow documents unresolved decision state"
+assert_contains "$QUESTIONNAIRE_FILE" 'state: assumed' \
+  "Questionnaire flow documents assumed decision state"
+assert_contains "$QUESTIONNAIRE_FILE" 'state: confirmed' \
+  "Questionnaire flow documents confirmed decision state"
+
+echo "Skill-builder runtime-target contract tests: passed"


### PR DESCRIPTION
Summary:\n- add a dedicated contract test for skill-builder runtime-target behavior\n- enforce Claude mapping to per-skill SKILL.md entrypoint and forbid orphan <name>.md primary entrypoints\n- enforce runtime-target ambiguity follow-up requirement and decision-state coverage (confirmed/assumed/unresolved)\n- run the new contract test in the existing contract-and-pipeline workflow\n\nValidation:\n- ./tests/test-skill-builder-runtime-target-contract.sh\n\nIssue:\n- Closes #107

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added automated contract validation to verify runtime target configurations and documentation artifacts are correctly configured and enforced.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->