### PR TITLE
Add /superagents-upgrade skill: review, propose, apply, and feed back

### DIFF
--- a/docs/builder-usage-and-repo-local-precedence-contract.md
+++ b/docs/builder-usage-and-repo-local-precedence-contract.md
@@ -161,6 +161,10 @@ Regenerate when:
 
 Regeneration behavior and compatibility classification continue to follow [`docs/release-versioning-and-upgrade-contract.md`](./release-versioning-and-upgrade-contract.md).
 
+### Regeneration Flow
+
+For an interactive review-and-apply flow over an existing repo-local bundle — comparing the installed framework release, the project's `.agency/skills/superagents/manifest.yaml`, and (optionally) the latest superagents `origin/main` — invoke the `superagents-upgrade` skill instead of running the builder directly. The upgrade skill detects drift across contract versions, fragment lock, generated SKILL.md content, and devcontainer scaffold, classifies the result per the upgrade contract, prompts the operator per change with `apply | raise | skip | both`, and hands approved changes back to the skill-builder for regeneration.
+
 ## Worktree Strategy Resolution Contract
 
 Worktree isolation is optional and repository-scoped by default.

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -322,6 +322,11 @@ install_claude_code() {
   local devcontainer_backup="${HOME}/.claude/skills/superagents-devcontainer-bootstrap.bak"
   local devcontainer_stage=""
   local devcontainer_count=0
+  local upgrade_src="$SKILLS_ROOT/superagents-upgrade"
+  local upgrade_dest="${HOME}/.claude/skills/superagents-upgrade"
+  local upgrade_backup="${HOME}/.claude/skills/superagents-upgrade.bak"
+  local upgrade_stage=""
+  local upgrade_count=0
   local builder_src="$SKILLS_ROOT/skill-builder/SKILL.md"
   local fragments_src="$SKILLS_ROOT/fragments"
   local count=0
@@ -392,6 +397,32 @@ install_claude_code() {
   devcontainer_stage=""
   trap - RETURN
 
+  [[ -f "$upgrade_src/SKILL.md" ]] || { err "skills/superagents-upgrade/SKILL.md missing."; return 1; }
+  upgrade_stage="$(mktemp -d "$skills_parent/superagents-upgrade.tmp.XXXXXX")"
+  trap '[[ -n "$upgrade_stage" && -d "$upgrade_stage" ]] && rm -rf "$upgrade_stage"' RETURN
+  cp -R "$upgrade_src/." "$upgrade_stage/"
+  upgrade_count=$(find "$upgrade_src" -type f | wc -l | awk '{print $1}')
+  if (( upgrade_count == 0 )); then
+    rm -rf "$upgrade_stage"
+    err "skills/superagents-upgrade contains no files."
+    return 1
+  fi
+  rm -rf "$upgrade_backup"
+  if [[ -d "$upgrade_dest" ]]; then
+    mv "$upgrade_dest" "$upgrade_backup"
+  fi
+  if ! mv "$upgrade_stage" "$upgrade_dest"; then
+    err "failed to activate staged upgrade skill bundle at $upgrade_dest"
+    rm -rf "$upgrade_dest"
+    if [[ -d "$upgrade_backup" ]]; then
+      mv "$upgrade_backup" "$upgrade_dest"
+    fi
+    return 1
+  fi
+  rm -rf "$upgrade_backup"
+  upgrade_stage=""
+  trap - RETURN
+
   mkdir -p "$dest"
   for dir in "${AGENT_DIRS[@]}"; do
     [[ -d "$AGENTS_ROOT/$dir" ]] || continue
@@ -406,6 +437,7 @@ install_claude_code() {
   ok "Claude Code: $count agents -> $dest"
   ok "Claude Code: skill-builder + $fragment_count fragments -> $skills_dest"
   ok "Claude Code: devcontainer bootstrap skill + $devcontainer_count files -> $devcontainer_dest"
+  ok "Claude Code: upgrade skill + $upgrade_count files -> $upgrade_dest"
 }
 
 install_copilot() {

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -322,12 +322,18 @@ install_claude_code() {
   local devcontainer_backup="${HOME}/.claude/skills/superagents-devcontainer-bootstrap.bak"
   local devcontainer_stage=""
   local devcontainer_count=0
+  local devcontainer_lifecycle_src="$SKILLS_ROOT/superagents-devcontainer"
+  local devcontainer_lifecycle_dest="${HOME}/.claude/skills/superagents-devcontainer"
+  local devcontainer_lifecycle_backup="${HOME}/.claude/skills/superagents-devcontainer.bak"
+  local devcontainer_lifecycle_stage=""
+  local devcontainer_lifecycle_count=0
   local upgrade_src="$SKILLS_ROOT/superagents-upgrade"
   local upgrade_dest="${HOME}/.claude/skills/superagents-upgrade"
   local upgrade_backup="${HOME}/.claude/skills/superagents-upgrade.bak"
   local upgrade_stage=""
   local upgrade_count=0
   local builder_src="$SKILLS_ROOT/skill-builder/SKILL.md"
+  local builder_release_json="$SKILLS_ROOT/skill-builder/release.json"
   local fragments_src="$SKILLS_ROOT/fragments"
   local count=0
   local fragment_count=0
@@ -340,6 +346,10 @@ install_claude_code() {
   skills_stage="$(mktemp -d "$skills_parent/superagents-skill-builder.tmp.XXXXXX")"
   trap '[[ -n "$skills_stage" && -d "$skills_stage" ]] && rm -rf "$skills_stage"' RETURN
   cp "$builder_src" "$skills_stage/SKILL.md"
+  # Optional: forward release.json into the installed bundle so superagents-upgrade can read it.
+  if [[ -f "$builder_release_json" ]]; then
+    cp "$builder_release_json" "$skills_stage/release.json"
+  fi
   mkdir -p "$skills_stage/fragments"
 
   # Stage fragment copies first; only replace the live bundle after a full successful copy.
@@ -397,6 +407,32 @@ install_claude_code() {
   devcontainer_stage=""
   trap - RETURN
 
+  [[ -f "$devcontainer_lifecycle_src/SKILL.md" ]] || { err "skills/superagents-devcontainer/SKILL.md missing."; return 1; }
+  devcontainer_lifecycle_stage="$(mktemp -d "$skills_parent/superagents-devcontainer.tmp.XXXXXX")"
+  trap '[[ -n "$devcontainer_lifecycle_stage" && -d "$devcontainer_lifecycle_stage" ]] && rm -rf "$devcontainer_lifecycle_stage"' RETURN
+  cp -R "$devcontainer_lifecycle_src/." "$devcontainer_lifecycle_stage/"
+  devcontainer_lifecycle_count=$(find "$devcontainer_lifecycle_src" -type f | wc -l | awk '{print $1}')
+  if (( devcontainer_lifecycle_count == 0 )); then
+    rm -rf "$devcontainer_lifecycle_stage"
+    err "skills/superagents-devcontainer contains no files."
+    return 1
+  fi
+  rm -rf "$devcontainer_lifecycle_backup"
+  if [[ -d "$devcontainer_lifecycle_dest" ]]; then
+    mv "$devcontainer_lifecycle_dest" "$devcontainer_lifecycle_backup"
+  fi
+  if ! mv "$devcontainer_lifecycle_stage" "$devcontainer_lifecycle_dest"; then
+    err "failed to activate staged devcontainer lifecycle skill bundle at $devcontainer_lifecycle_dest"
+    rm -rf "$devcontainer_lifecycle_dest"
+    if [[ -d "$devcontainer_lifecycle_backup" ]]; then
+      mv "$devcontainer_lifecycle_backup" "$devcontainer_lifecycle_dest"
+    fi
+    return 1
+  fi
+  rm -rf "$devcontainer_lifecycle_backup"
+  devcontainer_lifecycle_stage=""
+  trap - RETURN
+
   [[ -f "$upgrade_src/SKILL.md" ]] || { err "skills/superagents-upgrade/SKILL.md missing."; return 1; }
   upgrade_stage="$(mktemp -d "$skills_parent/superagents-upgrade.tmp.XXXXXX")"
   trap '[[ -n "$upgrade_stage" && -d "$upgrade_stage" ]] && rm -rf "$upgrade_stage"' RETURN
@@ -437,6 +473,7 @@ install_claude_code() {
   ok "Claude Code: $count agents -> $dest"
   ok "Claude Code: skill-builder + $fragment_count fragments -> $skills_dest"
   ok "Claude Code: devcontainer bootstrap skill + $devcontainer_count files -> $devcontainer_dest"
+  ok "Claude Code: devcontainer lifecycle skill + $devcontainer_lifecycle_count files -> $devcontainer_lifecycle_dest"
   ok "Claude Code: upgrade skill + $upgrade_count files -> $upgrade_dest"
 }
 

--- a/skills/skill-builder/SKILL.md
+++ b/skills/skill-builder/SKILL.md
@@ -94,6 +94,8 @@ Each generated skill must:
 - define context/model usage expectations
 - prefer repo-local conventions over user-level defaults
 
+The generated primary orchestration skill (`superagents`) must additionally reference the installed `superagents-upgrade` skill in its trigger conditions or workflow section so operators discover it when their installed framework has advanced past the project's `framework_release`. Recommended wording: "When the installed Superagents framework has moved past this project's recorded `framework_release`, invoke `/superagents-upgrade` to review, apply, or feed back the delta."
+
 The builder metadata bundle must include the inventory record, decision record, fragment lock information, and a human-readable review summary.
 
 The generated `manifest.yaml` must additionally carry the upgrade-aware metadata required by `docs/release-versioning-and-upgrade-contract.md` so a future upgrade tool can compare an installed framework release against this generated bundle. Required fields:

--- a/skills/superagents-devcontainer/SKILL.md
+++ b/skills/superagents-devcontainer/SKILL.md
@@ -159,3 +159,4 @@ devcontainer up --workspace-folder . --remove-existing-container
 - Dev Containers CLI: `https://github.com/devcontainers/cli`
 - VS Code Dev Containers extension: `https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers`
 - For initial devcontainer setup, see the `superagents-devcontainer-bootstrap` skill.
+- To review and apply Superagents framework upgrades against a project bundle (including detection of devcontainer scaffold drift that would require a rebuild), see the `superagents-upgrade` skill.

--- a/skills/superagents-upgrade/SKILL.md
+++ b/skills/superagents-upgrade/SKILL.md
@@ -82,11 +82,11 @@ If individual fields are missing, treat each missing field as drift in Phase 2.
 
 ### 1.3 Origin/main delta (optional)
 
-Only run when `SUPERAGENTS_FETCH_REMOTE=1` (or the operator explicitly opts in when prompted). When opted in:
+Only run when `SUPERAGENTS_FETCH_REMOTE=1` (or the operator explicitly opts in when prompted). All steps use the configured `$SUPERAGENTS_REMOTE` so fork or mirror setups work without code changes.
 
-1. Use `gh release list --repo peakweb-team/superagents --limit 1` to find the latest tagged release.
-2. Use `gh api repos/peakweb-team/superagents/compare/<latest-tag>...main --jq '.ahead_by'` to count commits on `main` ahead of the latest tag, and `--jq '.commits[].commit.message'` to enumerate them. Prefer this `gh api`-based approach over a clone — it is cheap and stays inside the container.
-3. If `gh` is not available, fall back to a shallow clone into a temp directory (`git clone --depth 50 --filter=blob:none $SUPERAGENTS_REMOTE`) and run `git rev-list <latest-tag>..origin/main --count`. Clean up the temp clone before exiting.
+1. Derive `<owner>/<repo>` from `$SUPERAGENTS_REMOTE` (strip the `https://github.com/` prefix and any trailing `.git`). Use `gh release list --repo <owner>/<repo> --limit 1` to find the latest tagged release.
+2. Use `gh api repos/<owner>/<repo>/compare/<latest-tag>...main --jq '.ahead_by'` to count commits on `main` ahead of the latest tag, and `--jq '.commits[].commit.message'` to enumerate them. Prefer this `gh api`-based approach over a clone — it is cheap and stays inside the container.
+3. If `gh` is not available, fall back to a shallow clone into a temp directory (`git clone --depth 50 --filter=blob:none $SUPERAGENTS_REMOTE`). Inside the clone, fetch tags (`git fetch --tags --depth=1`) and derive `<latest-tag>` with `git describe --tags --abbrev=0 origin/main`. Then run `git rev-list <latest-tag>..origin/main --count`. Clean up the temp clone before exiting.
 
 Surface the count and the short log so the operator can decide whether to compare against `origin/main` or only against the latest released tag.
 
@@ -117,7 +117,7 @@ For each generated `SKILL.md`, do a textual diff against the file the current in
 - **Manual edits** — content differs from the builder's deterministic output even though the fragment set is unchanged. The operator hand-edited the file. This must be surfaced explicitly per Phase 3.
 - **Both** — the file is hand-edited *and* fragments have moved. This is the highest-risk case.
 
-Detect manual edits by re-running the builder in dry-run mode against the locked fragments and the recorded decisions, then diffing the result against the committed file. Any non-empty diff there is a manual edit.
+Detect manual edits heuristically: a manual edit is present when the committed `SKILL.md` content cannot be explained by the recorded fragment lock (for example, prose that does not appear in any selected fragment, or sections out of the order the builder emits). The MVP skill-builder does not currently expose a deterministic dry-run mode, so this detection is best-effort, not authoritative — surface a single warning per file rather than line-level attribution. When the skill-builder grows a deterministic dry-run/non-interactive mode (see Open Questions at the bottom of this file), upgrade this step to a strict diff against the dry-run output.
 
 ### 2.4 Devcontainer scaffold
 
@@ -225,13 +225,13 @@ A `N` (or no answer) terminates the skill cleanly without writing files. A `y` p
 
 For every change marked `apply` or `both`:
 
-1. **Hand off to the installed skill-builder.** Do **not** invoke any CLI. Hand off by invoking the `superagents-skill-builder` skill with a context describing what to regenerate. Pass:
+1. **Hand off to the installed skill-builder.** Do **not** invoke any CLI. Hand off by invoking the `superagents-skill-builder` skill with a context describing the regeneration intent. Pass:
    - the project root
-   - the list of approved change ids (so the builder can scope regeneration where the contract permits)
+   - the list of approved change ids (advisory only — see scoping note below)
    - the `regeneration-recommended` / `regeneration-required` posture
    - any unresolved decisions captured in `decisions.yaml` so the builder does not re-ask them
 
-   When the builder cannot scope the regeneration to a subset (the MVP behavior is "regenerate the whole bundle"), regenerate the whole bundle and surface the broader impact in the resulting diff.
+   **Scoping note:** the MVP skill-builder regenerates the whole bundle in a single run. It does not yet promise scoped regeneration, deterministic dry-run, or a fully non-interactive replay from `fragments.lock.yaml` plus `decisions.yaml`. Phase 5 therefore depends only on the whole-bundle path: pass the change-id list as advisory context for the builder's review summary, regenerate the whole bundle, and let the operator review the resulting diff in normal git history. If the operator approved only a subset of changes, the resulting diff will include changes the operator did not explicitly approve — surface that fact in the final summary so the operator can selectively `git restore` portions before committing. Tightening this hand-off (deterministic dry-run, scoped regeneration) is tracked under Open Questions at the bottom of this file.
 
 2. **Outputs land at the canonical roots:**
    - `<project>/.claude/skills/superagents/` — the execution-facing root described in `docs/generated-skill-layout.md`. For projects following the `superagents-<function>` standardization from issue #135, generated skills also land at `<project>/.claude/skills/superagents-<function>/`.
@@ -331,5 +331,5 @@ The skill stops with an error when:
 These are surfaced for the operator and for follow-up work; they are not blocking.
 
 - **Where does the installed framework release live?** Phase 1.1 uses a four-step resolution order that prefers a shipped `release.json` artifact, then bundle frontmatter, then a host checkout's `git describe`, then `unknown`. The release-versioning contract does not pick a canonical source today. Once one source becomes authoritative, this skill should narrow the resolution order and the contract should be updated to match.
-- **Scoped vs whole-bundle regeneration in Phase 5.** The current skill-builder regenerates the whole bundle. When per-change scoped regeneration becomes possible the Phase 5 hand-off should pass a scope hint instead of falling back to whole-bundle regeneration.
+- **Builder hand-off contract for Phase 5 and Phase 2.3.** Phase 2.3's manual-edit detection is best-effort heuristic and Phase 5's hand-off regenerates the whole bundle, because the installed `superagents-skill-builder` does not yet promise three behaviors this skill would benefit from: (1) deterministic re-run from `fragments.lock.yaml` plus `decisions.yaml` without re-prompting, (2) a `--dry-run` mode that emits the would-be output without writing files, (3) a `--scope` / `--change-ids` mode that regenerates only a subset of skills. Adding those behaviors to `skills/skill-builder/SKILL.md` is a follow-up; until then, this skill stays on the whole-bundle-regenerate path and on heuristic manual-edit detection. See `skills/skill-builder/SKILL.md` Phase 4 for the current contract.
 - **Phase 7 record format.** The `upstream-feedback-pending.log` line format above is provisional. Issue #146 will define the canonical record shape; until then the line-based format is forward-compatible and easy to grep.

--- a/skills/superagents-upgrade/SKILL.md
+++ b/skills/superagents-upgrade/SKILL.md
@@ -61,7 +61,7 @@ Resolve in this order, stopping at the first source that yields a value:
 
 Log both the resolved value and the source so the operator can audit it.
 
-> Open question for operators: there are several plausible resolution sources for the installed framework release and no single source of truth ships in the bundle today. The order above is this skill's working answer; it should be promoted into `docs/release-versioning-and-upgrade-contract.md` once one source is canonical. See the "Open Questions" section at the bottom of this file.
+> Note: the installed `release.json` (step 1) is the canonical source of the installed framework release once a release has shipped — `docs/release-process.md` defines that artifact and the install path is now configured to forward it into the bundle. Steps 2–4 are backward-compatibility fallbacks for installs that predate the release pipeline or are running directly off `main`. The four-step order above should be promoted into `docs/release-versioning-and-upgrade-contract.md` so consumers other than this skill can rely on it. See the "Open Questions" section at the bottom of this file.
 
 ### 1.2 Project bundle metadata
 
@@ -330,6 +330,6 @@ The skill stops with an error when:
 
 These are surfaced for the operator and for follow-up work; they are not blocking.
 
-- **Where does the installed framework release live?** Phase 1.1 uses a four-step resolution order that prefers a shipped `release.json` artifact, then bundle frontmatter, then a host checkout's `git describe`, then `unknown`. The release-versioning contract does not pick a canonical source today. Once one source becomes authoritative, this skill should narrow the resolution order and the contract should be updated to match.
+- **Promote Phase 1.1 resolution order into the contract.** The installed `release.json` is canonical when present; the other three steps (bundle frontmatter, host-checkout `git describe`, literal `unknown`) are backward-compatibility fallbacks for installs that predate the release pipeline. `docs/release-versioning-and-upgrade-contract.md` does not yet record this ordering — it should, so other consumers can rely on the same resolution.
 - **Builder hand-off contract for Phase 5 and Phase 2.3.** Phase 2.3's manual-edit detection is best-effort heuristic and Phase 5's hand-off regenerates the whole bundle, because the installed `superagents-skill-builder` does not yet promise three behaviors this skill would benefit from: (1) deterministic re-run from `fragments.lock.yaml` plus `decisions.yaml` without re-prompting, (2) a `--dry-run` mode that emits the would-be output without writing files, (3) a `--scope` / `--change-ids` mode that regenerates only a subset of skills. Adding those behaviors to `skills/skill-builder/SKILL.md` is a follow-up; until then, this skill stays on the whole-bundle-regenerate path and on heuristic manual-edit detection. See `skills/skill-builder/SKILL.md` Phase 4 for the current contract.
 - **Phase 7 record format.** The `upstream-feedback-pending.log` line format above is provisional. Issue #146 will define the canonical record shape; until then the line-based format is forward-compatible and easy to grep.

--- a/skills/superagents-upgrade/SKILL.md
+++ b/skills/superagents-upgrade/SKILL.md
@@ -15,7 +15,7 @@ This skill is **interactive and never silently applies changes**. Every detected
 
 - Optional argument: project path. If omitted, use the current working directory.
 - Optional environment overrides:
-  - `SUPERAGENTS_HOST_CHECKOUT` — absolute path to a host superagents source checkout, used as a fallback when the installed bundle does not record its own framework release. Defaults to "(none)" — see [Phase 1](#phase-1--detect) for the resolution order.
+  - `SUPERAGENTS_HOST_CHECKOUT` — absolute path to a host superagents source checkout, used as a fallback when the installed bundle does not record its own framework release. Defaults to "(none)" — see [Phase 1](#phase-1-detect) for the resolution order.
   - `SUPERAGENTS_REMOTE` — origin URL used for the optional remote-fetch in Phase 1. Defaults to `https://github.com/peakweb-team/superagents`.
   - `SUPERAGENTS_FETCH_REMOTE` — set to `1` to opt in to the remote fetch. Default off.
 

--- a/skills/superagents-upgrade/SKILL.md
+++ b/skills/superagents-upgrade/SKILL.md
@@ -1,0 +1,335 @@
+---
+name: superagents-upgrade
+description: Review, propose, apply, and feed back upgrades for a project's Superagents bundle. Compares the installed framework release, the project's generated skills under .claude/skills/superagents-* and metadata under .agency/skills/superagents/, and the latest superagents origin/main; classifies the delta per the upgrade contract; prompts the operator per change; and hands approved changes either to the skill-builder for local regeneration or to the upstream-feedback flow.
+disable-model-invocation: false
+argument-hint: "[optional-project-path]"
+---
+
+# Superagents Upgrade
+
+Use this skill when an operator wants to bring a project's Superagents bundle in line with a newer installed framework release or the latest superagents `origin/main`. It is the project-local counterpart to the installed `superagents-skill-builder`: the builder generates, this skill reconciles.
+
+This skill is **interactive and never silently applies changes**. Every detected difference must be approved by the operator before any file is written.
+
+## Inputs
+
+- Optional argument: project path. If omitted, use the current working directory.
+- Optional environment overrides:
+  - `SUPERAGENTS_HOST_CHECKOUT` — absolute path to a host superagents source checkout, used as a fallback when the installed bundle does not record its own framework release. Defaults to "(none)" — see [Phase 1](#phase-1--detect) for the resolution order.
+  - `SUPERAGENTS_REMOTE` — origin URL used for the optional remote-fetch in Phase 1. Defaults to `https://github.com/peakweb-team/superagents`.
+  - `SUPERAGENTS_FETCH_REMOTE` — set to `1` to opt in to the remote fetch. Default off.
+
+## When To Use
+
+Invoke this skill whenever any of the following is true:
+
+- the operator has just updated the installed Superagents framework (via `~/.claude/skills/superagents-skill-builder/` and friends) and wants to know whether the project bundle needs regeneration
+- the project's `.agency/skills/superagents/manifest.yaml` records a `framework_release` that is older than the installed framework
+- the operator wants to surface drift between project-local generated skills and what the latest fragments would produce
+- the operator wants to forward a noticed gap upstream as a superagents issue
+
+Do **not** invoke this skill to perform the initial bootstrap of a project — for first-time generation use the installed `superagents-skill-builder` directly.
+
+## Phase Map
+
+This skill executes seven phases in order. Phases 1–5 are implemented in this skill. Phases 6 and 7 are deliberately stubbed: they reference dependent epic issues and surface the relevant prompts but do not act yet.
+
+| Phase | Name | Status |
+|-------|------|--------|
+| 1 | Detect | implemented |
+| 2 | Diff | implemented |
+| 3 | Summarize | implemented |
+| 4 | Decide | implemented |
+| 5 | Apply locally | implemented |
+| 6 | Devcontainer advisory | stub (deferred to issue #147) |
+| 7 | Upstream feedback | stub (deferred to issue #146) |
+
+The seven-phase contract maps to the six-step "Recommended Upgrade Flow" in [`docs/release-versioning-and-upgrade-contract.md`](../../docs/release-versioning-and-upgrade-contract.md): phases 1–2 implement step 2 (compare), phase 3 implements step 3 (surface), phase 4 implements step 5 (review) interactively per change, phase 5 implements step 4 (regenerate), phase 6 is the devcontainer-specific extension of step 5, and phase 7 is the upstream-feedback hand-off introduced for this skill.
+
+## Phase 1 — Detect
+
+Determine three pieces of state.
+
+### 1.1 Installed framework release
+
+Resolve in this order, stopping at the first source that yields a value:
+
+1. **Installed `release.json` artifact.** If `~/.claude/skills/superagents-skill-builder/release.json` exists, read its `version` field as the installed framework release. This is the canonical source once releases ship the artifact alongside the bundle.
+2. **Installed bundle frontmatter.** If the installed `~/.claude/skills/superagents-skill-builder/SKILL.md` carries a `framework_release` frontmatter key, use it.
+3. **Host superagents checkout.** If `SUPERAGENTS_HOST_CHECKOUT` is set and points at a git checkout, run `git -C "$SUPERAGENTS_HOST_CHECKOUT" describe --tags --always --dirty` and use the result. Mirrors the fallback documented in `skills/skill-builder/SKILL.md` Phase 4.
+4. **Unknown — degrade gracefully.** Record the framework release as the literal string `unknown` and surface a warning. Do not fail the skill — the operator can still review the diff against `origin/main`.
+
+Log both the resolved value and the source so the operator can audit it.
+
+> Open question for operators: there are several plausible resolution sources for the installed framework release and no single source of truth ships in the bundle today. The order above is this skill's working answer; it should be promoted into `docs/release-versioning-and-upgrade-contract.md` once one source is canonical. See the "Open Questions" section at the bottom of this file.
+
+### 1.2 Project bundle metadata
+
+Read the project's manifest at `<project>/.agency/skills/superagents/manifest.yaml` and extract the upgrade-aware metadata fields required by [`docs/release-versioning-and-upgrade-contract.md`](../../docs/release-versioning-and-upgrade-contract.md) and produced by `skills/skill-builder/SKILL.md` Phase 4:
+
+- `framework_release`
+- `generated_at`
+- `contract_versions.fragment_schema`
+- `contract_versions.generated_skill_schema`
+- `contract_versions.integration_declaration_schema`
+- `compatibility.status` — one of `compatible | regeneration-recommended | regeneration-required`
+- `compatibility.reason`
+- `compatibility.manual_review_required`
+
+If the manifest is missing entirely, treat the project as never bootstrapped: stop the upgrade flow and direct the operator at the installed `superagents-skill-builder`.
+
+If individual fields are missing, treat each missing field as drift in Phase 2.
+
+### 1.3 Origin/main delta (optional)
+
+Only run when `SUPERAGENTS_FETCH_REMOTE=1` (or the operator explicitly opts in when prompted). When opted in:
+
+1. Use `gh release list --repo peakweb-team/superagents --limit 1` to find the latest tagged release.
+2. Use `gh api repos/peakweb-team/superagents/compare/<latest-tag>...main --jq '.ahead_by'` to count commits on `main` ahead of the latest tag, and `--jq '.commits[].commit.message'` to enumerate them. Prefer this `gh api`-based approach over a clone — it is cheap and stays inside the container.
+3. If `gh` is not available, fall back to a shallow clone into a temp directory (`git clone --depth 50 --filter=blob:none $SUPERAGENTS_REMOTE`) and run `git rev-list <latest-tag>..origin/main --count`. Clean up the temp clone before exiting.
+
+Surface the count and the short log so the operator can decide whether to compare against `origin/main` or only against the latest released tag.
+
+## Phase 2 — Diff
+
+Compare four surfaces. Each comparison produces a list of changes that feeds Phase 3.
+
+### 2.1 `contract_versions`
+
+For each of `fragment_schema`, `generated_skill_schema`, `integration_declaration_schema`, compute `installed - project`. Any positive delta is upgrade drift. Any negative delta means the project bundle was generated against a newer framework than the one installed — surface this as an explicit warning ("project bundle is ahead of installed framework"), do not classify it as compatible-to-upgrade.
+
+### 2.2 `fragments.lock.yaml`
+
+Read `<project>/.agency/skills/superagents/fragments.lock.yaml` and compare line-by-line against what the installed builder would produce given the same inventory. The diff that matters is fragment additions, removals, and version bumps; suppression-reason changes are advisory.
+
+If the project bundle does not record a fragment lock, treat the entire fragment set as drift.
+
+### 2.3 Generated `SKILL.md` content
+
+Diff the generated execution-facing files. Their location depends on the layout the project committed under:
+
+- For projects following `docs/generated-skill-layout.md` (current canonical layout), look under `<project>/.claude/skills/superagents/<skill-name>/SKILL.md`.
+- For projects updated through issue #135's standardization, additionally check `<project>/.claude/skills/superagents-<function>/SKILL.md`.
+
+For each generated `SKILL.md`, do a textual diff against the file the current installed skill-builder would produce given the locked fragments. Three signals matter:
+
+- **Fragment-driven drift** — content differs because new fragments are selected. Phase 5 can regenerate this cleanly.
+- **Manual edits** — content differs from the builder's deterministic output even though the fragment set is unchanged. The operator hand-edited the file. This must be surfaced explicitly per Phase 3.
+- **Both** — the file is hand-edited *and* fragments have moved. This is the highest-risk case.
+
+Detect manual edits by re-running the builder in dry-run mode against the locked fragments and the recorded decisions, then diffing the result against the committed file. Any non-empty diff there is a manual edit.
+
+### 2.4 Devcontainer scaffold
+
+Compare the project's `.devcontainer/` files against the templates the installed `superagents-devcontainer-bootstrap` skill would currently emit. Files to compare (sourced from the bootstrap skill's templates):
+
+- `.devcontainer/devcontainer.json`
+- `.devcontainer/Dockerfile`
+- `.devcontainer/post-create-superagents.sh`
+- `.devcontainer/scaffold-devcontainer.sh`
+- `.devcontainer/smoke-test-superagents.sh`
+
+A diff in any of these triggers the Phase 6 advisory but does **not** trigger Phase 5 regeneration — devcontainer rebuilds are host-side.
+
+## Phase 3 — Summarize
+
+Print a single, reviewable summary block before any prompt. The summary must include:
+
+### 3.1 Per-surface change counts
+
+```text
+Upgrade summary
+  Installed framework release: <value> (source: <release.json | bundle frontmatter | host checkout | unknown>)
+  Project framework release:   <value>
+  Origin/main commits ahead of latest tag: <N or 'not checked'>
+
+  Contract version drift:
+    fragment_schema:                <project> -> <installed>
+    generated_skill_schema:         <project> -> <installed>
+    integration_declaration_schema: <project> -> <installed>
+
+  Fragment lock changes: +<added> / -<removed> / ~<changed>
+  Generated SKILL.md changes: <N> file(s) with fragment-driven drift, <M> file(s) with manual edits
+  Devcontainer scaffold changes: <K> file(s)
+```
+
+### 3.2 Compatibility classification
+
+Compute the project bundle's effective upgrade posture using the rules in `docs/release-versioning-and-upgrade-contract.md` § "Upgrade Classification Rules":
+
+- `compatible` — no contract version delta, no fragment lock changes, no generated content drift beyond noise.
+- `regeneration-recommended` — additive contract version delta (minor) or new fragments/providers; no breaking change; old bundle still truthful but no longer ideal.
+- `regeneration-required` — at least one breaking signal: a contract version moved in a way the contract calls breaking, or a manifest field that older bundles cannot interpret was added.
+
+Use the `release.json` `regeneration_status` from the installed framework when available — its values map onto the per-bundle `compatibility.status` per `docs/release-process.md` § "regeneration_status vs the manifest's compatibility.status":
+
+| `release.json` `regeneration_status` | Bundle `compatibility.status` |
+|---|---|
+| `compatible-no-regeneration-needed` | `compatible` |
+| `compatible-regeneration-recommended` | `regeneration-recommended` |
+| `breaking-regeneration-required` | `regeneration-required` |
+
+Print the classification verbatim — `compatible`, `regeneration-recommended`, or `regeneration-required` — together with the one-line `reason` that should land in the regenerated manifest's `compatibility.reason`.
+
+### 3.3 Manual-edit warnings
+
+When Phase 2.3 detects manual edits, print a warning per the contract's "Manual Edit Expectations During Upgrade":
+
+```text
+WARNING: <relative-path-to-SKILL.md>
+  This file appears to have been hand-edited since the last builder run.
+  Applying this change will overwrite the manual edits.
+  Recommended: move durable changes back into fragments or builder inputs
+  before re-running this upgrade.
+```
+
+The warning is informational; the operator still gets to choose `apply` / `raise` / `skip` / `both` in Phase 4.
+
+## Phase 4 — Decide
+
+For **each** detected change, prompt the operator with a four-way choice. Never apply silently — even when the classification is `regeneration-required`, the operator must approve each change.
+
+Use a structured per-change prompt. The four options are exactly:
+
+- **`apply`** — regenerate this portion locally in Phase 5
+- **`raise`** — record the change as an upstream-feedback candidate (Phase 7 stub records it; the upstream issue is not opened in this PR)
+- **`skip`** — do nothing for this change in this run
+- **`both`** — apply locally **and** record an upstream-feedback candidate
+
+Ask the questions one at a time and group them by surface (contract drift first, then fragment lock, then generated SKILL.md, then devcontainer). For each question:
+
+1. Show the relevant diff or change summary.
+2. Show the manual-edit warning if applicable.
+3. Show the four options with one-line explanations.
+4. Wait for the operator's response.
+5. Record the choice in an in-memory plan keyed by change id.
+
+The structured-prompt pattern this codebase uses elsewhere (notably the AskUserQuestion-style flows in the installed skill-builder questionnaire) applies here. Treat each per-change prompt as a single question with a four-option multiple choice.
+
+A "no choice" answer (the operator skips the prompt or terminates the session) defaults to `skip` for that change. Never default to `apply`.
+
+When all changes have a recorded choice, print the plan back to the operator for a final confirmation before Phase 5 begins:
+
+```text
+Plan:
+  apply:   <N> change(s)
+  raise:   <M> change(s)
+  skip:    <K> change(s)
+  both:    <L> change(s)
+Proceed? [y/N]
+```
+
+A `N` (or no answer) terminates the skill cleanly without writing files. A `y` proceeds to Phase 5.
+
+## Phase 5 — Apply locally
+
+For every change marked `apply` or `both`:
+
+1. **Hand off to the installed skill-builder.** Do **not** invoke any CLI. Hand off by invoking the `superagents-skill-builder` skill with a context describing what to regenerate. Pass:
+   - the project root
+   - the list of approved change ids (so the builder can scope regeneration where the contract permits)
+   - the `regeneration-recommended` / `regeneration-required` posture
+   - any unresolved decisions captured in `decisions.yaml` so the builder does not re-ask them
+
+   When the builder cannot scope the regeneration to a subset (the MVP behavior is "regenerate the whole bundle"), regenerate the whole bundle and surface the broader impact in the resulting diff.
+
+2. **Outputs land at the canonical roots:**
+   - `<project>/.claude/skills/superagents/` — the execution-facing root described in `docs/generated-skill-layout.md`. For projects following the `superagents-<function>` standardization from issue #135, generated skills also land at `<project>/.claude/skills/superagents-<function>/`.
+   - `<project>/.agency/skills/superagents/` — the metadata bundle root.
+
+3. **Verify the regenerated manifest.** After the builder finishes, run `tests/test-manifest-upgrade-metadata.sh` from the project's superagents source checkout (or the host checkout) against the regenerated `<project>/.agency/skills/superagents/manifest.yaml` if the test supports out-of-tree fixture paths; otherwise, re-validate the required-field set inline:
+   - `framework_release` is non-empty
+   - `generated_at` parses as ISO-8601
+   - `contract_versions` contains all three required keys
+   - `compatibility.status` is one of the three allowed values
+   - `compatibility.reason` is non-empty
+   - `compatibility.manual_review_required` is a boolean
+
+   If validation fails, **stop and surface the failure**. Do not pretend the upgrade succeeded.
+
+4. **Print the final diff summary.** List every file that was created, modified, or deleted under both roots so the operator can stage and review with normal `git diff`.
+
+## Phase 6 — Devcontainer advisory (stub)
+
+This phase is **deliberately stubbed** in this skill version. Full implementation is tracked under issue #147 (epic #148).
+
+When Phase 2.4 detected differences in any of `.devcontainer/devcontainer.json`, `.devcontainer/Dockerfile`, `.devcontainer/post-create-superagents.sh`, `.devcontainer/scaffold-devcontainer.sh`, or `.devcontainer/smoke-test-superagents.sh`:
+
+1. Print:
+   ```text
+   Devcontainer scaffold has changed. A host-side rebuild is required.
+   Phase 6 (devcontainer rebuild advisory) is deferred to issue #147 — see epic #148.
+   For the rebuild command and detach-VS-Code-first reminder, see the
+   superagents-devcontainer skill, "Rebuild" section.
+   ```
+2. Reference the `superagents-devcontainer` skill's "Rebuild" section as the operational source.
+3. **Do not** invoke `devcontainer` or `docker` from inside this skill. The skill runs inside the devcontainer; rebuilds happen on the host.
+4. Move on. Phase 6 must not block phases that already executed.
+
+## Phase 7 — Upstream feedback (stub)
+
+This phase is **deliberately stubbed** in this skill version. Full implementation is tracked under issue #146 (epic #148).
+
+For every change the operator marked `raise` or `both`:
+
+1. Print:
+   ```text
+   Upstream feedback for this change is deferred to issue #146 — see epic #148.
+   Selection recorded.
+   ```
+2. Append a structured selection record to `<project>/.agency/skills/superagents/upstream-feedback-pending.log` so the future #146 implementation can pick the records up. Each record is one line, key:value pairs separated by `;`:
+   ```text
+   ts:<ISO-8601>; surface:<contract|fragments|skill-md|devcontainer>; change_id:<id>; choice:<raise|both>; summary:<one-line>
+   ```
+   Create the file if it does not exist; append otherwise. Never overwrite.
+3. **Do not** call `gh issue create`. The upstream issue creation is exclusively #146's territory.
+
+## Error Handling
+
+- **Manifest missing** → stop with a clear message; direct the operator at the installed skill-builder for first-time generation. Do not pretend to upgrade a project that has not been bootstrapped.
+- **Installed framework release unresolved** → continue with `unknown` and warn; the diff against `origin/main` is still useful.
+- **Network unavailable for Phase 1.3** → skip the origin/main delta silently; the rest of the flow continues.
+- **Builder hand-off fails in Phase 5** → leave the project in its pre-Phase-5 state. The skill-builder is responsible for atomic writes; if it left a partial bundle, surface that with a message asking the operator to revert.
+- **Manifest validation fails after regeneration** → stop and surface the failure. Do not let the operator commit a manifest the upgrade-metadata test would reject.
+
+## Stopping Conditions
+
+The skill stops cleanly (without applying changes) when:
+
+- the project has no `.agency/skills/superagents/manifest.yaml` (project never bootstrapped)
+- the operator declines the Phase 4 plan confirmation
+- every detected change is marked `skip`
+- the installed framework release equals the project's `framework_release` *and* every Phase 2 surface is empty (nothing to upgrade)
+
+The skill stops with an error when:
+
+- the manifest exists but is malformed (cannot be parsed as YAML)
+- Phase 5 hand-off to the builder fails or produces an invalid manifest
+
+## Success Criteria
+
+- Detection logged the installed framework release, the project framework release, and (when opted in) the origin/main commit count, with sources for each.
+- The summary block printed all four diff surfaces with counts.
+- The classification matches the upgrade contract's three states verbatim.
+- Manual-edit warnings, when applicable, named the file path and the consequence.
+- Every detected change received a per-change `apply | raise | skip | both` decision from the operator.
+- For changes marked `apply` or `both`, the regenerated bundle's `manifest.yaml` validates against the upgrade-metadata field set.
+- For changes marked `raise` or `both`, an entry was appended to `upstream-feedback-pending.log`.
+- For devcontainer-scaffold changes, the operator saw the host-side rebuild advisory and was pointed at the `superagents-devcontainer` skill.
+
+## Reference
+
+- Authoritative upgrade contract: [`docs/release-versioning-and-upgrade-contract.md`](../../docs/release-versioning-and-upgrade-contract.md)
+- Release artifact and pipeline: [`docs/release-process.md`](../../docs/release-process.md), [`docs/schemas/release.schema.json`](../../docs/schemas/release.schema.json)
+- Generated layout this skill operates on: [`docs/generated-skill-layout.md`](../../docs/generated-skill-layout.md)
+- The skill-builder this skill hands off to in Phase 5: [`skills/skill-builder/SKILL.md`](../skill-builder/SKILL.md)
+- Companion devcontainer skill referenced from Phase 6: [`skills/superagents-devcontainer/SKILL.md`](../superagents-devcontainer/SKILL.md)
+- Manifest validation harness used in Phase 5 verification: [`tests/test-manifest-upgrade-metadata.sh`](../../tests/test-manifest-upgrade-metadata.sh)
+
+## Open Questions
+
+These are surfaced for the operator and for follow-up work; they are not blocking.
+
+- **Where does the installed framework release live?** Phase 1.1 uses a four-step resolution order that prefers a shipped `release.json` artifact, then bundle frontmatter, then a host checkout's `git describe`, then `unknown`. The release-versioning contract does not pick a canonical source today. Once one source becomes authoritative, this skill should narrow the resolution order and the contract should be updated to match.
+- **Scoped vs whole-bundle regeneration in Phase 5.** The current skill-builder regenerates the whole bundle. When per-change scoped regeneration becomes possible the Phase 5 hand-off should pass a scope hint instead of falling back to whole-bundle regeneration.
+- **Phase 7 record format.** The `upstream-feedback-pending.log` line format above is provisional. Issue #146 will define the canonical record shape; until then the line-based format is forward-compatible and easy to grep.

--- a/skills/superagents-upgrade/SKILL.md
+++ b/skills/superagents-upgrade/SKILL.md
@@ -15,7 +15,7 @@ This skill is **interactive and never silently applies changes**. Every detected
 
 - Optional argument: project path. If omitted, use the current working directory.
 - Optional environment overrides:
-  - `SUPERAGENTS_HOST_CHECKOUT` — absolute path to a host superagents source checkout, used as a fallback when the installed bundle does not record its own framework release. Defaults to "(none)" — see [Phase 1](#phase-1-detect) for the resolution order.
+  - `SUPERAGENTS_HOST_CHECKOUT` — absolute path to a host superagents source checkout, used as a fallback when the installed bundle does not record its own framework release. Defaults to "(none)". The resolution order is described in the "Phase 1 — Detect" section below.
   - `SUPERAGENTS_REMOTE` — origin URL used for the optional remote-fetch in Phase 1. Defaults to `https://github.com/peakweb-team/superagents`.
   - `SUPERAGENTS_FETCH_REMOTE` — set to `1` to opt in to the remote fetch. Default off.
 
@@ -262,7 +262,7 @@ When Phase 2.4 detected differences in any of `.devcontainer/devcontainer.json`,
    For the rebuild command and detach-VS-Code-first reminder, see the
    superagents-devcontainer skill, "Rebuild" section.
    ```
-2. Reference the `superagents-devcontainer` skill's "Rebuild" section as the operational source.
+2. Reference the `superagents-devcontainer` skill's "Rebuild" section as the operational source. Note: this is a different skill from `superagents-devcontainer-bootstrap` — the bootstrap skill scaffolds a devcontainer for the first time and ships the templates Phase 2.4 compares against, while the lifecycle skill (`superagents-devcontainer`) carries the rebuild/stop/extend command reference. Both ship in the Claude install via `scripts/install.sh`.
 3. **Do not** invoke `devcontainer` or `docker` from inside this skill. The skill runs inside the devcontainer; rebuilds happen on the host.
 4. Move on. Phase 6 must not block phases that already executed.
 

--- a/tests/test-install-smoke.sh
+++ b/tests/test-install-smoke.sh
@@ -14,11 +14,13 @@ HOME="$TMP_HOME" "$INSTALL_SCRIPT" --tool claude-code --no-interactive >/tmp/sup
 AGENTS_DIR="$TMP_HOME/.claude/agents"
 SKILL_BUILDER_DIR="$TMP_HOME/.claude/skills/superagents-skill-builder"
 DEVCONTAINER_DIR="$TMP_HOME/.claude/skills/superagents-devcontainer-bootstrap"
+DEVCONTAINER_LIFECYCLE_DIR="$TMP_HOME/.claude/skills/superagents-devcontainer"
 UPGRADE_DIR="$TMP_HOME/.claude/skills/superagents-upgrade"
 
 [[ -d "$AGENTS_DIR" ]] || { echo "Expected agent install directory at $AGENTS_DIR"; exit 1; }
 [[ -f "$SKILL_BUILDER_DIR/SKILL.md" ]] || { echo "Missing skill-builder SKILL.md"; exit 1; }
 [[ -f "$DEVCONTAINER_DIR/SKILL.md" ]] || { echo "Missing devcontainer bootstrap SKILL.md"; exit 1; }
+[[ -f "$DEVCONTAINER_LIFECYCLE_DIR/SKILL.md" ]] || { echo "Missing devcontainer lifecycle SKILL.md"; exit 1; }
 [[ -f "$UPGRADE_DIR/SKILL.md" ]] || { echo "Missing upgrade SKILL.md"; exit 1; }
 [[ -f "$SKILL_BUILDER_DIR/fragments/project-management/github-issues.md" ]] || { echo "Missing copied fragment in skill-builder bundle"; exit 1; }
 

--- a/tests/test-install-smoke.sh
+++ b/tests/test-install-smoke.sh
@@ -14,10 +14,12 @@ HOME="$TMP_HOME" "$INSTALL_SCRIPT" --tool claude-code --no-interactive >/tmp/sup
 AGENTS_DIR="$TMP_HOME/.claude/agents"
 SKILL_BUILDER_DIR="$TMP_HOME/.claude/skills/superagents-skill-builder"
 DEVCONTAINER_DIR="$TMP_HOME/.claude/skills/superagents-devcontainer-bootstrap"
+UPGRADE_DIR="$TMP_HOME/.claude/skills/superagents-upgrade"
 
 [[ -d "$AGENTS_DIR" ]] || { echo "Expected agent install directory at $AGENTS_DIR"; exit 1; }
 [[ -f "$SKILL_BUILDER_DIR/SKILL.md" ]] || { echo "Missing skill-builder SKILL.md"; exit 1; }
 [[ -f "$DEVCONTAINER_DIR/SKILL.md" ]] || { echo "Missing devcontainer bootstrap SKILL.md"; exit 1; }
+[[ -f "$UPGRADE_DIR/SKILL.md" ]] || { echo "Missing upgrade SKILL.md"; exit 1; }
 [[ -f "$SKILL_BUILDER_DIR/fragments/project-management/github-issues.md" ]] || { echo "Missing copied fragment in skill-builder bundle"; exit 1; }
 
 expected_fragments="$(find "$ROOT_DIR/skills/fragments" -name '*.md' -type f | wc -l | awk '{print $1}')"


### PR DESCRIPTION
## What does this PR do?

Adds the project-local `/superagents-upgrade` orchestration skill described in #145.

The skill compares three surfaces — the installed Superagents framework release, the project's generated bundle under `.claude/skills/superagents*` and `.agency/skills/superagents/`, and (optionally) the latest superagents `origin/main` — classifies the delta per the upgrade contract, prompts the operator per detected change, and hands approved changes either to the installed skill-builder for regeneration or to the upstream-feedback flow.

`Closes #145`

## Phase Summary

| Phase | Name | Status in this PR |
|-------|------|------|
| 1 | Detect | implemented |
| 2 | Diff | implemented |
| 3 | Summarize | implemented |
| 4 | Decide | implemented |
| 5 | Apply locally | implemented |
| 6 | Devcontainer advisory | **stub** — deferred to #147 (epic #148) |
| 7 | Upstream feedback | **stub** — deferred to #146 (epic #148) |

Phases 6 and 7 are deliberately left as documented stubs in this PR. They print deferral messages and reference their tracking issues without acting. Phase 7 records selections to `.agency/skills/superagents/upstream-feedback-pending.log` so #146 can pick them up later. Phase 6 only prints the host-side rebuild advisory and points at the `superagents-devcontainer` skill — it never invokes `devcontainer` or `docker` from inside the container.

## Files

- **Added:** `skills/superagents-upgrade/SKILL.md` — primary deliverable.
- **Modified:** `scripts/install.sh` — packages the skill at `~/.claude/skills/superagents-upgrade/` alongside the existing companion skills, with the same atomic stage/replace/restore pattern.
- **Modified:** `tests/test-install-smoke.sh` — asserts the upgrade SKILL.md lands at the expected path on install.
- **Modified:** `skills/skill-builder/SKILL.md` — instructs the builder to reference `/superagents-upgrade` from the generated primary orchestration skill so operators discover it.
- **Modified:** `skills/superagents-devcontainer/SKILL.md` — adds a reference link to the upgrade skill from the existing companion skill.
- **Modified:** `docs/builder-usage-and-repo-local-precedence-contract.md` — adds a "Regeneration Flow" subsection pointing at the upgrade skill for the interactive review path.

## Per-change Operator Choices

For every change Phase 4 detects, the operator picks exactly one of:

- `apply` — regenerate this portion locally
- `raise` — record an upstream-feedback candidate (deferred to #146)
- `skip` — do nothing for this change
- `both` — apply locally and record an upstream-feedback candidate

Never applies silently. A no-answer defaults to `skip`. Phase 5 only proceeds after a final plan-summary confirmation.

## Open Question Surfaced In The Skill

The release-versioning contract does not pick a single canonical source for "installed framework release." The skill documents a four-step resolution order — `release.json` artifact -> bundle frontmatter -> `git describe` of a host checkout -> `unknown` — and surfaces this as an open question for follow-up. The contract should narrow this once one source is authoritative.

## Test plan

- [x] `tests/test-skill-builder-runtime-target-contract.sh` — passes locally
- [x] `tests/test-manifest-upgrade-metadata.sh` — passes locally (9/9 fixtures)
- [x] `tests/test-dogfooding-guardrails.sh` — passes locally; no `.agency/` or `.claude/` artifacts slipped in
- [x] `tests/test-install-smoke.sh` — passes locally; asserts the new skill lands at `~/.claude/skills/superagents-upgrade/SKILL.md`
- [ ] `tests/test-doc-link-integrity.sh` — relies on `ruby`, not available in this worktree; CI will run it. The single doc link added is identical to one already present in the same file.
- [ ] `tests/test-fragment-contract-validation.sh` — relies on `ruby`, not available in this worktree; CI will run it. No fragments were added or modified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Interactive upgrade skill that guides framework upgrades with drift detection, per-change classification, and operator prompts (apply | raise | skip | both).
* **Documentation**
  * Added a Regeneration Flow and upgrade workflow docs; cross-referenced from related skills.
* **Chores**
  * Installer now stages and activates devcontainer and upgrade skill bundles during setup.
* **Tests**
  * Installation smoke test updated to validate the new skill bundles are present.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->