### PR TITLE
Install Playwright (Chromium) in devcontainer post-create

### DIFF
--- a/skills/devcontainer-bootstrap/SKILL.md
+++ b/skills/devcontainer-bootstrap/SKILL.md
@@ -49,6 +49,7 @@ After installation, this skill's templates are expected at:
 - Generated `devcontainer.json` does not require firewall bootstrap (`postStartCommand`/`waitFor` coupling removed, no `NET_ADMIN`/`NET_RAW` capability additions).
 - npm and pnpm cache storage is configured to use named Docker volumes mounted at `/home/node/.npm-cache` and `/home/node/.pnpm-store`.
 - `postCreateCommand` installs Superagents with user-level scope inside the container.
+- Playwright (Chromium) is installed during post-create so browser automation works without additional setup (`npx playwright --version` succeeds inside the container).
 - Smoke test passes after container creation.
 
 ## Reference

--- a/skills/devcontainer-bootstrap/templates/post-create-superagents.sh
+++ b/skills/devcontainer-bootstrap/templates/post-create-superagents.sh
@@ -23,6 +23,25 @@ upgrade_gh_cli() {
 
 upgrade_gh_cli
 
+# ---------------------------------------------------------------------------
+# Install Playwright (Chromium only) so the container can run browser
+# automation without additional setup.  Chromium binaries are ~150 MB;
+# --with-deps handles OS-level libraries (libglib, libatk, etc.).
+# Expect ~2-3 min on a warm network.  Failures are non-fatal: a warning is
+# logged and post-create continues so the rest of the workflow is not blocked.
+# ---------------------------------------------------------------------------
+install_playwright() {
+  echo "Installing Playwright (Chromium only)..."
+  if npm install -g playwright \
+     && npx playwright install chromium --with-deps; then
+    echo "Playwright installed: $(npx playwright --version)"
+  else
+    echo "WARNING: Playwright install failed (network may be degraded or OS deps unavailable) — continuing without Playwright"
+  fi
+}
+
+install_playwright
+
 SUPERAGENTS_REPO="${SUPERAGENTS_REPO:-https://github.com/peakweb-team/pw-agency-agents.git}"
 SUPERAGENTS_REF="${SUPERAGENTS_REF:-main}"
 WORKDIR="$(mktemp -d)"


### PR DESCRIPTION
## What does this PR do?

Adds a `install_playwright` function to `post-create-superagents.sh` that installs Playwright globally via npm and then installs Chromium binaries with `npx playwright install chromium --with-deps`. This means any project bootstrapped with the devcontainer skill gets browser automation support out of the box — enabling the `scripts/s3-review-upload.sh` screenshot flow without any extra container setup.

Failures are non-fatal: if the install fails (e.g., network degraded inside the container), a warning is logged and the rest of post-create continues — consistent with the existing `upgrade_gh_cli` pattern.

Closes #120

## Agent Information (if adding/modifying an agent)

- **Agent Name**: superagents-devcontainer-bootstrap
- **Category**: devcontainer / tooling
- **Specialty**: browser automation setup

## Checklist

- [x] Follows the agent template structure from CONTRIBUTING.md
- [x] Includes YAML frontmatter with `name`, `description`, `color`
- [x] Has concrete code/template examples (for new agents)
- [x] Tested in real scenarios
- [x] Proofread and formatted correctly

## Changes

- `skills/devcontainer-bootstrap/templates/post-create-superagents.sh` — adds `install_playwright` function after `upgrade_gh_cli`; includes a comment noting ~2-3 min install time and ~150 MB binary size; failures are non-fatal
- `skills/devcontainer-bootstrap/SKILL.md` — adds Playwright Chromium to the Success Criteria list