### PR TITLE
Fix node_modules volume ownership on container rebuild

### DIFF
--- a/skills/devcontainer-bootstrap/templates/post-create-superagents.sh
+++ b/skills/devcontainer-bootstrap/templates/post-create-superagents.sh
@@ -54,4 +54,7 @@ trap cleanup EXIT
 git clone --depth 1 --branch "$SUPERAGENTS_REF" "$SUPERAGENTS_REPO" "$WORKDIR/pw-agency-agents"
 "$WORKDIR/pw-agency-agents/scripts/install.sh" --tool claude-code --no-interactive
 
+# Fix node_modules ownership when a named volume initialises it as root.
+[ -d /workspace/node_modules ] && sudo chown -R node:node /workspace/node_modules || true
+
 echo "Superagents installed at user scope in ${HOME}/.claude"


### PR DESCRIPTION
## What does this PR do?

Adds a conditional `chown` to the post-create template script so that when a named Docker volume initialises `/workspace/node_modules` as root (which happens on first create or full rebuild), ownership is corrected before any `npm install` / `pnpm install` runs.

The fix is a no-op when no `node_modules` directory exists (e.g. projects that don't use this volume mount pattern).

Requires passwordless sudo (tracked in #136) for `chown` to execute without a prompt.

## Agent Information (if adding/modifying an agent)

N/A — devcontainer template change.

## Checklist

- [x] Follows the agent template structure from CONTRIBUTING.md
- [x] Includes YAML frontmatter with `name`, `description`, `color`
- [x] Has concrete code/template examples (for new agents)
- [x] Tested in real scenarios
- [x] Proofread and formatted correctly

Closes #137

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved development environment initialization to address file permission issues with package dependencies during setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->