### PR TITLE
Enforce blocked-by relationships when issues declare dependencies

### DIFF
--- a/docs/workflow-conventions.md
+++ b/docs/workflow-conventions.md
@@ -1,0 +1,64 @@
+# Workflow Conventions
+
+This document defines conventions that contributors and operators must follow when working with issues and pull requests in this repository.
+
+## Issue Dependency Declaration
+
+### Standard
+
+When an issue cannot be started until another issue is resolved, the blocked issue body must include a `## Blocked by` section. Each blocker is listed as:
+
+```
+#N — one-line reason
+```
+
+where `N` is the issue number and the reason briefly explains why the dependency exists.
+
+### Example
+
+```markdown
+## Blocked by
+
+#119 — gh CLI upgrade required before this issue's automation can run correctly
+```
+
+Multiple blockers are listed as separate lines under the same section:
+
+```markdown
+## Blocked by
+
+#119 — gh CLI upgrade required before automation can run correctly
+#125 — port registry must exist before devcontainer scaffold can write forwardPorts
+```
+
+### GitHub linked-issue relationship
+
+In addition to the body declaration, set the GitHub "blocked by" linked-issue relationship via the UI (issue sidebar → "Development" or "Linked issues") or via the `gh` CLI:
+
+```bash
+gh issue edit <blocked-issue-N> --add-label "" # placeholder — use the GitHub UI or GraphQL API to set the "blocked by" relationship
+```
+
+The body `## Blocked by` section is the machine-readable and human-readable source of truth. The GitHub linked-issue relationship is supplementary and improves discoverability in the project board.
+
+### Stale blockers
+
+When a blocker issue is resolved (merged or closed), remove or strike through its entry in the `## Blocked by` section and note the resolution:
+
+```markdown
+## Blocked by
+
+~~#119 — gh CLI upgrade required before automation can run correctly~~ (resolved in #118)
+```
+
+Or remove the resolved entry entirely if no historical context is needed.
+
+## Commit Message Convention
+
+Follow the imperative mood, present tense for commit messages:
+
+- `Add dependency declaration standard to workflow conventions`
+- `Update superagents-workflow SKILL.md with blocker-check step`
+- `Fix informal blocker language in issue bodies`
+
+Keep the subject line under 72 characters. Include a body when the commit reason is not obvious from the subject alone.

--- a/docs/workflow-conventions.md
+++ b/docs/workflow-conventions.md
@@ -8,7 +8,7 @@ This document defines conventions that contributors and operators must follow wh
 
 When an issue cannot be started until another issue is resolved, the blocked issue body must include a `## Blocked by` section. Each blocker is listed as:
 
-```
+```text
 #N — one-line reason
 ```
 

--- a/examples/generated-skills/direct-brief-vibe-bootstrap/.claude/skills/superagents/superagents-workflow/SKILL.md
+++ b/examples/generated-skills/direct-brief-vibe-bootstrap/.claude/skills/superagents/superagents-workflow/SKILL.md
@@ -34,6 +34,13 @@ In `auto`, use deterministic task slug naming for branch/worktree, reuse valid t
 - Mark unresolved decisions explicitly rather than hiding uncertainty.
 - Reconcile assumptions after feedback or validation failures.
 
+## Work Intake — Blocker Check
+
+If the brief references a GitHub issue, read the issue body before proceeding. Check whether the body contains an open `## Blocked by` section.
+
+- If a `## Blocked by` section is present and any listed blocker issue is still open, surface the blocker(s) to the operator and stop. Do not proceed with implementation until the operator confirms the blocker is resolved or explicitly overrides it.
+- If the `## Blocked by` section is absent or all listed blockers are closed, proceed normally.
+
 ## Guardrails
 
 - Do not claim tracker synchronization happened when no tracker is configured.

--- a/examples/generated-skills/github-heavy-dual-intake-coderabbit/.claude/skills/superagents/superagents-workflow/SKILL.md
+++ b/examples/generated-skills/github-heavy-dual-intake-coderabbit/.claude/skills/superagents/superagents-workflow/SKILL.md
@@ -33,9 +33,24 @@ Choose intake per request and keep the chosen path explicit in updates.
 
 Use deterministic naming for task worktrees/branches. Reuse an existing path only when it maps to the same task context. If path or branch context is ambiguous, stop and emit remediation instead of continuing in-place.
 
+## Work Intake — Blocker Check
+
+After reading the issue, check whether the body contains an open `## Blocked by` section.
+
+- If a `## Blocked by` section is present and any listed blocker issue is still open, surface the blocker(s) to the operator and stop. Do not proceed with implementation until the operator confirms the blocker is resolved or explicitly overrides it.
+- If the `## Blocked by` section is absent or all listed blockers are closed, proceed normally.
+
+Example stop message:
+
+```
+Issue #N is blocked by #M — <one-line reason>.
+Resolve #M first or confirm an override before proceeding.
+```
+
 ## Tracked-Task Responsibilities
 
 - Read issue context before coding when tracked-task intake is selected.
+- Apply the blocker check above before any implementation work begins.
 - Keep issue updates milestone-oriented, not commit-by-commit logs.
 - Link PR and verification evidence in issue updates.
 


### PR DESCRIPTION
## What does this PR do?

Implements the dependency declaration standard from issue #121 — three changes:

1. **New `docs/workflow-conventions.md`** — documents the `## Blocked by` section standard for issue bodies, including the exact format (`#N — one-line reason`), a multi-blocker example, guidance on the GitHub linked-issue relationship, and stale-blocker cleanup instructions.

2. **`superagents-workflow` SKILL.md blocker-check step** — added a new "Work Intake — Blocker Check" section to both example `superagents-workflow` SKILL.md files. After reading the issue, the skill now checks for an open `## Blocked by` section and stops with a clear message if any blocker is still open.

3. **Open issue cleanup** — reviewed all open issues (#119, #120, #122, #124, #125, #126). Only #120 had informal dependency language. Updated #120 to use the formal `## Blocked by` format and removed the stale "Prerequisite for #123" note (PR 127 merged #123).

## Agent Information (if adding/modifying an agent)

- **Agent Name**: superagents-workflow
- **Category**: workflow / orchestration
- **Specialty**: Adds issue dependency enforcement to work intake

## Checklist

- [x] Follows the agent template structure from CONTRIBUTING.md
- [x] Dependency convention documented with a correct `## Blocked by` example
- [x] `superagents-workflow` SKILL.md Work Intake step updated with blocker check in both example variants
- [x] All open issues reviewed; #120 updated to formal `## Blocked by` format
- [x] Pre-PR tests pass: `test-doc-link-integrity.sh` and `test-dogfooding-guardrails.sh`
- [x] Proofread and formatted correctly

Closes #121

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added workflow conventions documentation standardizing issue and PR practices, including "Blocked by" section formatting and commit message guidelines.

* **New Features**
  * Implemented intake-stage gates that check for open blockers and halt workflow execution until blockers are resolved or explicitly overridden.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->