### PR TITLE
Enable passwordless sudo and install gh CLI from official source at build time

### DIFF
--- a/skills/devcontainer-bootstrap/templates/post-create-superagents.sh
+++ b/skills/devcontainer-bootstrap/templates/post-create-superagents.sh
@@ -2,28 +2,6 @@
 set -euo pipefail
 
 # ---------------------------------------------------------------------------
-# Upgrade gh CLI to latest stable release (base image ships v2.23.0 which
-# predates gh project item-edit and gh project field-list improvements).
-# Networking failures are non-fatal: a warning is logged and the script
-# continues so the rest of post-create is not blocked.
-# ---------------------------------------------------------------------------
-upgrade_gh_cli() {
-  echo "Upgrading gh CLI to latest stable release..."
-  if curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
-       | sudo dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg 2>/dev/null \
-     && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
-       | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null \
-     && sudo apt-get -o APT::Sandbox::User=root update -y \
-     && sudo apt-get install -y gh; then
-    echo "gh CLI upgraded: $(gh --version | head -1)"
-  else
-    echo "WARNING: gh CLI upgrade failed (network may be degraded) — continuing with existing version: $(gh --version 2>/dev/null | head -1 || echo 'unknown')"
-  fi
-}
-
-upgrade_gh_cli
-
-# ---------------------------------------------------------------------------
 # Install Playwright (Chromium only) so the container can run browser
 # automation without additional setup.  Chromium binaries are ~150 MB;
 # --with-deps handles OS-level libraries (libglib, libatk, etc.).

--- a/skills/devcontainer-bootstrap/templates/scaffold-devcontainer.sh
+++ b/skills/devcontainer-bootstrap/templates/scaffold-devcontainer.sh
@@ -143,5 +143,57 @@ if (
 fs.writeFileSync(file, updated);
 NODE
 
+# Install gh CLI from the official GitHub source at build time so the container
+# ships the latest version without needing a runtime upgrade in post-create.
+node - "$TARGET_DIR/Dockerfile" <<'NODE'
+const fs = require('fs');
+const file = process.argv[2];
+let updated = fs.readFileSync(file, 'utf8');
+
+if (!updated.includes('githubcli-archive-keyring.gpg')) {
+  // Remove `gh` from the basic apt-get install list (Debian ships an older version).
+  updated = updated.replace(/^[ \t]+gh[ \t]*\\?\n/gm, '');
+
+  // Append the official gh CLI install block after the first apt-get clean line.
+  const ghBlock = [
+    '',
+    '# Install gh CLI from official GitHub source (gets latest, not Debian\'s older version).',
+    'RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \\',
+    '      | dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg \\',
+    '    && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \\',
+    '      > /etc/apt/sources.list.d/github-cli.list \\',
+    '    && apt-get -o APT::Sandbox::User=root update \\',
+    '    && apt-get install -y gh',
+  ].join('\n');
+  updated = updated.replace(
+    /(&&\s*apt-get\s+clean\s*&&\s*rm\s+-rf\s+\/var\/lib\/apt\/lists\/\*)/,
+    `$1${ghBlock}`
+  );
+}
+fs.writeFileSync(file, updated);
+NODE
+
+# Enable passwordless sudo for the node user (devcontainer-only).
+node - "$TARGET_DIR/Dockerfile" <<'NODE'
+const fs = require('fs');
+const file = process.argv[2];
+let updated = fs.readFileSync(file, 'utf8');
+
+if (!updated.includes('sudoers.d/node')) {
+  const sudoersBlock = [
+    '',
+    '# Allow the node user to run sudo without a password (devcontainer-only).',
+    'RUN echo "node ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers.d/node && \\',
+    '    chmod 0440 /etc/sudoers.d/node',
+  ].join('\n');
+  // Insert immediately before USER node (or USER $USERNAME as a fallback).
+  updated = updated.replace(
+    /(^\s*USER\s+(?:node|\$USERNAME)\s*$)/m,
+    `${sudoersBlock}\n\n$1`
+  );
+}
+fs.writeFileSync(file, updated);
+NODE
+
 echo "Scaffolded Anthropic-based devcontainer into $TARGET_DIR"
 echo "Next step: reopen this repository in container and run .devcontainer/smoke-test-superagents.sh"


### PR DESCRIPTION
## What does this PR do?

Two related fixes that eliminate sudo password prompts in the devcontainer:

**1. gh CLI — move install to Dockerfile build time**

The Dockerfile previously installed an old `gh` version from Debian's package list; `post-create-superagents.sh` then tried to upgrade it via the official GitHub CLI apt source using `sudo`, which prompted for a password that was never set. This PR:

- Removes `gh` from the basic `apt-get install` list in the Dockerfile patch.
- Adds a new Dockerfile patch that installs `gh` from `https://cli.github.com/packages` at build time (runs as root, no sudo needed).
- Removes the `upgrade_gh_cli` function and its call from `post-create-superagents.sh`.

**2. Passwordless sudo for the `node` user**

Adds a new Dockerfile patch that writes a `sudoers.d/node` entry immediately before `USER node`, enabling `sudo` without a password inside the devcontainer. This unblocks the `node_modules` ownership fix in #137 and any future operations that legitimately need elevated privileges inside the container.

Both patches are idempotent (guarded by content checks before applying).

## Agent Information (if adding/modifying an agent)

N/A — devcontainer scaffold template changes only.

## Checklist

- [x] Follows the agent template structure from CONTRIBUTING.md
- [x] Includes YAML frontmatter with `name`, `description`, `color`
- [x] Has concrete code/template examples (for new agents)
- [x] Tested in real scenarios
- [x] Proofread and formatted correctly

Closes #136

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Streamlined GitHub CLI installation process by removing redundant post-create upgrade logic
  * GitHub CLI now sourced from official packages for improved version management
  * Enabled passwordless sudo access for the node user in the development container environment

<!-- end of auto-generated comment: release notes by coderabbit.ai -->