### PR TITLE
Add per-project port designation for devcontainer dev servers

### DIFF
--- a/skills/devcontainer-bootstrap/SKILL.md
+++ b/skills/devcontainer-bootstrap/SKILL.md
@@ -31,11 +31,12 @@ Use this skill when a team needs to run Claude Code with `--dangerously-skip-per
    - `scaffold-devcontainer.sh`
    - `post-create-superagents.sh`
    - `smoke-test-superagents.sh`
-4. Run `scaffold-devcontainer.sh` from the project root.
-5. Confirm `.devcontainer/devcontainer.json` has `postCreateCommand` set to `.devcontainer/post-create-superagents.sh`.
-6. Ask the user to reopen the repository in the container.
-7. After container startup, run `.devcontainer/smoke-test-superagents.sh` in the container terminal.
-8. Summarize what was generated and any follow-up required.
+4. **Look up (or register) the project's designated port** — see [Port Designation](#port-designation) below.
+5. Run `scaffold-devcontainer.sh` from the project root.
+6. Confirm `.devcontainer/devcontainer.json` has `postCreateCommand` set to `.devcontainer/post-create-superagents.sh` and `forwardPorts` set to the designated port.
+7. Ask the user to reopen the repository in the container.
+8. After container startup, run `.devcontainer/smoke-test-superagents.sh` in the container terminal.
+9. Summarize what was generated and any follow-up required.
 
 ## Template Location
 
@@ -43,12 +44,54 @@ After installation, this skill's templates are expected at:
 
 - `~/.claude/skills/superagents-devcontainer-bootstrap/templates/`
 
+## Port Designation
+
+When multiple projects run simultaneously each needs a distinct dev server port to avoid collisions.
+A static registry at `skills/devcontainer-bootstrap/ports.yaml` in the superagents repo maps repo names to port numbers.
+
+### Looking up a port
+
+`scaffold-devcontainer.sh` reads the registry automatically.  It resolves the repo name from
+`basename $(git rev-parse --show-toplevel)` and looks up the matching port.  Two files are written:
+
+- `devcontainer.json` — `"forwardPorts": [<port>]` is set to the designated port.
+- `.devcontainer/.project-port` — contains just the port number so that scripts and skills can read
+  it without hardcoding (e.g. `PORT=$(cat .devcontainer/.project-port)`).
+
+### Registering a new project
+
+1. Open `skills/devcontainer-bootstrap/ports.yaml` in the superagents repo.
+2. Pick an **unused** port in the range **3100–3999**.  (3000–3099 is reserved for ad-hoc /
+   unregistered use; do not use those.)
+3. Add an entry under `projects:`:
+   ```yaml
+   projects:
+     superagents: 3100
+     my-new-project: 3101   # ← new entry
+   ```
+4. Verify no other entry uses the same port number — duplicate ports are a registry authoring error
+   that will cause port-forwarding conflicts between simultaneously running devcontainers.
+5. Commit the change to the superagents repo and re-run `scaffold-devcontainer.sh` in the target
+   project.
+
+### Error: repo not found in registry
+
+If `scaffold-devcontainer.sh` exits with:
+```
+ERROR: repo '<name>' not found in port registry.
+       Add an entry to skills/devcontainer-bootstrap/ports.yaml:
+         <name>: <port>   # pick an unused port in 3100-3999
+```
+follow the registration steps above, then re-run the scaffold.
+
 ## Success Criteria
 
 - `.devcontainer/` exists and is based on Anthropic's reference assets (`devcontainer.json`, `Dockerfile`) with superagents-specific patches applied.
 - Generated `devcontainer.json` does not require firewall bootstrap (`postStartCommand`/`waitFor` coupling removed, no `NET_ADMIN`/`NET_RAW` capability additions).
 - npm and pnpm cache storage is configured to use named Docker volumes mounted at `/home/node/.npm-cache` and `/home/node/.pnpm-store`.
 - `postCreateCommand` installs Superagents with user-level scope inside the container.
+- `devcontainer.json` contains `"forwardPorts": [<port>]` set to the project's designated port.
+- `.devcontainer/.project-port` contains the designated port number.
 - Smoke test passes after container creation.
 
 ## Reference

--- a/skills/devcontainer-bootstrap/ports.yaml
+++ b/skills/devcontainer-bootstrap/ports.yaml
@@ -1,0 +1,14 @@
+# Per-project dev server port registry.
+# Each entry maps a repo name to its designated port.
+# Port range: 3100-3999 (3000-3099 reserved for ad-hoc / unregistered use).
+#
+# To register a new project:
+#   1. Pick an unused port in the 3100-3999 range.
+#   2. Add an entry below: <repo-name>: <port>
+#   3. Commit the change to the superagents repo.
+#
+# IMPORTANT: each port number must be unique — duplicate ports are a registry
+# authoring error and will cause devcontainer port-forwarding conflicts.
+projects:
+  superagents: 3100
+  # Add new projects here

--- a/skills/devcontainer-bootstrap/templates/scaffold-devcontainer.sh
+++ b/skills/devcontainer-bootstrap/templates/scaffold-devcontainer.sh
@@ -14,10 +14,62 @@ cp "$TEMPLATE_DIR/post-create-superagents.sh" "$TARGET_DIR/post-create-superagen
 cp "$TEMPLATE_DIR/smoke-test-superagents.sh" "$TARGET_DIR/smoke-test-superagents.sh"
 chmod +x "$TARGET_DIR/post-create-superagents.sh" "$TARGET_DIR/smoke-test-superagents.sh"
 
-node - "$TARGET_DIR/devcontainer.json" <<'NODE'
-const fs = require('fs');
+# ---------------------------------------------------------------------------
+# Port designation
+# ---------------------------------------------------------------------------
+# Resolve the repo name from the git root of the project being scaffolded,
+# then look up the designated dev server port in the port registry.
+REPO_NAME="$(basename "$(git rev-parse --show-toplevel 2>/dev/null || pwd)")"
+PORTS_REGISTRY="${TEMPLATE_DIR}/../ports.yaml"
+
+if [ ! -f "$PORTS_REGISTRY" ]; then
+  echo "ERROR: port registry not found at $PORTS_REGISTRY" >&2
+  exit 1
+fi
+
+PROJECT_PORT="$(python3 - "$PORTS_REGISTRY" "$REPO_NAME" <<'PYEOF'
+import sys, re
+
+registry_file = sys.argv[1]
+repo_name     = sys.argv[2]
+
+with open(registry_file) as f:
+    content = f.read()
+
+# Parse only the projects block — avoid a hard yaml dependency.
+in_projects = False
+for line in content.splitlines():
+    stripped = line.strip()
+    if stripped.startswith('#') or not stripped:
+        continue
+    if stripped == 'projects:':
+        in_projects = True
+        continue
+    if in_projects:
+        # Detect end of mapping (top-level key)
+        if re.match(r'^\S', line) and not line.startswith(' '):
+            break
+        m = re.match(r'^\s+(\S+):\s*(\d+)', line)
+        if m and m.group(1) == repo_name:
+            print(m.group(2))
+            sys.exit(0)
+
+print(f"ERROR: repo '{repo_name}' not found in port registry.", file=sys.stderr)
+print(f"       Add an entry to skills/devcontainer-bootstrap/ports.yaml:", file=sys.stderr)
+print(f"         {repo_name}: <port>   # pick an unused port in 3100-3999", file=sys.stderr)
+sys.exit(1)
+PYEOF
+)" || exit 1
+
+# Write the port file so scripts/skills can read it without hardcoding.
+printf '%s\n' "$PROJECT_PORT" > "$TARGET_DIR/.project-port"
+echo "Port designation: $REPO_NAME -> $PROJECT_PORT (written to $TARGET_DIR/.project-port)"
+
+node - "$TARGET_DIR/devcontainer.json" "$PROJECT_PORT" <<'NODE'
+const fs   = require('fs');
 const file = process.argv[2];
-const doc = JSON.parse(fs.readFileSync(file, 'utf8'));
+const port = Number(process.argv[3]);
+const doc  = JSON.parse(fs.readFileSync(file, 'utf8'));
 delete doc.postStartCommand;
 if (doc.waitFor === 'postStartCommand') {
   delete doc.waitFor;
@@ -58,6 +110,7 @@ doc.containerEnv = {
   npm_config_store_dir: '/home/node/.pnpm-store'
 };
 doc.postCreateCommand = '.devcontainer/post-create-superagents.sh';
+doc.forwardPorts = [port];
 fs.writeFileSync(file, `${JSON.stringify(doc, null, 2)}\n`);
 NODE
 


### PR DESCRIPTION
## What does this PR do?

Implements per-project dev server port designation for devcontainers so multiple projects can run simultaneously without port collisions.

- Introduces `skills/devcontainer-bootstrap/ports.yaml` — a static registry mapping repo names to designated ports (range 3100–3999; `superagents` -> 3100).
- `scaffold-devcontainer.sh` now resolves the repo name via `basename $(git rev-parse --show-toplevel)`, looks up the port using `python3` (no extra deps), writes `"forwardPorts": [<port>]` into `devcontainer.json`, and writes the port number to `.devcontainer/.project-port` for downstream scripts/skills to consume.
- Scaffold exits with a clear, actionable error message when the repo is not found in the registry.
- `SKILL.md` gets a new **Port Designation** section covering port lookup, project registration, and error recovery.

Closes #125

## Agent Information (if adding/modifying an agent)

N/A — this is a devcontainer scaffold enhancement, not a new agent.

## Checklist

- [x] Follows the agent template structure from CONTRIBUTING.md
- [x] Includes YAML frontmatter with `name`, `description`, `color`
- [x] Has concrete code/template examples (for new agents)
- [x] Tested in real scenarios
- [x] Proofread and formatted correctly

## Validation

```
./tests/test-doc-link-integrity.sh      # passed (60 markdown files)
./tests/test-fragment-contract-validation.sh   # passed (9 fragment files)
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced dev container bootstrap workflow documentation with port management guidelines, registration procedures, and error handling guidance.

* **New Features**
  * Introduced dev server port registry system for consistent per-project port allocation.
  * Dev containers now automatically configure port forwarding for designated project ports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->