### PR TITLE
Release pipeline: tag superagents releases with machine-readable upgrade metadata

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,95 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v[0-9]+.[0-9]+.[0-9]+"
+
+permissions:
+  contents: write
+
+jobs:
+  publish:
+    name: Validate release.json and publish GitHub release
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Resolve tag and release.json paths
+        id: resolve
+        run: |
+          TAG_NAME="${GITHUB_REF_NAME}"
+          BARE_VERSION="${TAG_NAME#v}"
+          RELEASE_FILE="releases/${BARE_VERSION}.json"
+
+          if [ ! -f "$RELEASE_FILE" ]; then
+            echo "::error::Expected release artifact ${RELEASE_FILE} not found at tagged commit. See docs/release-process.md."
+            exit 1
+          fi
+
+          {
+            echo "tag_name=${TAG_NAME}"
+            echo "bare_version=${BARE_VERSION}"
+            echo "release_file=${RELEASE_FILE}"
+            echo "commit_sha=${GITHUB_SHA}"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Install schema validator
+        run: |
+          npm install --no-save --silent ajv-cli@5 ajv-formats@3
+
+      - name: Validate release.json against schema
+        env:
+          RELEASE_FILE: ${{ steps.resolve.outputs.release_file }}
+        run: |
+          npx ajv-cli validate \
+            --spec=draft2020 \
+            -c ajv-formats \
+            -s docs/schemas/release.schema.json \
+            -d "$RELEASE_FILE" \
+            --strict=false
+
+      - name: Assert version and commit SHA match tag
+        env:
+          RELEASE_FILE: ${{ steps.resolve.outputs.release_file }}
+          EXPECTED_VERSION: ${{ steps.resolve.outputs.bare_version }}
+          EXPECTED_SHA: ${{ steps.resolve.outputs.commit_sha }}
+        run: |
+          ACTUAL_VERSION=$(node -e "console.log(JSON.parse(require('fs').readFileSync(process.env.RELEASE_FILE,'utf8')).version)")
+          ACTUAL_SHA=$(node -e "console.log(JSON.parse(require('fs').readFileSync(process.env.RELEASE_FILE,'utf8')).commit_sha)")
+
+          if [ "$ACTUAL_VERSION" != "$EXPECTED_VERSION" ]; then
+            echo "::error::release.json version=${ACTUAL_VERSION} does not match tag bare version=${EXPECTED_VERSION}"
+            exit 1
+          fi
+
+          if [ "$ACTUAL_SHA" != "$EXPECTED_SHA" ]; then
+            echo "::error::release.json commit_sha=${ACTUAL_SHA} does not match tagged commit SHA=${EXPECTED_SHA}"
+            exit 1
+          fi
+
+      - name: Stage release.json upload asset
+        env:
+          RELEASE_FILE: ${{ steps.resolve.outputs.release_file }}
+        run: |
+          mkdir -p .release-staging
+          cp "$RELEASE_FILE" .release-staging/release.json
+
+      - name: Create GitHub release with release.json attached
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG_NAME: ${{ steps.resolve.outputs.tag_name }}
+        run: |
+          gh release create "$TAG_NAME" \
+            --repo "$GITHUB_REPOSITORY" \
+            --title "Superagents $TAG_NAME" \
+            --notes "Automated release for $TAG_NAME. See docs/release-process.md for the release-note template; edit this description to add human-readable notes." \
+            .release-staging/release.json

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: Release
 on:
   push:
     tags:
-      - "v[0-9]+.[0-9]+.[0-9]+"
+      - "v[0-9]*.[0-9]*.[0-9]*"
 
 permissions:
   contents: write
@@ -22,6 +22,10 @@ jobs:
         id: resolve
         run: |
           TAG_NAME="${GITHUB_REF_NAME}"
+          if ! [[ "$TAG_NAME" =~ ^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$ ]]; then
+            echo "::error::Tag ${TAG_NAME} must match vMAJOR.MINOR.PATCH with no leading zeros and no pre-release suffix. See docs/release-process.md."
+            exit 1
+          fi
           BARE_VERSION="${TAG_NAME#v}"
           RELEASE_FILE="releases/${BARE_VERSION}.json"
 

--- a/README.md
+++ b/README.md
@@ -321,6 +321,10 @@ Install interactively for detected tools:
 ./scripts/install.sh
 ```
 
+## Releases
+
+Superagents is published as semver-tagged GitHub releases. Each release attaches a machine-readable `release.json` artifact (semver scope, contract/schema versions, regeneration posture) so downstream upgrade tooling can decide whether a project's generated bundle is still compatible. See [docs/release-process.md](docs/release-process.md) for tag naming, the release-note template, and the exact maintainer command sequence.
+
 ## Contributing
 
 See [CONTRIBUTING.md](CONTRIBUTING.md).

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -1,0 +1,167 @@
+# Superagents Release Process
+
+This document describes how Superagents framework releases are cut. It is the operational companion to the authoritative [`docs/release-versioning-and-upgrade-contract.md`](./release-versioning-and-upgrade-contract.md). Where this document and the contract disagree, the contract wins.
+
+## Cadence
+
+Releases are ad-hoc. There is no fixed schedule. A release is cut when a maintainer decides the changes on `main` are worth tagging — typically when a contract or schema version moves, when new fragments or providers ship, or when a notable bug fix lands.
+
+## Who Cuts Releases
+
+Anyone with `peakweb-team/superagents` maintainer permissions (i.e., merge access to `main`) may cut a release. Tag pushes are not automated.
+
+## Versioning
+
+Superagents follows semantic versioning. The release-versioning contract defines the exact scope rules. They are reproduced here verbatim.
+
+### Patch Release
+
+Patch releases should be used for:
+
+- docs fixes
+- bug fixes
+- clarification that does not change contract meaning
+- implementation fixes that do not require generated bundle regeneration
+
+Expected behavior:
+
+- installed framework may update in place
+- existing generated bundles are normally still compatible
+- regeneration is optional unless the patch specifically fixes generated output quality
+
+### Minor Release
+
+Minor releases should be used for additive change such as:
+
+- new optional metadata fields
+- new fragments or providers
+- expanded non-breaking contract guidance
+- new builder behavior that older generated bundles can still coexist with
+
+Expected behavior:
+
+- existing generated bundles may remain usable
+- the release notes should say whether regeneration is recommended
+- additive metadata should not force a stop-the-world migration
+
+### Major Release
+
+Major releases should be used when Superagents changes behavior or metadata in ways that can make existing generated bundles misleading or unsafe.
+
+Examples:
+
+- changing contract meaning rather than only extending it
+- requiring new metadata fields for correct interpretation
+- changing precedence or upgrade semantics in a breaking way
+- making older generated bundle assumptions no longer trustworthy
+
+Expected behavior:
+
+- the release notes must call out the breaking change explicitly
+- repo-local generated bundles should be treated as requiring regeneration or migration review
+- Superagents should not pretend an older generated bundle is safely current
+
+## Tag Naming
+
+- Format: `vMAJOR.MINOR.PATCH` (for example, `v0.1.0`, `v1.2.3`).
+- The `v` prefix is part of the tag name. The `version` field inside `release.json` carries the bare semver string (`0.1.0`), without the `v`.
+- No leading-zero or pre-release suffix support in the MVP. Tags like `v01.0.0`, `v1.0.0-rc1`, or `v1.0.0+build.42` are out of scope and will be rejected by the workflow.
+
+## The `release.json` Artifact
+
+Every release ships a machine-readable artifact called `release.json` so downstream tooling (notably the planned `/superagents-upgrade` skill) can decide whether a project's generated bundle is compatible with the installed framework release.
+
+- **Schema:** [`docs/schemas/release.schema.json`](./schemas/release.schema.json) (JSON Schema draft 2020-12).
+- **Where it lives at tag time:** `releases/<version>.json` at the repo root, committed in the same commit (or an earlier commit on `main`) that the tag points at. For example, `v0.1.0` reads `releases/0.1.0.json`.
+- **What the workflow does with it:** validates against the schema and uploads it as a release asset on the GitHub release. If validation fails, the release run fails and the GitHub release is not created.
+
+The schema requires the following fields. All are required; `additionalProperties: false`.
+
+| Field | Type | Notes |
+| --- | --- | --- |
+| `version` | string | Semver `MAJOR.MINOR.PATCH` with no leading `v`. Must match the tag's bare version. |
+| `release_type` | enum | `patch` \| `minor` \| `major`. |
+| `contract_versions` | object | Required keys: `fragment_schema`, `generated_skill_schema`, `integration_declaration_schema`. Each is an integer >= 1. |
+| `regeneration_status` | enum | `compatible-no-regeneration-needed` \| `compatible-regeneration-recommended` \| `breaking-regeneration-required`. |
+| `changelog_url` | string (uri) | Absolute URL to the human-readable release notes. Typically the GitHub release URL. |
+| `commit_sha` | string | Full 40-character lowercase hex SHA the tag points at. |
+
+### `regeneration_status` vs the manifest's `compatibility.status`
+
+The manifest under `.agency/skills/superagents/manifest.yaml` carries a per-bundle `compatibility.status` field with values `compatible` / `regeneration-recommended` / `regeneration-required`. The `release.json` `regeneration_status` enum uses different wording on purpose: the manifest records a specific generated bundle's state, while `release.json` declares the release-wide intent. See the contract's "Recommended status wording" section for the canonical mapping.
+
+## Release Notes Template
+
+GitHub release notes (the human-readable description on the release) should include an upgrade section at minimum. Use this template:
+
+```
+## Framework Release Version
+
+vX.Y.Z
+
+## Release Type
+
+patch | minor | major
+
+## Regeneration Posture
+
+compatible-no-regeneration-needed | compatible-regeneration-recommended | breaking-regeneration-required
+
+State whether project-local generated bundles under `.claude/skills/superagents/`
+and `.agency/skills/superagents/` need to be regenerated.
+
+## Contract / Schema Version Changes
+
+- fragment_schema: <previous> -> <current> (or "unchanged")
+- generated_skill_schema: <previous> -> <current> (or "unchanged")
+- integration_declaration_schema: <previous> -> <current> (or "unchanged")
+
+## Manual Review Expectations
+
+- Whether repos with hand-edited generated SKILL.md files need targeted review.
+- Whether any breaking change requires the operator to read a specific section of
+  the contract before regenerating.
+
+## Highlights
+
+- Bullet-list of notable changes.
+```
+
+## Cutting A Release
+
+The maintainer-side workflow:
+
+1. **Decide the version.** Apply the patch / minor / major rules above. Write down the new version string.
+
+2. **Author `releases/<version>.json`** at the repo root, conforming to [`docs/schemas/release.schema.json`](./schemas/release.schema.json). Set `commit_sha` to the SHA of the commit that will be tagged.
+
+3. **Open a PR** containing only the new `releases/<version>.json` file (and any release-note adjustments). Land it through normal review.
+
+4. **Tag the merge commit and push the tag.** From a clean checkout of `main` at the merge commit:
+
+   ```bash
+   git fetch --all --tags
+   git checkout main
+   git pull --ff-only
+   git tag -a vX.Y.Z -m "Superagents vX.Y.Z"
+   git push origin vX.Y.Z
+   ```
+
+5. **The release workflow takes over.** On tag push matching `v[0-9]+.[0-9]+.[0-9]+`, [`.github/workflows/release.yml`](../.github/workflows/release.yml):
+   - reads `releases/<bare-version>.json` from the tagged commit
+   - validates it against the schema and asserts that the `version` field matches the tag and `commit_sha` matches the tagged commit SHA
+   - creates a GitHub release for the tag, with the validated `release.json` attached as an asset (uploaded as `release.json`)
+   - fails the run, and does not create the release, if validation fails
+
+6. **Edit the GitHub release description** to add the human-readable release notes using the template above. (The workflow does not author prose.)
+
+If the workflow run fails, fix the `releases/<version>.json` file on `main`, delete the tag locally and on the remote, and re-tag at the new fixing commit. Do not amend the original tag.
+
+## Out Of Scope For MVP
+
+- Auto-bumping version numbers from commit messages (semantic-release-style).
+- Multi-channel releases (alpha / beta / rc / nightly).
+- Attaching migration scripts as release assets.
+- Mirroring releases to other registries.
+
+These are explicitly listed as out-of-scope in [issue #144](https://github.com/peakweb-team/superagents/issues/144).

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -94,7 +94,7 @@ The manifest under `.agency/skills/superagents/manifest.yaml` carries a per-bund
 
 GitHub release notes (the human-readable description on the release) should include an upgrade section at minimum. Use this template:
 
-```
+```markdown
 ## Framework Release Version
 
 vX.Y.Z
@@ -147,7 +147,7 @@ The maintainer-side workflow:
    git push origin vX.Y.Z
    ```
 
-5. **The release workflow takes over.** On tag push matching `v[0-9]+.[0-9]+.[0-9]+`, [`.github/workflows/release.yml`](../.github/workflows/release.yml):
+5. **The release workflow takes over.** On tag push matching `v[0-9]*.[0-9]*.[0-9]*` (with strict `vMAJOR.MINOR.PATCH` semver re-validated inside the job to reject leading zeros and pre-release suffixes), [`.github/workflows/release.yml`](../.github/workflows/release.yml):
    - reads `releases/<bare-version>.json` from the tagged commit
    - validates it against the schema and asserts that the `version` field matches the tag and `commit_sha` matches the tagged commit SHA
    - creates a GitHub release for the tag, with the validated `release.json` attached as an asset (uploaded as `release.json`)

--- a/docs/schemas/release.schema.json
+++ b/docs/schemas/release.schema.json
@@ -17,7 +17,7 @@
     "version": {
       "type": "string",
       "description": "Semantic version of the framework release (no leading 'v').",
-      "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+$"
+      "pattern": "^(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)$"
     },
     "release_type": {
       "type": "string",

--- a/docs/schemas/release.schema.json
+++ b/docs/schemas/release.schema.json
@@ -1,0 +1,75 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/peakweb-team/superagents/docs/schemas/release.schema.json",
+  "title": "Superagents Release Artifact",
+  "description": "Machine-readable release.json artifact attached to every Superagents GitHub release. Carries semver scope, contract/schema versions, and regeneration posture for downstream upgrade tooling.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "version",
+    "release_type",
+    "contract_versions",
+    "regeneration_status",
+    "changelog_url",
+    "commit_sha"
+  ],
+  "properties": {
+    "version": {
+      "type": "string",
+      "description": "Semantic version of the framework release (no leading 'v').",
+      "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+$"
+    },
+    "release_type": {
+      "type": "string",
+      "description": "Semver scope of the release.",
+      "enum": [
+        "patch",
+        "minor",
+        "major"
+      ]
+    },
+    "contract_versions": {
+      "type": "object",
+      "description": "Schema/contract version integers for each versioned surface in this release.",
+      "additionalProperties": false,
+      "required": [
+        "fragment_schema",
+        "generated_skill_schema",
+        "integration_declaration_schema"
+      ],
+      "properties": {
+        "fragment_schema": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "generated_skill_schema": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "integration_declaration_schema": {
+          "type": "integer",
+          "minimum": 1
+        }
+      }
+    },
+    "regeneration_status": {
+      "type": "string",
+      "description": "Release-wide regeneration posture for project-local generated bundles. Mirrors the release-versioning contract's 'Recommended status wording'.",
+      "enum": [
+        "compatible-no-regeneration-needed",
+        "compatible-regeneration-recommended",
+        "breaking-regeneration-required"
+      ]
+    },
+    "changelog_url": {
+      "type": "string",
+      "description": "Absolute URL to the human-readable release notes for this version.",
+      "format": "uri"
+    },
+    "commit_sha": {
+      "type": "string",
+      "description": "Full 40-character lowercase hex git commit SHA the tag points to.",
+      "pattern": "^[0-9a-f]{40}$"
+    }
+  }
+}


### PR DESCRIPTION
## What does this PR do?

Stands up the Superagents release pipeline so future tagged releases ship a machine-readable `release.json` artifact alongside human-readable notes. Closes #144.

What lands:

- `docs/release-process.md` — operational release runbook (semver scope rules verbatim from the contract, tag naming, release-note template, ad-hoc cadence, maintainer authority, exact command sequence to cut a release).
- `docs/schemas/release.schema.json` — JSON Schema (draft 2020-12) for the `release.json` artifact. All six fields required (`version`, `release_type`, `contract_versions`, `regeneration_status`, `changelog_url`, `commit_sha`); `additionalProperties: false`.
- `.github/workflows/release.yml` — triggers on tag push `v[0-9]+.[0-9]+.[0-9]+`, reads `releases/<bare-version>.json` from the tagged commit, validates it against the schema with `ajv-cli` + `ajv-formats`, asserts the file's `version` and `commit_sha` match the tag and tagged SHA, and creates the GitHub release with `release.json` attached as an asset. Validation failure aborts before any release is created.
- `README.md` — short `Releases` section pointing to the new docs.

### `regeneration_status` vs the manifest's `compatibility.status`

Per the contract's "Recommended status wording" section, the `release.json` `regeneration_status` enum (`compatible-no-regeneration-needed` | `compatible-regeneration-recommended` | `breaking-regeneration-required`) is intentionally distinct from the per-bundle manifest's `compatibility.status` enum (`compatible` | `regeneration-recommended` | `regeneration-required`) being added in #143. The release artifact carries release-wide intent; the manifest carries per-bundle state. They are not interchangeable.

### Coordination with #143

This PR does not touch:

- `.agency/skills/superagents/manifest.yaml`
- `skills/skill-builder/SKILL.md`
- anything under `.devcontainer/`

## Agent Information (if adding/modifying an agent)

N/A — no agent changes.

## Checklist

- [x] Follows the agent template structure from CONTRIBUTING.md
- [x] Includes YAML frontmatter with `name`, `description`, `color`
- [x] Has concrete code/template examples (for new agents)
- [x] Tested in real scenarios
- [x] Proofread and formatted correctly

(Agent-specific items N/A. Validation actually performed: `release.json` JSON parses and a sample document validates against the schema with `ajv-cli@5 --spec=draft2020 -c ajv-formats`. Workflow YAML parses cleanly via `js-yaml`. New markdown link targets all resolve. The repo's `tests/test-doc-link-integrity.sh` requires Ruby which isn't available in this environment, but the linked paths were spot-checked manually and the test will run in CI.)

## Maintainer post-merge action: cut v0.1.0

This PR deliberately does not push a tag. To cut the baseline `v0.1.0` release after merge:

1. From `main`, author `releases/0.1.0.json` and merge it through normal review. Suggested contents (replace `commit_sha` with the SHA of the merge commit you intend to tag):

   ```json
   {
     "version": "0.1.0",
     "release_type": "minor",
     "contract_versions": {
       "fragment_schema": 1,
       "generated_skill_schema": 1,
       "integration_declaration_schema": 1
     },
     "regeneration_status": "compatible-no-regeneration-needed",
     "changelog_url": "https://github.com/peakweb-team/superagents/releases/tag/v0.1.0",
     "commit_sha": "<sha-of-merge-commit>"
   }
   ```

   Note the `contract_versions` integers all default to `1`. Sources: `docs/fragment-schema.md` (`schema_version: 1`), `docs/generated-skill-layout.md` (`schema_version: 1`), `docs/project-integration-declaration-format.md` (`schema_version: 1`). Please verify these match the integers #143 records in `compatibility.contract_versions` before tagging — both PRs should agree on baseline.

2. Tag and push:

   ```bash
   git fetch --all --tags
   git checkout main
   git pull --ff-only
   git tag -a v0.1.0 -m "Superagents v0.1.0"
   git push origin v0.1.0
   ```

3. The `Release` workflow will validate and publish. Edit the resulting GitHub release description to add release notes using the template in `docs/release-process.md`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Established comprehensive release process documentation with semver tagging conventions and release metadata specifications.
  * Added JSON schema defining machine-readable release artifact structure and validation requirements.

* **Chores**
  * Implemented automated CI/CD workflow for GitHub release creation with tag-triggered validation and asset packaging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->