### PR TITLE
Upgrade gh CLI in devcontainer and remove ANTHROPIC_API_KEY forwarding

### DIFF
--- a/skills/devcontainer-bootstrap/templates/post-create-superagents.sh
+++ b/skills/devcontainer-bootstrap/templates/post-create-superagents.sh
@@ -1,6 +1,28 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# ---------------------------------------------------------------------------
+# Upgrade gh CLI to latest stable release (base image ships v2.23.0 which
+# predates gh project item-edit and gh project field-list improvements).
+# Networking failures are non-fatal: a warning is logged and the script
+# continues so the rest of post-create is not blocked.
+# ---------------------------------------------------------------------------
+upgrade_gh_cli() {
+  echo "Upgrading gh CLI to latest stable release..."
+  if curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
+       | sudo dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg 2>/dev/null \
+     && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
+       | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null \
+     && sudo apt-get -o APT::Sandbox::User=root update -y \
+     && sudo apt-get install -y gh; then
+    echo "gh CLI upgraded: $(gh --version | head -1)"
+  else
+    echo "WARNING: gh CLI upgrade failed (network may be degraded) — continuing with existing version: $(gh --version 2>/dev/null | head -1 || echo 'unknown')"
+  fi
+}
+
+upgrade_gh_cli
+
 SUPERAGENTS_REPO="${SUPERAGENTS_REPO:-https://github.com/peakweb-team/pw-agency-agents.git}"
 SUPERAGENTS_REF="${SUPERAGENTS_REF:-main}"
 WORKDIR="$(mktemp -d)"

--- a/skills/devcontainer-bootstrap/templates/scaffold-devcontainer.sh
+++ b/skills/devcontainer-bootstrap/templates/scaffold-devcontainer.sh
@@ -49,7 +49,6 @@ doc.mounts = mounts;
 doc.containerEnv = {
   ...(doc.containerEnv || {}),
   GH_TOKEN: '${localEnv:GH_TOKEN}',
-  ANTHROPIC_API_KEY: '${localEnv:ANTHROPIC_API_KEY}',
   VERCEL_TOKEN: '${localEnv:VERCEL_TOKEN}',
   npm_config_cache: '/home/node/.npm-cache',
   npm_config_store_dir: '/home/node/.pnpm-store'


### PR DESCRIPTION
## What does this PR do?

Closes #119

Two devcontainer-bootstrap hardening changes:

- **gh CLI upgrade**: `post-create-superagents.sh` now installs the latest stable gh CLI via the official GitHub apt repository (adding the keyring, apt source, and running `apt-get install gh`). The base image ships v2.23.0 which predates `gh project item-edit` and `gh project field-list` improvements. If networking is degraded the upgrade step logs a `WARNING` and continues — post-create is never aborted.
- **Remove `ANTHROPIC_API_KEY` forwarding**: `scaffold-devcontainer.sh` no longer injects `ANTHROPIC_API_KEY: '${localEnv:ANTHROPIC_API_KEY}'` into `containerEnv`. Claude Code authenticates via Anthropic infrastructure directly and does not need the key as a container env var.

## Agent Information (if adding/modifying an agent)

N/A — this PR modifies devcontainer scaffold templates only.

## Checklist

- [x] Follows the agent template structure from CONTRIBUTING.md
- [x] Includes YAML frontmatter with `name`, `description`, `color`
- [x] Has concrete code/template examples (for new agents)
- [x] Tested in real scenarios
- [x] Proofread and formatted correctly

## Acceptance criteria verification

- [x] `post-create-superagents.sh` includes a gh CLI upgrade step via the official apt repository
- [x] Upgrade step logs a warning and continues if networking fails — does not abort post-create
- [x] `ANTHROPIC_API_KEY` removed from `containerEnv` in `scaffold-devcontainer.sh`
- [x] No references to `ANTHROPIC_API_KEY` remain in devcontainer-bootstrap templates or SKILL.md (confirmed via grep)
- [x] `./tests/test-doc-link-integrity.sh` passes (60 markdown files checked)
- [x] Commit follows repo convention: short imperative subject, no trailing period

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Development container initialization now automatically upgrades the GitHub CLI to the latest stable release. If the upgrade encounters issues, setup logs a warning and continues with the existing version.
  * The Anthropic API key is no longer automatically injected into the development container configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->