### PR TITLE
Add devcontainer management skill

### DIFF
--- a/skills/README.md
+++ b/skills/README.md
@@ -14,6 +14,8 @@ This directory is the starting point for the Superagents skills layer.
   - Interactive builder skill that inventories a repo, asks a targeted questionnaire, and assembles project-specific skills.
 - `devcontainer-bootstrap/`
   - Isolated Claude devcontainer bootstrap skill based on Anthropic reference assets, including user-level Superagents install hooks for containerized `--dangerously-skip-permissions` usage.
+- `superagents-devcontainer/`
+  - Day-to-day devcontainer management: rebuild after config changes, stop running containers, and extend a container with a new package or tool.
 - `fragments/task-intake/`
   - Work-entry fragments for direct-brief and other intake modes.
 - `fragments/project-management/`

--- a/skills/devcontainer-bootstrap/SKILL.md
+++ b/skills/devcontainer-bootstrap/SKILL.md
@@ -95,6 +95,10 @@ follow the registration steps above, then re-run the scaffold.
 - Playwright (Chromium) is installed during post-create so browser automation works without additional setup (`npx playwright --version` succeeds inside the container).
 - Smoke test passes after container creation.
 
+## Container Management
+
+For day-to-day container operations after the initial bootstrap — rebuilding after a config change, stopping a running container, or installing a bespoke package — see the `superagents-devcontainer` skill.
+
 ## Reference
 
 - Anthropic devcontainer docs: `https://code.claude.com/docs/en/devcontainer`

--- a/skills/fragments/README.md
+++ b/skills/fragments/README.md
@@ -28,7 +28,7 @@ In v1, each fragment is:
 - `orchestration/`
   - team-sizing, role-shaping, and coordination fragments
 - `runtime/`
-  - context, model-routing, and execution-discipline fragments
+  - context, model-routing, execution-discipline, and devcontainer-management fragments
 
 ## Builder Expectations
 

--- a/skills/fragments/runtime/devcontainer-management.md
+++ b/skills/fragments/runtime/devcontainer-management.md
@@ -1,0 +1,50 @@
+---
+schema_version: 1
+id: runtime/devcontainer-management
+title: Devcontainer Management
+fragment_type: generic
+layer: runtime
+summary: Surface rebuild, stop, and package-extension operations for Superagents devcontainers so operators do not need to recall Docker and VS Code commands from memory.
+capabilities:
+  - runtime.devcontainer-management
+selection:
+  evidence_any:
+    - repo.devcontainer
+    - toolchain.docker
+    - runtime.claude-code-dangerously-skip-permissions
+  evidence_all: []
+  evidence_none: []
+  preference: 60
+composition:
+  requires: []
+  suggests:
+    - runtime/context-and-model-routing
+  conflicts: []
+  exclusive_within: []
+  emits:
+    - devcontainer-management-rules
+  order: 75
+---
+
+# Fragment: Devcontainer Management
+
+## Purpose
+
+Make common devcontainer lifecycle operations discoverable so operators do not need to ask Claude for the right commands each time they rebuild, stop, or extend a running container.
+
+## Include When
+
+- The repository contains a `.devcontainer/` directory.
+- The workflow uses `--dangerously-skip-permissions` inside a container.
+- Docker is part of the project's local development toolchain.
+
+## Expected Behaviors
+
+- When a config change is detected (`devcontainer.json`, `Dockerfile`, `post-create-superagents.sh`), proactively suggest a rebuild using the `superagents-devcontainer` skill.
+- When asked to stop or pause a container environment, use the Docker label-filter approach rather than stopping all containers indiscriminately.
+- When asked to add a package, distinguish between a one-off in-container install and a permanent change to `post-create-superagents.sh` and recommend the appropriate path.
+
+## Builder Notes
+
+- This fragment delegates the actual command reference to the `superagents-devcontainer` skill; include that skill in the generated output alongside the primary orchestration skill.
+- Do not include this fragment unless a `.devcontainer/` directory or equivalent Docker-based workflow signal is present.

--- a/skills/superagents-devcontainer/SKILL.md
+++ b/skills/superagents-devcontainer/SKILL.md
@@ -1,0 +1,161 @@
+---
+name: superagents-devcontainer
+description: Manage a running or stopped Superagents devcontainer — rebuild after config changes, stop running containers, or extend an existing container with a new package or tool.
+disable-model-invocation: false
+argument-hint: "[rebuild | stop | extend <package>]"
+---
+
+# Superagents Devcontainer Management
+
+Use this skill when you need to manage the lifecycle of a Superagents devcontainer:
+
+- **Rebuild** — after changing `devcontainer.json`, `Dockerfile`, or `post-create-superagents.sh`
+- **Stop** — shut down a running container (specific project or all Superagents instances)
+- **Extend** — add a package or tool to a running container without a full rebuild
+
+---
+
+## 1. Rebuild
+
+### When to Use
+
+Rebuild any time you change:
+
+- `.devcontainer/devcontainer.json`
+- `.devcontainer/Dockerfile`
+- `.devcontainer/post-create-superagents.sh`
+
+### Prerequisites
+
+Either:
+- VS Code with the [Dev Containers extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers) installed, **or**
+- The `@devcontainers/cli` npm package: `npm install -g @devcontainers/cli`
+
+### Commands
+
+**VS Code (host):**
+
+1. Open the Command Palette (`Cmd+Shift+P` on macOS, `Ctrl+Shift+P` on Linux/Windows).
+2. Run `Dev Containers: Rebuild Container`.
+3. To discard the cached image layers as well, run `Dev Containers: Rebuild Without Cache` instead.
+
+**CLI (host terminal):**
+
+```bash
+# Standard rebuild (uses cached layers where possible)
+devcontainer up --workspace-folder .
+
+# Force a clean rebuild (no cached layers)
+devcontainer up --workspace-folder . --remove-existing-container
+```
+
+Run both commands from the **project root on the host** (not inside the container).
+
+### Prerequisite Check
+
+Before rebuilding, confirm that either VS Code with the Dev Containers extension is active, or `devcontainer` is on your PATH:
+
+```bash
+devcontainer --version
+```
+
+If the command is not found, install the CLI:
+
+```bash
+npm install -g @devcontainers/cli
+```
+
+---
+
+## 2. Stop / Shutdown
+
+### Where to Run
+
+All stop commands run on the **host Mac terminal** (not inside the container).
+
+### Stop a Specific Project's Container
+
+```bash
+docker ps --filter "label=devcontainer.local_folder=<absolute-path-to-project>" -q \
+  | xargs -r docker stop
+```
+
+Replace `<absolute-path-to-project>` with the absolute path of the project whose container you want to stop, for example `/Users/yourname/dev/my-project`.
+
+To find the path label for a running container:
+
+```bash
+docker inspect <container-id> --format '{{ index .Config.Labels "devcontainer.local_folder" }}'
+```
+
+### Stop All Superagents Devcontainers
+
+```bash
+docker ps --filter "label=devcontainer.local_folder" -q | xargs -r docker stop
+```
+
+This stops every container that carries the `devcontainer.local_folder` label, which is set by VS Code's Dev Containers extension on all devcontainers it manages.
+
+### Important: Detach VS Code First
+
+Containers managed by VS Code **auto-restart** when VS Code re-attaches to them. Before stopping:
+
+1. In VS Code, open the Command Palette and run `Dev Containers: Close Remote Connection`.
+2. Confirm the status bar no longer shows the container name.
+3. Then run the stop command above.
+
+---
+
+## 3. Extend (Add a Package or Tool)
+
+### One-Off Install (not persisted across rebuilds)
+
+Run inside the container terminal:
+
+```bash
+sudo apt-get install -y <package>
+```
+
+This installs the package in the running container immediately. The change is **lost on the next rebuild**.
+
+Use this approach for temporary exploration or when you are not yet sure if the package should be permanent.
+
+### Permanent Install (persisted across rebuilds)
+
+1. On the **host**, open `.devcontainer/post-create-superagents.sh`.
+2. Add the package under the appropriate `apt-get install` block, following the existing grouping comments in the file.
+3. Commit the change.
+4. Rebuild the container (see [Rebuild](#1-rebuild) above) so the new package is baked into the post-create step.
+
+#### Example — adding `jq` permanently
+
+```bash
+# Inside post-create-superagents.sh, locate the apt install block:
+sudo apt-get install -y \
+  git \
+  curl \
+  jq        # ← add here
+```
+
+Then rebuild:
+
+```bash
+devcontainer up --workspace-folder . --remove-existing-container
+```
+
+### Where to Run
+
+| Step | Location |
+|------|----------|
+| One-off `apt-get install` | Inside the running container |
+| Edit `post-create-superagents.sh` | Host (your editor) |
+| `devcontainer up` rebuild | Host terminal |
+
+---
+
+## Reference
+
+- Anthropic devcontainer docs: `https://code.claude.com/docs/en/devcontainer`
+- Dev Containers CLI: `https://github.com/devcontainers/cli`
+- VS Code Dev Containers extension: `https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers`
+- For initial devcontainer setup, see the `superagents-devcontainer-bootstrap` skill.


### PR DESCRIPTION
## What does this PR do?

Adds a `superagents-devcontainer` skill covering the three core devcontainer management operations: rebuild, stop/shutdown, and extend (add a package). Operators no longer need to recall Docker and VS Code commands from memory — they can invoke the skill or ask Claude to apply it.

Closes #126

## Changes

- **`skills/superagents-devcontainer/SKILL.md`** — new skill with three sections:
  - **Rebuild**: VS Code Command Palette path + `devcontainer up` CLI equivalent, prerequisite check, and when to use each variant (cached vs. `--remove-existing-container`)
  - **Stop / Shutdown**: `docker ps --filter label=devcontainer.local_folder` commands for single-project and all-superagents targets; note on detaching VS Code before stopping to prevent auto-restart
  - **Extend**: `sudo apt-get install -y` for one-off in-container installs; `post-create-superagents.sh` edit + rebuild for permanent installs; where-to-run table

- **`skills/devcontainer-bootstrap/SKILL.md`** — added a "Container Management" section pointing operators to the new `superagents-devcontainer` skill for post-bootstrap lifecycle operations

- **`skills/fragments/runtime/devcontainer-management.md`** — new fragment the skill-builder selects when `repo.devcontainer`, `toolchain.docker`, or `runtime.claude-code-dangerously-skip-permissions` signals are detected; emits `devcontainer-management-rules` and references the `superagents-devcontainer` skill

- **`skills/README.md`** — listed new `superagents-devcontainer/` skill

- **`skills/fragments/README.md`** — noted devcontainer-management in the `runtime/` layer description

## Agent Information (if adding/modifying an agent)

- **Agent Name**: superagents-devcontainer
- **Category**: runtime / devcontainer lifecycle
- **Specialty**: rebuild, stop, extend devcontainer operations

## Checklist

- [x] Follows the agent template structure from CONTRIBUTING.md
- [x] Includes YAML frontmatter with `name`, `description`
- [x] Has concrete code/template examples (for new agents)
- [x] Tested in real scenarios
- [x] Proofread and formatted correctly
- [x] `test-doc-link-integrity.sh` passed
- [x] `test-fragment-contract-validation.sh` passed
- [x] `test-dogfooding-guardrails.sh` passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)