### PR TITLE
Builder: emit upgrade-aware metadata in generated bundles

### DIFF
--- a/docs/generated-skill-layout.md
+++ b/docs/generated-skill-layout.md
@@ -22,6 +22,8 @@ It builds on:
 - the batch spec planning and artifact model in [`docs/spec-batch-planning-contract.md`](./spec-batch-planning-contract.md)
 - the roadmap direction toward a workflow operating system instead of a loose prompt library
 
+This contract is at `schema_version: 1`. Manifests reference this value as `contract_versions.generated_skill_schema`.
+
 ## Why This Exists
 
 The builder can only be trustworthy if its output lands in a predictable place, uses stable names, and is reviewable like normal project code.
@@ -215,6 +217,7 @@ The MVP metadata bundle should include:
 
 - `manifest.yaml`
   - top-level summary of the builder run, generated skills, framework release, compatibility status, and schema versions
+  - must carry the upgrade-aware metadata fields required by [`docs/release-versioning-and-upgrade-contract.md`](./release-versioning-and-upgrade-contract.md): `framework_release`, `generated_at`, `contract_versions` (with at minimum `fragment_schema`, `generated_skill_schema`, `integration_declaration_schema`), and a structured `compatibility` block (`status`, `reason`, `manual_review_required`)
 - `integrations.yaml`
   - repo-local declaration of which configured integration satisfies each external capability
 - `inventory.yaml`

--- a/skills/skill-builder/SKILL.md
+++ b/skills/skill-builder/SKILL.md
@@ -96,6 +96,28 @@ Each generated skill must:
 
 The builder metadata bundle must include the inventory record, decision record, fragment lock information, and a human-readable review summary.
 
+The generated `manifest.yaml` must additionally carry the upgrade-aware metadata required by `docs/release-versioning-and-upgrade-contract.md` so a future upgrade tool can compare an installed framework release against this generated bundle. Required fields:
+
+- `framework_release`
+  - Type: string
+  - Source: the release tag of the installed superagents framework (for example `v0.1.0`)
+  - Fallback: when no release tag is available, populate this field with `git describe --tags --always --dirty` of the host superagents checkout. The dirty marker is intentional so a bundle generated from an uncommitted superagents working tree is reviewable as such.
+- `generated_at`
+  - Type: string (ISO-8601 UTC timestamp)
+  - Source: the moment the bundle was assembled. Do not reuse the contract example value `2026-04-30T00:00:00Z`.
+- `contract_versions`
+  - Type: object
+  - Required keys: `fragment_schema`, `generated_skill_schema`, `integration_declaration_schema`
+  - Each value is the integer `schema_version` of the corresponding contract document (`docs/fragment-schema.md`, `docs/generated-skill-layout.md`, `docs/project-integration-declaration-format.md`). Read those docs at generation time rather than hardcoding values.
+- `compatibility`
+  - Type: object
+  - Required keys:
+    - `status` — one of `compatible`, `regeneration-recommended`, `regeneration-required` (the exact enum from the upgrade contract)
+    - `reason` — short string explaining the recorded status
+    - `manual_review_required` — boolean
+
+These fields replace any earlier loose `framework_release: v0.x` placeholder or single-string `compatibility_status` field.
+
 When integrations are in scope, the metadata bundle must also include `integrations.yaml` so provider mappings are reviewable and versioned with the project.
 
 If a capability is degraded or unavailable, the metadata bundle must make the fallback mode and any manual steps visible.

--- a/tests/fixtures/manifest-upgrade-metadata/invalid/bad-compatibility-status.yaml
+++ b/tests/fixtures/manifest-upgrade-metadata/invalid/bad-compatibility-status.yaml
@@ -1,0 +1,12 @@
+# Invalid: compatibility.status is not one of the contract enum values.
+schema_version: 1
+framework_release: v1.1.0
+generated_at: 2026-04-30T12:34:56Z
+contract_versions:
+  fragment_schema: 1
+  generated_skill_schema: 1
+  integration_declaration_schema: 1
+compatibility:
+  status: maybe
+  reason: bad status on purpose
+  manual_review_required: false

--- a/tests/fixtures/manifest-upgrade-metadata/invalid/bad-generated-at.yaml
+++ b/tests/fixtures/manifest-upgrade-metadata/invalid/bad-generated-at.yaml
@@ -1,0 +1,12 @@
+# Invalid: generated_at is not an ISO-8601 timestamp.
+schema_version: 1
+framework_release: v1.1.0
+generated_at: yesterday
+contract_versions:
+  fragment_schema: 1
+  generated_skill_schema: 1
+  integration_declaration_schema: 1
+compatibility:
+  status: compatible
+  reason: bad generated_at on purpose
+  manual_review_required: false

--- a/tests/fixtures/manifest-upgrade-metadata/invalid/missing-compatibility-reason.yaml
+++ b/tests/fixtures/manifest-upgrade-metadata/invalid/missing-compatibility-reason.yaml
@@ -1,0 +1,12 @@
+# Invalid: compatibility.reason is missing. The contract requires a short
+# string explaining why the recorded status applies.
+schema_version: 1
+framework_release: v1.1.0
+generated_at: 2026-04-30T12:34:56Z
+contract_versions:
+  fragment_schema: 1
+  generated_skill_schema: 1
+  integration_declaration_schema: 1
+compatibility:
+  status: regeneration-required
+  manual_review_required: true

--- a/tests/fixtures/manifest-upgrade-metadata/invalid/missing-contract-version-key.yaml
+++ b/tests/fixtures/manifest-upgrade-metadata/invalid/missing-contract-version-key.yaml
@@ -1,0 +1,13 @@
+# Invalid: contract_versions.integration_declaration_schema is missing.
+# All three contract version keys are required so a future upgrade tool
+# can pin every contract surface independently.
+schema_version: 1
+framework_release: v1.1.0
+generated_at: 2026-04-30T12:34:56Z
+contract_versions:
+  fragment_schema: 1
+  generated_skill_schema: 1
+compatibility:
+  status: compatible
+  reason: missing integration_declaration_schema on purpose
+  manual_review_required: false

--- a/tests/fixtures/manifest-upgrade-metadata/invalid/missing-framework-release.yaml
+++ b/tests/fixtures/manifest-upgrade-metadata/invalid/missing-framework-release.yaml
@@ -1,0 +1,12 @@
+# Invalid: framework_release is omitted entirely. Must be rejected because
+# the upgrade contract requires this field for release diffing.
+schema_version: 1
+generated_at: 2026-04-30T12:34:56Z
+contract_versions:
+  fragment_schema: 1
+  generated_skill_schema: 1
+  integration_declaration_schema: 1
+compatibility:
+  status: compatible
+  reason: missing framework_release on purpose
+  manual_review_required: false

--- a/tests/fixtures/manifest-upgrade-metadata/invalid/quoted-contract-version.yaml
+++ b/tests/fixtures/manifest-upgrade-metadata/invalid/quoted-contract-version.yaml
@@ -1,0 +1,14 @@
+# Invalid: contract_versions.fragment_schema is a quoted string ("1") rather
+# than an unquoted integer. The contract requires the YAML integer type;
+# this fixture exists specifically to keep the quoted-scalar bypass closed.
+schema_version: 1
+framework_release: v1.1.0
+generated_at: 2026-04-30T12:34:56Z
+contract_versions:
+  fragment_schema: "1"
+  generated_skill_schema: 1
+  integration_declaration_schema: 1
+compatibility:
+  status: compatible
+  reason: quoted contract version on purpose
+  manual_review_required: false

--- a/tests/fixtures/manifest-upgrade-metadata/invalid/quoted-manual-review-required.yaml
+++ b/tests/fixtures/manifest-upgrade-metadata/invalid/quoted-manual-review-required.yaml
@@ -1,0 +1,14 @@
+# Invalid: compatibility.manual_review_required is a quoted YAML string
+# ("true") rather than the boolean type the contract requires. Pairs with
+# quoted-contract-version.yaml to lock down the quoted-scalar bypass.
+schema_version: 1
+framework_release: v1.1.0
+generated_at: 2026-04-30T12:34:56Z
+contract_versions:
+  fragment_schema: 1
+  generated_skill_schema: 1
+  integration_declaration_schema: 1
+compatibility:
+  status: compatible
+  reason: quoted boolean on purpose
+  manual_review_required: "true"

--- a/tests/fixtures/manifest-upgrade-metadata/valid/git-describe-fallback.yaml
+++ b/tests/fixtures/manifest-upgrade-metadata/valid/git-describe-fallback.yaml
@@ -1,0 +1,16 @@
+# Valid manifest fixture: framework_release populated via the documented
+# `git describe --tags --always --dirty` fallback when no release tag exists
+# yet (the pre-1.0 main case). Uses regeneration-recommended status with
+# manual_review_required=true to exercise the non-default enum/boolean
+# branches.
+schema_version: 1
+framework_release: 0.0.0-12-gabcdef0-dirty
+generated_at: 2026-04-30T08:15:00+00:00
+contract_versions:
+  fragment_schema: 1
+  generated_skill_schema: 1
+  integration_declaration_schema: 1
+compatibility:
+  status: regeneration-recommended
+  reason: Built from a dirty pre-release working tree
+  manual_review_required: true

--- a/tests/fixtures/manifest-upgrade-metadata/valid/release-tagged.yaml
+++ b/tests/fixtures/manifest-upgrade-metadata/valid/release-tagged.yaml
@@ -1,0 +1,15 @@
+# Valid manifest fixture: framework_release pinned to a release tag.
+# Demonstrates the canonical, fully populated upgrade-aware metadata shape
+# defined in docs/release-versioning-and-upgrade-contract.md and required by
+# skills/skill-builder/SKILL.md Phase 4.
+schema_version: 1
+framework_release: v1.1.0
+generated_at: 2026-04-30T12:34:56Z
+contract_versions:
+  fragment_schema: 1
+  generated_skill_schema: 1
+  integration_declaration_schema: 1
+compatibility:
+  status: compatible
+  reason: First generation against v1.1.0
+  manual_review_required: false

--- a/tests/test-manifest-upgrade-metadata.sh
+++ b/tests/test-manifest-upgrade-metadata.sh
@@ -54,7 +54,10 @@ get_top_level() {
 }
 
 # Extract the value of a nested key (single level) under a parent object.
-# Assumes two-space indentation for child keys.
+# Assumes two-space indentation for child keys. Strips surrounding quotes
+# so callers receive the string value of YAML scalars regardless of
+# quoting style. Use get_nested_raw when the YAML type itself
+# (integer/boolean vs quoted string) needs to be enforced.
 get_nested() {
   local parent="$1" key="$2" file="$3"
   awk -v parent="$parent" -v key="$key" '
@@ -64,6 +67,23 @@ get_nested() {
       sub("^  "key":[[:space:]]*", "", $0)
       sub("[[:space:]]+#.*$", "", $0)
       gsub(/^["'\'']|["'\'']$/, "", $0)
+      print
+      exit
+    }
+  ' "$file"
+}
+
+# Same as get_nested but preserves surrounding quotes so type-strict
+# checks (e.g. integer or boolean) can reject quoted YAML scalars.
+get_nested_raw() {
+  local parent="$1" key="$2" file="$3"
+  awk -v parent="$parent" -v key="$key" '
+    $0 ~ "^"parent":[[:space:]]*$" { in_block = 1; next }
+    in_block && /^[^[:space:]]/ { in_block = 0 }
+    in_block && $0 ~ "^  "key":" {
+      sub("^  "key":[[:space:]]*", "", $0)
+      sub("[[:space:]]+#.*$", "", $0)
+      sub("[[:space:]]+$", "", $0)
       print
       exit
     }
@@ -113,12 +133,14 @@ for manifest in "${MANIFESTS[@]}"; do
   fi
 
   for nested_key in fragment_schema generated_skill_schema integration_declaration_schema; do
-    value="$(get_nested contract_versions "$nested_key" "$manifest")"
+    # Use the raw extractor: a quoted YAML scalar like `"1"` is a string,
+    # not the integer the contract requires.
+    value="$(get_nested_raw contract_versions "$nested_key" "$manifest")"
     if [[ -z "$value" ]]; then
       fail "contract_versions.$nested_key is missing" "$manifest"
     fi
     if ! [[ "$value" =~ ^[0-9]+$ ]]; then
-      fail "contract_versions.$nested_key must be an integer, got '$value'" "$manifest"
+      fail "contract_versions.$nested_key must be an unquoted integer, got '$value'" "$manifest"
     fi
   done
 
@@ -135,12 +157,14 @@ for manifest in "${MANIFESTS[@]}"; do
     fail "compatibility.reason is missing or empty" "$manifest"
   fi
 
-  manual_review_required="$(get_nested compatibility manual_review_required "$manifest")"
+  # Use the raw extractor so a quoted YAML string like `"true"` is rejected;
+  # the contract requires the YAML boolean type.
+  manual_review_required="$(get_nested_raw compatibility manual_review_required "$manifest")"
   if [[ -z "$manual_review_required" ]]; then
     fail "compatibility.manual_review_required is missing" "$manifest"
   fi
   if ! is_boolean "$manual_review_required"; then
-    fail "compatibility.manual_review_required must be a boolean, got '$manual_review_required'" "$manifest"
+    fail "compatibility.manual_review_required must be an unquoted boolean, got '$manual_review_required'" "$manifest"
   fi
 done
 

--- a/tests/test-manifest-upgrade-metadata.sh
+++ b/tests/test-manifest-upgrade-metadata.sh
@@ -1,0 +1,147 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+AGENCY_ROOT="$ROOT_DIR/.agency/skills"
+
+# The dogfood metadata bundle under .agency/skills/ is gitignored and only
+# present after a local builder run. If it is absent, there is nothing to
+# validate in this environment; the test is a no-op rather than a failure.
+if [[ ! -d "$AGENCY_ROOT" ]]; then
+  echo "Manifest upgrade-metadata tests: no .agency/skills/ found, skipping (passed)"
+  exit 0
+fi
+
+mapfile -d '' MANIFESTS < <(find "$AGENCY_ROOT" -type f -name 'manifest.yaml' -print0)
+
+if [[ "${#MANIFESTS[@]}" -eq 0 ]]; then
+  echo "Manifest upgrade-metadata tests: no manifest.yaml files found under .agency/skills/, skipping (passed)"
+  exit 0
+fi
+
+# Compatibility status enum from docs/release-versioning-and-upgrade-contract.md.
+ALLOWED_STATUSES=(compatible regeneration-recommended regeneration-required)
+
+# Required top-level scalar fields. Each entry is "<key>:<regex>" where the
+# regex matches the field on a line of its own (allowing optional value).
+REQUIRED_TOP_LEVEL=(
+  'framework_release:^framework_release:[[:space:]]*\S'
+  'generated_at:^generated_at:[[:space:]]*\S'
+)
+
+fail() {
+  echo "Manifest upgrade-metadata test failure: $1" >&2
+  if [[ -n "${2:-}" ]]; then
+    echo "  manifest: $2" >&2
+  fi
+  exit 1
+}
+
+# Extract the value of a top-level scalar key from a YAML manifest.
+# Treats the file as a flat YAML document with two-space indentation for
+# nested objects. Strips surrounding quotes and trailing comments.
+get_top_level() {
+  local key="$1" file="$2"
+  awk -v key="$key" '
+    $0 ~ "^"key":" {
+      sub("^"key":[[:space:]]*", "", $0)
+      sub("[[:space:]]+#.*$", "", $0)
+      gsub(/^["'\'']|["'\'']$/, "", $0)
+      print
+      exit
+    }
+  ' "$file"
+}
+
+# Extract the value of a nested key (single level) under a parent object.
+# Assumes two-space indentation for child keys.
+get_nested() {
+  local parent="$1" key="$2" file="$3"
+  awk -v parent="$parent" -v key="$key" '
+    $0 ~ "^"parent":[[:space:]]*$" { in_block = 1; next }
+    in_block && /^[^[:space:]]/ { in_block = 0 }
+    in_block && $0 ~ "^  "key":" {
+      sub("^  "key":[[:space:]]*", "", $0)
+      sub("[[:space:]]+#.*$", "", $0)
+      gsub(/^["'\'']|["'\'']$/, "", $0)
+      print
+      exit
+    }
+  ' "$file"
+}
+
+is_iso_8601() {
+  local value="$1"
+  # Accept basic ISO-8601 UTC ("...Z") or with explicit offset ("+HH:MM"/"-HH:MM").
+  [[ "$value" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(\.[0-9]+)?(Z|[+-][0-9]{2}:[0-9]{2})$ ]]
+}
+
+is_allowed_status() {
+  local value="$1" allowed
+  for allowed in "${ALLOWED_STATUSES[@]}"; do
+    if [[ "$value" == "$allowed" ]]; then
+      return 0
+    fi
+  done
+  return 1
+}
+
+is_boolean() {
+  local value="$1"
+  [[ "$value" == "true" || "$value" == "false" ]]
+}
+
+for manifest in "${MANIFESTS[@]}"; do
+  echo "Validating $manifest"
+
+  for entry in "${REQUIRED_TOP_LEVEL[@]}"; do
+    field="${entry%%:*}"
+    pattern="${entry#*:}"
+    if ! grep -Eq "$pattern" "$manifest"; then
+      fail "missing or empty top-level field '$field'" "$manifest"
+    fi
+  done
+
+  framework_release="$(get_top_level framework_release "$manifest")"
+  if [[ -z "$framework_release" ]]; then
+    fail "framework_release is empty" "$manifest"
+  fi
+
+  generated_at="$(get_top_level generated_at "$manifest")"
+  if ! is_iso_8601 "$generated_at"; then
+    fail "generated_at is not a valid ISO-8601 timestamp: '$generated_at'" "$manifest"
+  fi
+
+  for nested_key in fragment_schema generated_skill_schema integration_declaration_schema; do
+    value="$(get_nested contract_versions "$nested_key" "$manifest")"
+    if [[ -z "$value" ]]; then
+      fail "contract_versions.$nested_key is missing" "$manifest"
+    fi
+    if ! [[ "$value" =~ ^[0-9]+$ ]]; then
+      fail "contract_versions.$nested_key must be an integer, got '$value'" "$manifest"
+    fi
+  done
+
+  status="$(get_nested compatibility status "$manifest")"
+  if [[ -z "$status" ]]; then
+    fail "compatibility.status is missing" "$manifest"
+  fi
+  if ! is_allowed_status "$status"; then
+    fail "compatibility.status '$status' is not one of: ${ALLOWED_STATUSES[*]}" "$manifest"
+  fi
+
+  reason="$(get_nested compatibility reason "$manifest")"
+  if [[ -z "$reason" ]]; then
+    fail "compatibility.reason is missing or empty" "$manifest"
+  fi
+
+  manual_review_required="$(get_nested compatibility manual_review_required "$manifest")"
+  if [[ -z "$manual_review_required" ]]; then
+    fail "compatibility.manual_review_required is missing" "$manifest"
+  fi
+  if ! is_boolean "$manual_review_required"; then
+    fail "compatibility.manual_review_required must be a boolean, got '$manual_review_required'" "$manifest"
+  fi
+done
+
+echo "Manifest upgrade-metadata tests: passed (${#MANIFESTS[@]} manifest(s) validated)"

--- a/tests/test-manifest-upgrade-metadata.sh
+++ b/tests/test-manifest-upgrade-metadata.sh
@@ -1,23 +1,12 @@
 #!/usr/bin/env bash
 set -euo pipefail
+shopt -s nullglob
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 AGENCY_ROOT="$ROOT_DIR/.agency/skills"
-
-# The dogfood metadata bundle under .agency/skills/ is gitignored and only
-# present after a local builder run. If it is absent, there is nothing to
-# validate in this environment; the test is a no-op rather than a failure.
-if [[ ! -d "$AGENCY_ROOT" ]]; then
-  echo "Manifest upgrade-metadata tests: no .agency/skills/ found, skipping (passed)"
-  exit 0
-fi
-
-mapfile -d '' MANIFESTS < <(find "$AGENCY_ROOT" -type f -name 'manifest.yaml' -print0)
-
-if [[ "${#MANIFESTS[@]}" -eq 0 ]]; then
-  echo "Manifest upgrade-metadata tests: no manifest.yaml files found under .agency/skills/, skipping (passed)"
-  exit 0
-fi
+FIXTURE_ROOT="$ROOT_DIR/tests/fixtures/manifest-upgrade-metadata"
+VALID_FIXTURE_DIR="$FIXTURE_ROOT/valid"
+INVALID_FIXTURE_DIR="$FIXTURE_ROOT/invalid"
 
 # Compatibility status enum from docs/release-versioning-and-upgrade-contract.md.
 ALLOWED_STATUSES=(compatible regeneration-recommended regeneration-required)
@@ -28,14 +17,6 @@ REQUIRED_TOP_LEVEL=(
   'framework_release:^framework_release:[[:space:]]*\S'
   'generated_at:^generated_at:[[:space:]]*\S'
 )
-
-fail() {
-  echo "Manifest upgrade-metadata test failure: $1" >&2
-  if [[ -n "${2:-}" ]]; then
-    echo "  manifest: $2" >&2
-  fi
-  exit 1
-}
 
 # Extract the value of a top-level scalar key from a YAML manifest.
 # Treats the file as a flat YAML document with two-space indentation for
@@ -111,25 +92,35 @@ is_boolean() {
   [[ "$value" == "true" || "$value" == "false" ]]
 }
 
-for manifest in "${MANIFESTS[@]}"; do
-  echo "Validating $manifest"
+# Validate a single manifest. Returns 0 on success, 1 on the first
+# contract violation, and prints a description of the violation to stdout.
+# Does not call exit; callers decide whether a non-zero return is a test
+# pass (negative fixture) or a test failure (positive fixture / real
+# manifest).
+validate_manifest() {
+  local manifest="$1" entry field pattern
+  local framework_release generated_at value status reason
+  local manual_review_required nested_key
 
   for entry in "${REQUIRED_TOP_LEVEL[@]}"; do
     field="${entry%%:*}"
     pattern="${entry#*:}"
     if ! grep -Eq "$pattern" "$manifest"; then
-      fail "missing or empty top-level field '$field'" "$manifest"
+      echo "missing or empty top-level field '$field'"
+      return 1
     fi
   done
 
   framework_release="$(get_top_level framework_release "$manifest")"
   if [[ -z "$framework_release" ]]; then
-    fail "framework_release is empty" "$manifest"
+    echo "framework_release is empty"
+    return 1
   fi
 
   generated_at="$(get_top_level generated_at "$manifest")"
   if ! is_iso_8601 "$generated_at"; then
-    fail "generated_at is not a valid ISO-8601 timestamp: '$generated_at'" "$manifest"
+    echo "generated_at is not a valid ISO-8601 timestamp: '$generated_at'"
+    return 1
   fi
 
   for nested_key in fragment_schema generated_skill_schema integration_declaration_schema; do
@@ -137,35 +128,118 @@ for manifest in "${MANIFESTS[@]}"; do
     # not the integer the contract requires.
     value="$(get_nested_raw contract_versions "$nested_key" "$manifest")"
     if [[ -z "$value" ]]; then
-      fail "contract_versions.$nested_key is missing" "$manifest"
+      echo "contract_versions.$nested_key is missing"
+      return 1
     fi
     if ! [[ "$value" =~ ^[0-9]+$ ]]; then
-      fail "contract_versions.$nested_key must be an unquoted integer, got '$value'" "$manifest"
+      echo "contract_versions.$nested_key must be an unquoted integer, got '$value'"
+      return 1
     fi
   done
 
   status="$(get_nested compatibility status "$manifest")"
   if [[ -z "$status" ]]; then
-    fail "compatibility.status is missing" "$manifest"
+    echo "compatibility.status is missing"
+    return 1
   fi
   if ! is_allowed_status "$status"; then
-    fail "compatibility.status '$status' is not one of: ${ALLOWED_STATUSES[*]}" "$manifest"
+    echo "compatibility.status '$status' is not one of: ${ALLOWED_STATUSES[*]}"
+    return 1
   fi
 
   reason="$(get_nested compatibility reason "$manifest")"
   if [[ -z "$reason" ]]; then
-    fail "compatibility.reason is missing or empty" "$manifest"
+    echo "compatibility.reason is missing or empty"
+    return 1
   fi
 
   # Use the raw extractor so a quoted YAML string like `"true"` is rejected;
   # the contract requires the YAML boolean type.
   manual_review_required="$(get_nested_raw compatibility manual_review_required "$manifest")"
   if [[ -z "$manual_review_required" ]]; then
-    fail "compatibility.manual_review_required is missing" "$manifest"
+    echo "compatibility.manual_review_required is missing"
+    return 1
   fi
   if ! is_boolean "$manual_review_required"; then
-    fail "compatibility.manual_review_required must be an unquoted boolean, got '$manual_review_required'" "$manifest"
+    echo "compatibility.manual_review_required must be an unquoted boolean, got '$manual_review_required'"
+    return 1
+  fi
+
+  return 0
+}
+
+pass_count=0
+fail_count=0
+
+# Always exercise the committed fixtures so this contract test is
+# meaningful in CI even when no .agency/skills/ bundle is present.
+# CodeRabbit flagged the previous skip-on-empty behavior as letting
+# upgrade-contract regressions slip through automated runs; the fixtures
+# guarantee both positive and negative coverage on every run.
+valid_fixtures=("$VALID_FIXTURE_DIR"/*.yaml)
+invalid_fixtures=("$INVALID_FIXTURE_DIR"/*.yaml)
+
+if [[ ${#valid_fixtures[@]} -eq 0 ]]; then
+  echo "Manifest upgrade-metadata test failure: no valid fixtures found in $VALID_FIXTURE_DIR" >&2
+  exit 1
+fi
+
+if [[ ${#invalid_fixtures[@]} -eq 0 ]]; then
+  echo "Manifest upgrade-metadata test failure: no invalid fixtures found in $INVALID_FIXTURE_DIR" >&2
+  exit 1
+fi
+
+for fixture in "${valid_fixtures[@]}"; do
+  echo "Validating valid fixture: $fixture"
+  if reason="$(validate_manifest "$fixture")"; then
+    echo "  PASS"
+    pass_count=$((pass_count + 1))
+  else
+    echo "  FAIL(valid fixture rejected): $reason" >&2
+    fail_count=$((fail_count + 1))
   fi
 done
 
-echo "Manifest upgrade-metadata tests: passed (${#MANIFESTS[@]} manifest(s) validated)"
+for fixture in "${invalid_fixtures[@]}"; do
+  echo "Validating invalid fixture: $fixture"
+  if reason="$(validate_manifest "$fixture")"; then
+    echo "  FAIL(invalid fixture accepted)" >&2
+    fail_count=$((fail_count + 1))
+  else
+    echo "  PASS(invalid fixture rejected: $reason)"
+    pass_count=$((pass_count + 1))
+  fi
+done
+
+# Additionally validate any real generated manifests under .agency/skills/.
+# The dogfood metadata bundle is gitignored and only present after a local
+# builder run, so this pass is best-effort on a clean checkout but enforced
+# on developer machines that have actually generated a bundle.
+real_manifest_count=0
+if [[ -d "$AGENCY_ROOT" ]]; then
+  mapfile -d '' real_manifests < <(find "$AGENCY_ROOT" -type f -name 'manifest.yaml' -print0)
+  for manifest in "${real_manifests[@]}"; do
+    real_manifest_count=$((real_manifest_count + 1))
+    echo "Validating real manifest: $manifest"
+    if reason="$(validate_manifest "$manifest")"; then
+      echo "  PASS"
+      pass_count=$((pass_count + 1))
+    else
+      echo "  FAIL(real manifest rejected): $reason" >&2
+      fail_count=$((fail_count + 1))
+    fi
+  done
+fi
+
+total_checked=$((${#valid_fixtures[@]} + ${#invalid_fixtures[@]} + real_manifest_count))
+
+if [[ $total_checked -eq 0 ]]; then
+  echo "Manifest upgrade-metadata test failure: zero manifests were checked" >&2
+  exit 1
+fi
+
+echo "Manifest upgrade-metadata tests: ${pass_count} passed, ${fail_count} failed (${#valid_fixtures[@]} valid fixture(s), ${#invalid_fixtures[@]} invalid fixture(s), ${real_manifest_count} real manifest(s))"
+
+if [[ $fail_count -ne 0 ]]; then
+  exit 1
+fi


### PR DESCRIPTION
## What does this PR do?

Closes #143.

Brings generated bundle metadata into alignment with the
release-versioning and upgrade contract so a future `/superagents-upgrade`
skill has reliable fields to diff against.

- Documents the upgrade-safety fields the generated `manifest.yaml` must
  carry: `framework_release`, `generated_at`, `contract_versions`
  (`fragment_schema`, `generated_skill_schema`,
  `integration_declaration_schema`), and a structured `compatibility`
  block with `status` (enum: `compatible` | `regeneration-recommended` |
  `regeneration-required`), `reason`, `manual_review_required`.
- Declares `docs/generated-skill-layout.md` at `schema_version: 1` so
  manifests can pin `contract_versions.generated_skill_schema` against
  the doc. The other two contracts already carry an explicit
  `schema_version: 1` in their canonical examples.
- Updates `skills/skill-builder/SKILL.md` Phase 4 to require these fields
  during assembly, including the documented fallback
  `git describe --tags --always --dirty` for `framework_release` when no
  release tag exists yet (the pre-1.0 main case).
- Adds `tests/test-manifest-upgrade-metadata.sh`, which iterates every
  `manifest.yaml` under `.agency/skills/` and asserts the required keys
  are present, `compatibility.status` is one of the three contract enum
  values, and `generated_at` parses as ISO-8601. Fails fast with clear
  error messages.

The `compatibility.status` enum (`compatible` | `regeneration-recommended`
| `regeneration-required`) is intentionally distinct from the
`regeneration_status` enum on `release.json` defined in #144. The
contract document keeps these surfaces separate on purpose: per-bundle
posture vs release-wide intent.

### Local dogfood manifest

The `.agency/` tree is gitignored
(see `scripts/check-dogfooding-guardrails.sh`), so the regenerated
dogfood manifest at `.agency/skills/superagents/manifest.yaml` is not
included in this PR. The local copy used during development pinned
`framework_release` to `git rev-parse HEAD` (since pre-1.0 main has no
release tag yet) and recorded `compatibility.status: compatible` with
`reason: "First generation against pre-1.0 main"`. The new test was
exercised against that local manifest before commit.

## Checklist

- [x] Updates the `manifest.yaml` schema requirement to match
      `docs/release-versioning-and-upgrade-contract.md`.
- [x] `skills/skill-builder/SKILL.md` Phase 4 spells out each required
      field, including the `framework_release` fallback.
- [x] `docs/generated-skill-layout.md` no longer understates the manifest
      contract.
- [x] `tests/test-manifest-upgrade-metadata.sh` is executable, uses
      `set -euo pipefail`, and was exercised against passing and failing
      fixtures locally.
- [x] No changes under `.devcontainer/`, `docs/release-process.md`, or
      `docs/schemas/` (out of scope per #144/#147/#149 boundaries).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Generated-skill contract pinned to schema_version: 1; manifests must reference schema versions and include upgrade-aware metadata (framework release tag, ISO-8601 generation timestamp, contract schema versions, and structured compatibility with status, reason, and manual-review flag).

* **Tests**
  * Added executable validation that scans manifests and enforces presence and formats of the new upgrade metadata fields, failing on first detected violation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->