### PR TITLE
/superagents-upgrade: in-container update path to refresh ~/.claude install without rebuild

### DIFF
--- a/skills/devcontainer-bootstrap/templates/scaffold-devcontainer.sh
+++ b/skills/devcontainer-bootstrap/templates/scaffold-devcontainer.sh
@@ -12,7 +12,11 @@ curl -fsSL "$BASE_URL/Dockerfile" -o "$TARGET_DIR/Dockerfile"
 TEMPLATE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 cp "$TEMPLATE_DIR/post-create-superagents.sh" "$TARGET_DIR/post-create-superagents.sh"
 cp "$TEMPLATE_DIR/smoke-test-superagents.sh" "$TARGET_DIR/smoke-test-superagents.sh"
-chmod +x "$TARGET_DIR/post-create-superagents.sh" "$TARGET_DIR/smoke-test-superagents.sh"
+cp "$TEMPLATE_DIR/upgrade-superagents-in-container.sh" "$TARGET_DIR/upgrade-superagents-in-container.sh"
+chmod +x \
+  "$TARGET_DIR/post-create-superagents.sh" \
+  "$TARGET_DIR/smoke-test-superagents.sh" \
+  "$TARGET_DIR/upgrade-superagents-in-container.sh"
 
 # ---------------------------------------------------------------------------
 # Port designation

--- a/skills/devcontainer-bootstrap/templates/upgrade-superagents-in-container.sh
+++ b/skills/devcontainer-bootstrap/templates/upgrade-superagents-in-container.sh
@@ -210,8 +210,13 @@ snapshot_claude_dir() {
     : > "$out_file"
     return 0
   fi
+  # `-r` (--no-run-if-empty) prevents xargs from invoking sha256sum when
+  # find emits zero paths -- without it, sha256sum runs against stdin and
+  # writes a synthetic "<hash>  -" line to the snapshot, which would later
+  # surface as a phantom "-" entry in the diff report when ~/.claude/ is
+  # empty (rare, but possible in fresh-container or test scenarios).
   ( cd "$claude_dir" && find . -type f -print0 \
-      | xargs -0 sha256sum 2>/dev/null \
+      | xargs -0 -r sha256sum 2>/dev/null \
       | LC_ALL=C sort ) > "$out_file" || true
 }
 

--- a/skills/devcontainer-bootstrap/templates/upgrade-superagents-in-container.sh
+++ b/skills/devcontainer-bootstrap/templates/upgrade-superagents-in-container.sh
@@ -1,0 +1,261 @@
+#!/usr/bin/env bash
+#
+# upgrade-superagents-in-container.sh -- Refresh ~/.claude/ from a superagents
+# ref without rebuilding the devcontainer.
+#
+# Mirrors the clone+install pattern from .devcontainer/post-create-superagents.sh
+# (lines 23-33) but adds a scaffold-guard: if any of the four scaffold files
+# (.devcontainer/Dockerfile, devcontainer.json, post-create-superagents.sh,
+# scaffold-devcontainer.sh) differ between the cloned ref and what is committed
+# in the project, the script exits non-zero with a "rebuild required" message
+# and does NOT touch ~/.claude/. When the guard passes, the script invokes
+# scripts/install.sh --tool claude-code --no-interactive against the cloned
+# checkout and reports what changed under ~/.claude/.
+#
+# Usage:
+#   .devcontainer/upgrade-superagents-in-container.sh [--dry-run]
+#
+# Environment:
+#   SUPERAGENTS_REPO  -- override the upstream repo (default: pw-agency-agents)
+#   SUPERAGENTS_REF   -- pin a ref (default: main)
+#
+# Flags:
+#   --dry-run         -- run the scaffold guard only; do not invoke install.sh.
+#                        Exits 0 when guard passes, non-zero when it fires.
+#                        Used by tests/test-in-container-upgrade-guard.sh.
+#
+# Exit codes:
+#   0  -- success (install completed, or guard passed under --dry-run)
+#   1  -- general failure
+#   2  -- scaffold guard fired: rebuild required
+#   3  -- not running inside a devcontainer (host guard)
+
+set -euo pipefail
+
+SUPERAGENTS_REPO="${SUPERAGENTS_REPO:-https://github.com/peakweb-team/pw-agency-agents.git}"
+SUPERAGENTS_REF="${SUPERAGENTS_REF:-main}"
+
+DRY_RUN=0
+for arg in "$@"; do
+  case "$arg" in
+    --dry-run)
+      DRY_RUN=1
+      ;;
+    -h|--help)
+      sed -n '2,/^$/p' "$0" | sed 's/^# \{0,1\}//'
+      exit 0
+      ;;
+    *)
+      echo "ERROR: unknown argument: $arg" >&2
+      echo "Usage: $0 [--dry-run]" >&2
+      exit 1
+      ;;
+  esac
+done
+
+# ---------------------------------------------------------------------------
+# Host guard -- bail loudly if we look like we are running on the host rather
+# than inside a devcontainer. The script edits ~/.claude/ which would clobber
+# the operator's host install. Heuristic: the official Anthropic devcontainer
+# image runs as the `node` user with HOME=/home/node, and we ship inside a
+# container created from that image. If neither marker is present, refuse.
+# Override with SUPERAGENTS_SKIP_HOST_GUARD=1 (escape hatch for tests/CI).
+# ---------------------------------------------------------------------------
+host_guard() {
+  if [ "${SUPERAGENTS_SKIP_HOST_GUARD:-0}" = "1" ]; then
+    return 0
+  fi
+  if [ -d /home/node ] && [ "${HOME:-}" = "/home/node" ]; then
+    return 0
+  fi
+  if [ -n "${REMOTE_CONTAINERS:-}" ] || [ -n "${CODESPACES:-}" ] || [ -n "${DEVCONTAINER:-}" ]; then
+    return 0
+  fi
+  cat >&2 <<EOF
+ERROR: this script must run inside the superagents devcontainer.
+       It refreshes ~/.claude/ from a cloned superagents ref. Running on
+       the host would clobber your host claude install.
+       Open the project in its devcontainer and re-run from the container
+       terminal. To bypass this guard (e.g. in CI), set
+       SUPERAGENTS_SKIP_HOST_GUARD=1.
+EOF
+  exit 3
+}
+
+# ---------------------------------------------------------------------------
+# Scaffold guard -- compare the four scaffold files in the project's
+# .devcontainer/ against the cloned ref's .devcontainer/ files. If any differ,
+# the project has either drifted ahead of upstream or upstream has changed in
+# a way that requires a host-side rebuild. Exit 2 with a clear message; do not
+# run install.sh.
+#
+# Args:
+#   $1 -- absolute path to the project root (must contain .devcontainer/)
+#   $2 -- absolute path to the cloned superagents checkout root
+#         (must contain .devcontainer/)
+# Returns:
+#   0 -- all four scaffold files match
+#   2 -- at least one differs
+# ---------------------------------------------------------------------------
+SCAFFOLD_FILES=(
+  ".devcontainer/Dockerfile"
+  ".devcontainer/devcontainer.json"
+  ".devcontainer/post-create-superagents.sh"
+  ".devcontainer/scaffold-devcontainer.sh"
+)
+
+scaffold_guard() {
+  local project_root="$1"
+  local clone_root="$2"
+  local diffs=()
+  local missing=()
+
+  for relpath in "${SCAFFOLD_FILES[@]}"; do
+    local project_file="$project_root/$relpath"
+    local clone_file="$clone_root/$relpath"
+
+    if [ ! -f "$project_file" ]; then
+      missing+=("project: $relpath")
+      continue
+    fi
+    if [ ! -f "$clone_file" ]; then
+      # If the upstream ref does not ship this scaffold file, treat it as a
+      # signal that scaffolding has changed shape — a rebuild path is needed.
+      missing+=("upstream: $relpath")
+      continue
+    fi
+    if ! cmp -s "$project_file" "$clone_file"; then
+      diffs+=("$relpath")
+    fi
+  done
+
+  if [ ${#diffs[@]} -eq 0 ] && [ ${#missing[@]} -eq 0 ]; then
+    return 0
+  fi
+
+  cat >&2 <<EOF
+Rebuild required -- scaffold files differ between this project and superagents@${SUPERAGENTS_REF}.
+
+Differing files:
+EOF
+  for f in "${diffs[@]}"; do
+    echo "  - $f (content differs)" >&2
+  done
+  for f in "${missing[@]}"; do
+    echo "  - $f (missing)" >&2
+  done
+  cat >&2 <<EOF
+
+The in-container update path only refreshes ~/.claude/. Changes to the
+devcontainer scaffold itself require rebuilding the container image on the
+host.
+
+See the superagents-devcontainer skill (Rebuild section) for the rebuild
+procedure:
+  ~/.claude/skills/superagents-devcontainer/SKILL.md  (section 1: Rebuild)
+
+~/.claude/ was NOT modified by this run.
+EOF
+  return 2
+}
+
+# ---------------------------------------------------------------------------
+# Snapshot helper -- capture a deterministic listing of ~/.claude/ contents so
+# we can report what changed after install.sh runs. We use file path + size
+# + sha256 to detect both content changes and additions/removals without
+# blowing up on large files.
+# ---------------------------------------------------------------------------
+snapshot_claude_dir() {
+  local out_file="$1"
+  local claude_dir="${HOME}/.claude"
+  if [ ! -d "$claude_dir" ]; then
+    : > "$out_file"
+    return 0
+  fi
+  ( cd "$claude_dir" && find . -type f -print0 \
+      | xargs -0 sha256sum 2>/dev/null \
+      | LC_ALL=C sort ) > "$out_file" || true
+}
+
+main() {
+  host_guard
+
+  local project_root
+  project_root="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+
+  if [ ! -d "$project_root/.devcontainer" ]; then
+    echo "ERROR: $project_root/.devcontainer does not exist." >&2
+    echo "       This script must run from within a project that was bootstrapped" >&2
+    echo "       via the superagents-devcontainer-bootstrap skill." >&2
+    exit 1
+  fi
+
+  local workdir
+  workdir="$(mktemp -d)"
+  # shellcheck disable=SC2064
+  trap "rm -rf '$workdir'" EXIT
+
+  local clone_root="$workdir/superagents"
+  echo "Cloning $SUPERAGENTS_REPO@$SUPERAGENTS_REF into temp dir..."
+  git clone --depth 1 --branch "$SUPERAGENTS_REF" "$SUPERAGENTS_REPO" "$clone_root"
+
+  echo "Running scaffold guard against ${#SCAFFOLD_FILES[@]} file(s)..."
+  if ! scaffold_guard "$project_root" "$clone_root"; then
+    exit 2
+  fi
+  echo "Scaffold guard passed: project .devcontainer/ matches superagents@${SUPERAGENTS_REF}."
+
+  if [ "$DRY_RUN" -eq 1 ]; then
+    echo "--dry-run: skipping install.sh; exiting 0."
+    exit 0
+  fi
+
+  local before_snapshot="$workdir/before.txt"
+  local after_snapshot="$workdir/after.txt"
+  snapshot_claude_dir "$before_snapshot"
+
+  local installer="$clone_root/scripts/install.sh"
+  if [ ! -x "$installer" ]; then
+    echo "ERROR: installer not found or not executable at $installer" >&2
+    exit 1
+  fi
+
+  echo "Running $installer --tool claude-code --no-interactive..."
+  "$installer" --tool claude-code --no-interactive
+
+  snapshot_claude_dir "$after_snapshot"
+
+  echo
+  echo "Changes under ~/.claude/:"
+  if diff -u "$before_snapshot" "$after_snapshot" >/dev/null 2>&1; then
+    echo "  (no changes detected)"
+  else
+    # Show only the changed file paths, not the full sha256 lines, to keep
+    # the report compact. `+` for additions/changes, `-` for removals.
+    # diff lines look like: "< <sha256>  <path>" or "> <sha256>  <path>".
+    diff "$before_snapshot" "$after_snapshot" \
+      | awk '/^[<>] [0-9a-f]+ / {
+               sign=($1=="<"?"-":"+");
+               # Drop the leading "< " or "> " marker and the sha256 hash to
+               # leave only the file path (which may contain spaces).
+               $1=""; $2="";
+               sub(/^[[:space:]]+/, "");
+               print sign " " $0;
+             }' \
+      | LC_ALL=C sort -u
+    echo
+    echo "If a SKILL.md you currently have open in your claude session changed,"
+    echo "restart the claude session (or re-open the skill) so the new content"
+    echo "is picked up."
+  fi
+
+  echo
+  echo "Superagents refresh complete (ref: $SUPERAGENTS_REF)."
+}
+
+# Allow tests to source this file and call scaffold_guard / host_guard
+# directly without running main. Detect by checking BASH_SOURCE vs $0 -- when
+# sourced, BASH_SOURCE[0] != $0.
+if [ "${BASH_SOURCE[0]}" = "$0" ]; then
+  main "$@"
+fi

--- a/skills/devcontainer-bootstrap/templates/upgrade-superagents-in-container.sh
+++ b/skills/devcontainer-bootstrap/templates/upgrade-superagents-in-container.sh
@@ -233,13 +233,12 @@ main() {
     # Show only the changed file paths, not the full sha256 lines, to keep
     # the report compact. `+` for additions/changes, `-` for removals.
     # diff lines look like: "< <sha256>  <path>" or "> <sha256>  <path>".
+    # Operate on $0 directly via sub() so paths with consecutive spaces are
+    # preserved verbatim (avoids awk's $0 reconstruction via OFS).
     diff "$before_snapshot" "$after_snapshot" \
       | awk '/^[<>] [0-9a-f]+ / {
                sign=($1=="<"?"-":"+");
-               # Drop the leading "< " or "> " marker and the sha256 hash to
-               # leave only the file path (which may contain spaces).
-               $1=""; $2="";
-               sub(/^[[:space:]]+/, "");
+               sub(/^[<>] [0-9a-f]+[[:space:]]+/, "", $0);
                print sign " " $0;
              }' \
       | LC_ALL=C sort -u

--- a/skills/devcontainer-bootstrap/templates/upgrade-superagents-in-container.sh
+++ b/skills/devcontainer-bootstrap/templates/upgrade-superagents-in-container.sh
@@ -89,6 +89,12 @@ EOF
 # a way that requires a host-side rebuild. Exit 2 with a clear message; do not
 # run install.sh.
 #
+# When the project root is a git checkout, the project-side comparison reads
+# the COMMITTED blob via `git show HEAD:<relpath>` rather than the working
+# tree, so uncommitted local edits to a scaffold file do not falsely trigger
+# a "rebuild required" exit. Non-git project roots fall back to the
+# working-tree file path.
+#
 # Args:
 #   $1 -- absolute path to the project root (must contain .devcontainer/)
 #   $2 -- absolute path to the cloned superagents checkout root
@@ -110,23 +116,55 @@ scaffold_guard() {
   local diffs=()
   local missing=()
 
+  # If the project root is a git checkout, compare the COMMITTED scaffold
+  # blobs against upstream rather than the working tree. Operators
+  # frequently have unrelated working-tree edits to .devcontainer/ open;
+  # those should not block the in-container update path. Non-git roots
+  # (rare, e.g. an exported tarball) fall back to the working-tree file.
+  local project_is_git_checkout=0
+  if git -C "$project_root" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+    project_is_git_checkout=1
+  fi
+
   for relpath in "${SCAFFOLD_FILES[@]}"; do
     local project_file="$project_root/$relpath"
     local clone_file="$clone_root/$relpath"
+    # `committed_file` is the path scaffold_guard actually compares against
+    # `clone_file`. For git checkouts we materialize the committed blob into
+    # a temp file (so cmp -s, missing-detection, and the diff message all
+    # work uniformly across both branches).
+    local committed_file=""
 
-    if [ ! -f "$project_file" ]; then
-      missing+=("project: $relpath")
-      continue
+    if [ "$project_is_git_checkout" -eq 1 ]; then
+      committed_file="$(mktemp)"
+      # `git show HEAD:<relpath>` writes the committed blob to stdout. A
+      # non-zero exit means the path is not tracked at HEAD (untracked,
+      # never-committed, or removed) -- treat that as "missing on the
+      # project side", same as the filesystem branch below.
+      if ! git -C "$project_root" show "HEAD:$relpath" > "$committed_file" 2>/dev/null; then
+        rm -f "$committed_file"
+        missing+=("project: $relpath (not committed at HEAD)")
+        continue
+      fi
+    else
+      if [ ! -f "$project_file" ]; then
+        missing+=("project: $relpath")
+        continue
+      fi
+      committed_file="$project_file"
     fi
+
     if [ ! -f "$clone_file" ]; then
       # If the upstream ref does not ship this scaffold file, treat it as a
       # signal that scaffolding has changed shape — a rebuild path is needed.
+      [ "$project_is_git_checkout" -eq 1 ] && rm -f "$committed_file"
       missing+=("upstream: $relpath")
       continue
     fi
-    if ! cmp -s "$project_file" "$clone_file"; then
+    if ! cmp -s "$committed_file" "$clone_file"; then
       diffs+=("$relpath")
     fi
+    [ "$project_is_git_checkout" -eq 1 ] && rm -f "$committed_file"
   done
 
   if [ ${#diffs[@]} -eq 0 ] && [ ${#missing[@]} -eq 0 ]; then
@@ -196,8 +234,20 @@ main() {
   trap "rm -rf '$workdir'" EXIT
 
   local clone_root="$workdir/superagents"
-  echo "Cloning $SUPERAGENTS_REPO@$SUPERAGENTS_REF into temp dir..."
-  git clone --depth 1 --branch "$SUPERAGENTS_REF" "$SUPERAGENTS_REPO" "$clone_root"
+  # SUPERAGENTS_REF can be a branch name, a tag, or a commit SHA. `git clone
+  # --branch` only accepts branch/tag names, so we use the init/fetch/checkout
+  # pattern instead -- `git fetch origin <ref>` resolves all three forms and
+  # `git checkout --detach FETCH_HEAD` lands us on the resolved commit.
+  echo "Fetching $SUPERAGENTS_REPO@$SUPERAGENTS_REF into temp dir..."
+  git init --quiet "$clone_root"
+  git -C "$clone_root" remote add origin "$SUPERAGENTS_REPO"
+  if ! git -C "$clone_root" fetch --depth 1 origin "$SUPERAGENTS_REF"; then
+    echo "ERROR: failed to fetch $SUPERAGENTS_REPO@$SUPERAGENTS_REF" >&2
+    echo "       Verify SUPERAGENTS_REF is a valid branch, tag, or commit SHA" >&2
+    echo "       on $SUPERAGENTS_REPO." >&2
+    exit 1
+  fi
+  git -C "$clone_root" checkout --quiet --detach FETCH_HEAD
 
   echo "Running scaffold guard against ${#SCAFFOLD_FILES[@]} file(s)..."
   if ! scaffold_guard "$project_root" "$clone_root"; then

--- a/skills/superagents-devcontainer/SKILL.md
+++ b/skills/superagents-devcontainer/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: superagents-devcontainer
-description: Manage a running or stopped Superagents devcontainer — rebuild after config changes, stop running containers, or extend an existing container with a new package or tool.
+description: Manage a running or stopped Superagents devcontainer — rebuild after config changes, stop running containers, extend an existing container with a new package or tool, or refresh the Superagents install in place without a rebuild.
 disable-model-invocation: false
-argument-hint: "[rebuild | stop | extend <package>]"
+argument-hint: "[rebuild | stop | extend <package> | update]"
 ---
 
 # Superagents Devcontainer Management
@@ -12,6 +12,7 @@ Use this skill when you need to manage the lifecycle of a Superagents devcontain
 - **Rebuild** — after changing `devcontainer.json`, `Dockerfile`, or `post-create-superagents.sh`
 - **Stop** — shut down a running container (specific project or all Superagents instances)
 - **Extend** — add a package or tool to a running container without a full rebuild
+- **Update without rebuild** — refresh `~/.claude/` from a Superagents ref in place when only `agents/`, `skills/`, `docs/`, or `scripts/` changed
 
 ---
 
@@ -150,6 +151,63 @@ devcontainer up --workspace-folder . --remove-existing-container
 | One-off `apt-get install` | Inside the running container |
 | Edit `post-create-superagents.sh` | Host (your editor) |
 | `devcontainer up` rebuild | Host terminal |
+
+---
+
+## 4. Update Without Rebuild
+
+For Superagents updates that affect only `agents/`, `skills/`, `docs/`, or `scripts/` (i.e. content the installer copies into `~/.claude/`), you can refresh in-place without a container rebuild.
+
+### When to Use
+
+The `superagents-upgrade` skill detects this case automatically and surfaces it as Phase 5b. Use the manual command below when:
+
+- You know upstream has changes you want to pull in
+- The four scaffold files (`.devcontainer/Dockerfile`, `.devcontainer/devcontainer.json`, `.devcontainer/post-create-superagents.sh`, `.devcontainer/scaffold-devcontainer.sh`) are unchanged between your project and the target ref
+- A full rebuild would be wasteful (it redoes Playwright, OS packages, and the npm/pnpm caches)
+
+### Command
+
+Run inside the running container terminal (not on the host):
+
+```bash
+.devcontainer/upgrade-superagents-in-container.sh
+```
+
+To pin a specific ref (defaults to `main`):
+
+```bash
+SUPERAGENTS_REF=v0.2.0 .devcontainer/upgrade-superagents-in-container.sh
+```
+
+The script:
+
+1. Verifies it is running inside a devcontainer (refuses to clobber a host install).
+2. Shallow-clones the configured `SUPERAGENTS_REPO` at `SUPERAGENTS_REF` into a temp dir.
+3. Runs the scaffold guard against the four scaffold files.
+4. If the guard passes, invokes `scripts/install.sh --tool claude-code --no-interactive` and reports what changed under `~/.claude/`.
+5. Cleans up the temp clone on exit.
+
+### Where to Run
+
+| Step | Location |
+|------|----------|
+| `.devcontainer/upgrade-superagents-in-container.sh` | Inside the running container |
+
+### When the Script Bails
+
+If any of the four scaffold files differ between the project and the target ref, the script exits non-zero with a "rebuild required" message and does **not** modify `~/.claude/`. In that case, follow the [Rebuild](#1-rebuild) section above. The script's exit codes are:
+
+| Exit code | Meaning |
+|-----------|---------|
+| 0 | Success — install completed (or `--dry-run` guard passed) |
+| 1 | General failure (bad arguments, missing project `.devcontainer/`, install.sh failed) |
+| 2 | Scaffold guard fired — host-side rebuild required |
+| 3 | Not running inside a devcontainer (host guard tripped) |
+
+### Restarting Claude
+
+If a `SKILL.md` you currently have open in the running claude session was updated, restart claude (or re-open the skill) so the new content is picked up. The script prints a reminder when changes are detected.
 
 ---
 

--- a/skills/superagents-upgrade/SKILL.md
+++ b/skills/superagents-upgrade/SKILL.md
@@ -313,7 +313,7 @@ The script ships in every project scaffolded via `superagents-devcontainer-boots
 
 1. **Host guard.** Refuses to run on the host (would clobber the operator's host claude install).
 2. **Shallow clone.** Clones `$SUPERAGENTS_REPO@$SUPERAGENTS_REF` into a temp dir and removes it on exit.
-3. **Scaffold guard.** Compares the four scaffold files. Exits 2 with a "rebuild required" message if any differ, without touching `~/.claude/`.
+3. **Scaffold guard.** Compares the four scaffold files (matching the Phase 6 trigger set in § 6.1; `.devcontainer/smoke-test-superagents.sh` is a runtime helper and is intentionally not part of this guard). When the project is a git checkout, the project side of the comparison reads each file's committed blob via `git show HEAD:<relpath>` rather than the working tree, so uncommitted local edits do not falsely trigger this guard. Exits 2 with a "rebuild required" message if any differ, without touching `~/.claude/`.
 4. **Install.** Runs `scripts/install.sh --tool claude-code --no-interactive` against the cloned checkout.
 5. **Diff report.** Prints the file paths under `~/.claude/` that were added, removed, or modified, and reminds the operator to restart their claude session if a `SKILL.md` they had open was changed.
 

--- a/skills/superagents-upgrade/SKILL.md
+++ b/skills/superagents-upgrade/SKILL.md
@@ -319,11 +319,7 @@ The script ships in every project scaffolded via `superagents-devcontainer-boots
 
 ### Recording the decision
 
-Treat Phase 5b like any other Phase 4 decision: record the operator's choice in the in-memory plan so the final summary lists "in-container update: invoked / deferred / skipped". When the operator picks `[b]` or `[c]`, also append a one-line marker to `<project>/.agency/skills/superagents/upstream-feedback-pending.log` so an audit trail exists:
-
-```text
-ts:<ISO-8601>; surface:in-container-update; ref:<SUPERAGENTS_REF>; choice:invoked
-```
+Treat Phase 5b like any other Phase 4 decision: record the operator's choice in the in-memory plan so the final summary lists "in-container update: invoked / deferred / skipped". The script itself emits the durable audit trail (the diff report under `~/.claude/`); this skill does not need to write a separate log entry. Do **not** append to `upstream-feedback-pending.log` — that log's format is owned by Phase 7 (issue #146) and is reserved for `raise` / `both` decisions.
 
 ### Manual smoke test
 

--- a/skills/superagents-upgrade/SKILL.md
+++ b/skills/superagents-upgrade/SKILL.md
@@ -36,7 +36,7 @@ Do **not** invoke this skill to perform the initial bootstrap of a project — f
 
 ## Phase Map
 
-This skill executes seven phases in order. All seven phases are implemented in this skill. Phase 7 is also reachable as a standalone shortcut via `/superagents-upgrade feedback` — see the Phase 7 section for details.
+This skill executes seven phases in order, plus a 5b "in-container update" branch that runs in parallel with phase 5 when scaffold files are unchanged. All seven phases (and phase 5b) are implemented in this skill. Phase 7 is also reachable as a standalone shortcut via `/superagents-upgrade feedback` — see the Phase 7 section for details.
 
 | Phase | Name | Status |
 |-------|------|--------|
@@ -45,10 +45,11 @@ This skill executes seven phases in order. All seven phases are implemented in t
 | 3 | Summarize | implemented |
 | 4 | Decide | implemented |
 | 5 | Apply locally | implemented |
+| 5b | In-container update path | implemented (issue #149) |
 | 6 | Devcontainer advisory | implemented |
 | 7 | Upstream feedback | implemented (also reachable standalone) |
 
-The seven-phase contract maps to the six-step "Recommended Upgrade Flow" in [`docs/release-versioning-and-upgrade-contract.md`](../../docs/release-versioning-and-upgrade-contract.md): phases 1–2 implement step 2 (compare), phase 3 implements step 3 (surface), phase 4 implements step 5 (review) interactively per change, phase 5 implements step 4 (regenerate), phase 6 is the devcontainer-specific extension of step 5, and phase 7 is the upstream-feedback hand-off introduced for this skill.
+The phase contract maps to the six-step "Recommended Upgrade Flow" in [`docs/release-versioning-and-upgrade-contract.md`](../../docs/release-versioning-and-upgrade-contract.md): phases 1–2 implement step 2 (compare), phase 3 implements step 3 (surface), phase 4 implements step 5 (review) interactively per change, phase 5 implements step 4 (regenerate) for the project bundle, phase 5b extends step 4 to the container-installed `~/.claude/` surface (only when scaffold files match), phase 6 is the devcontainer-specific extension of step 5 for the rebuild branch, and phase 7 is the upstream-feedback hand-off introduced for this skill.
 
 ## Phase 1 — Detect
 
@@ -252,6 +253,88 @@ For every change marked `apply` or `both`:
    If validation fails, **stop and surface the failure**. Do not pretend the upgrade succeeded.
 
 4. **Print the final diff summary.** List every file that was created, modified, or deleted under both roots so the operator can stage and review with normal `git diff`.
+
+## Phase 5b — In-container update path
+
+This phase is the container-surface mirror of Phase 5. While Phase 5 regenerates the project-local bundle under `<project>/.claude/skills/superagents/` and `<project>/.agency/skills/superagents/`, Phase 5b refreshes the user-level Superagents install under `~/.claude/` (skills like `superagents-skill-builder`, `superagents-devcontainer`, `superagents-upgrade` themselves, plus `~/.claude/agents/`). The two surfaces drift independently and Phase 5b targets only the container-installed surface.
+
+### When to surface
+
+Phase 5b is offered when **both** of the following are true:
+
+1. **Phase 3 classification** is `regeneration-recommended` or `regeneration-required` (i.e. there is something worth applying — Phase 5b is a no-op when the project is already `compatible`).
+2. **Phase 2.4 detected no scaffold drift.** All four scaffold files (`.devcontainer/Dockerfile`, `.devcontainer/devcontainer.json`, `.devcontainer/post-create-superagents.sh`, `.devcontainer/scaffold-devcontainer.sh`) match the target ref. If even one differs, defer to Phase 6 (rebuild advisory) instead — the in-container path would fail its own scaffold guard and refuse to run.
+
+When scaffold files have changed: do **not** offer the in-container path. Surface only the Phase 6 rebuild advisory. Mentioning Phase 5b in this case would mislead the operator into running a script that will exit with code 2.
+
+### What to surface
+
+When Phase 5b is offered, present it alongside the Phase 5 project-bundle option as a parallel choice. Make the trade-off explicit so the operator can pick:
+
+```text
+Two refresh paths are available for this upgrade:
+
+  [a] Project-bundle regeneration (Phase 5)
+      Refreshes <project>/.claude/skills/superagents/ and
+      <project>/.agency/skills/superagents/ from the installed builder.
+      Scope: this project's bundle only.
+
+  [b] In-container update (Phase 5b)
+      Refreshes ~/.claude/ (user-level superagents install) from
+      <ref> via .devcontainer/upgrade-superagents-in-container.sh.
+      Scope: every project sharing this devcontainer's ~/.claude/.
+      Faster than a full rebuild; cleaner state than a manual clone.
+
+  [c] Both
+      Run [a] then [b].
+
+  [d] Skip both (operator runs nothing).
+```
+
+The two paths address different surfaces and are not redundant: the project bundle is what the project's own skills read at runtime; `~/.claude/` is what the operator's `claude` session loads on startup. Most upgrades benefit from refreshing both.
+
+### How to invoke
+
+For choice `[b]` or `[c]`, do **not** invoke the script from inside this skill's process. Instead, instruct the operator to run, from the container terminal:
+
+```bash
+.devcontainer/upgrade-superagents-in-container.sh
+```
+
+To pin a specific ref:
+
+```bash
+SUPERAGENTS_REF=<tag-or-sha> .devcontainer/upgrade-superagents-in-container.sh
+```
+
+The script ships in every project scaffolded via `superagents-devcontainer-bootstrap` (template at `skills/devcontainer-bootstrap/templates/upgrade-superagents-in-container.sh` in the superagents repo, copied into target projects' `.devcontainer/` by `scaffold-devcontainer.sh`). It re-runs the scaffold guard on its own — if scaffold files have drifted between the time of this Phase 5b decision and the time the script runs, it will exit with code 2 and the operator will need to follow the Phase 6 rebuild advisory.
+
+### What the script does
+
+1. **Host guard.** Refuses to run on the host (would clobber the operator's host claude install).
+2. **Shallow clone.** Clones `$SUPERAGENTS_REPO@$SUPERAGENTS_REF` into a temp dir and removes it on exit.
+3. **Scaffold guard.** Compares the four scaffold files. Exits 2 with a "rebuild required" message if any differ, without touching `~/.claude/`.
+4. **Install.** Runs `scripts/install.sh --tool claude-code --no-interactive` against the cloned checkout.
+5. **Diff report.** Prints the file paths under `~/.claude/` that were added, removed, or modified, and reminds the operator to restart their claude session if a `SKILL.md` they had open was changed.
+
+### Recording the decision
+
+Treat Phase 5b like any other Phase 4 decision: record the operator's choice in the in-memory plan so the final summary lists "in-container update: invoked / deferred / skipped". When the operator picks `[b]` or `[c]`, also append a one-line marker to `<project>/.agency/skills/superagents/upstream-feedback-pending.log` so an audit trail exists:
+
+```text
+ts:<ISO-8601>; surface:in-container-update; ref:<SUPERAGENTS_REF>; choice:invoked
+```
+
+### Manual smoke test
+
+After running the script, a quick sanity check inside the same container session:
+
+```bash
+ls -la ~/.claude/skills/superagents-devcontainer/SKILL.md
+head -3 ~/.claude/skills/superagents-devcontainer/SKILL.md
+```
+
+The mtime should be recent; the content should match the target ref. If the operator had a claude session running, they should restart it (or use the in-session reload) so the refreshed skills are loaded.
 
 ## Phase 6 — Devcontainer advisory
 
@@ -553,6 +636,7 @@ The skill stops with an error when:
 - For changes marked `raise` or `both`, the operator confirmed the rendered body, an upstream issue was filed via `gh issue create`, and a JSON Lines record was appended to `<project>/.agency/skills/superagents/upstream-feedback.log` capturing the URL, type, and project context.
 - The standalone shortcut `/superagents-upgrade feedback` reaches Phase 7 directly, prompts the operator for one improvement, and produces the same log entry shape with `originated_in_phase: 7`.
 - For devcontainer-scaffold changes, the operator saw the host-side rebuild advisory and was pointed at the `superagents-devcontainer` skill.
+- When Phase 5b applies (classification is `regeneration-recommended` or `regeneration-required` *and* scaffold files match), the operator saw the in-container update option alongside the project-bundle regeneration option, with the script path and `SUPERAGENTS_REF` override documented.
 
 ## Reference
 
@@ -560,10 +644,12 @@ The skill stops with an error when:
 - Release artifact and pipeline: [`docs/release-process.md`](../../docs/release-process.md), [`docs/schemas/release.schema.json`](../../docs/schemas/release.schema.json)
 - Generated layout this skill operates on: [`docs/generated-skill-layout.md`](../../docs/generated-skill-layout.md)
 - The skill-builder this skill hands off to in Phase 5: [`skills/skill-builder/SKILL.md`](../skill-builder/SKILL.md)
-- Companion devcontainer skill referenced from Phase 6: [`skills/superagents-devcontainer/SKILL.md`](../superagents-devcontainer/SKILL.md)
+- Companion devcontainer skill referenced from Phase 6 and Phase 5b's "Update Without Rebuild" section: [`skills/superagents-devcontainer/SKILL.md`](../superagents-devcontainer/SKILL.md)
 - Manifest validation harness used in Phase 5 verification: [`tests/test-manifest-upgrade-metadata.sh`](../../tests/test-manifest-upgrade-metadata.sh)
 - Issue templates Phase 7 maps onto: [`.github/ISSUE_TEMPLATE/`](../../.github/ISSUE_TEMPLATE/)
 - Issue body convention Phase 7's programmatic path follows: closed issues #126 and #135 (`## Context` / `## Goal` / `## Acceptance Criteria` / `## Dependencies` / `## Out of scope`)
+- In-container update script invoked by Phase 5b: [`skills/devcontainer-bootstrap/templates/upgrade-superagents-in-container.sh`](../devcontainer-bootstrap/templates/upgrade-superagents-in-container.sh) (shipped to `<project>/.devcontainer/upgrade-superagents-in-container.sh` by `scaffold-devcontainer.sh`)
+- Scaffold-guard test for the in-container update path: [`tests/test-in-container-upgrade-guard.sh`](../../tests/test-in-container-upgrade-guard.sh)
 
 ## Open Questions
 

--- a/tests/test-in-container-upgrade-guard.sh
+++ b/tests/test-in-container-upgrade-guard.sh
@@ -177,19 +177,78 @@ echo "Case E: end-to-end --dry-run"
 
 GIT_STUB_DIR="$WORK_DIR/git-stub-bin"
 mkdir -p "$GIT_STUB_DIR"
-# Stub `git`. When called as `git clone --depth 1 --branch X URL DEST`,
-# copy the contents of $FAKE_UPSTREAM_DIR into DEST. Otherwise fall through
-# to the real git so `git rev-parse --show-toplevel` keeps working.
+# Stub `git` for the upstream-repo network operations the script performs.
+# The script no longer uses `git clone --branch`; instead it issues:
+#   git init --quiet "$clone_root"
+#   git -C "$clone_root" remote add origin "$SUPERAGENTS_REPO"
+#   git -C "$clone_root" fetch --depth 1 origin "$SUPERAGENTS_REF"
+#   git -C "$clone_root" checkout --quiet --detach FETCH_HEAD
+# We can't really fetch from a URL in tests, so we intercept the `fetch`
+# step and copy $FAKE_UPSTREAM_DIR contents into the clone root instead.
+# `init`, `remote add`, and `checkout --detach FETCH_HEAD` are treated as
+# no-ops because the contents are already in place after the fetch.
+# Anything else (notably `rev-parse --show-toplevel`,
+# `rev-parse --is-inside-work-tree`, and `show HEAD:<path>` against the
+# project root) falls through to the real git.
 cat > "$GIT_STUB_DIR/git" <<'STUB'
 #!/usr/bin/env bash
 set -euo pipefail
-if [ "${1:-}" = "clone" ]; then
-  # Last positional argument is the destination directory.
-  dest="${@: -1}"
-  mkdir -p "$dest"
-  cp -R "${FAKE_UPSTREAM_DIR:?FAKE_UPSTREAM_DIR must be set for git stub}/." "$dest/"
-  exit 0
-fi
+
+# Parse out an optional leading `-C <dir>` so we can find the verb regardless
+# of where it appears in the argv. Track leftover args for later passthrough.
+work_dir=""
+args=("$@")
+i=0
+while [ $i -lt ${#args[@]} ]; do
+  case "${args[$i]}" in
+    -C)
+      work_dir="${args[$((i+1))]:-}"
+      args=("${args[@]:0:i}" "${args[@]:i+2}")
+      ;;
+    *)
+      i=$((i+1))
+      ;;
+  esac
+done
+verb="${args[0]:-}"
+
+case "$verb" in
+  init)
+    # `git init [--quiet] <dir>` -- just make the directory exist; the script
+    # uses --quiet, but tolerate either form.
+    target=""
+    for a in "${args[@]:1}"; do
+      case "$a" in --quiet|-q) ;; *) target="$a" ;; esac
+    done
+    [ -n "$target" ] && mkdir -p "$target"
+    exit 0
+    ;;
+  remote)
+    # `git remote add origin <url>` -- no-op for the stub.
+    exit 0
+    ;;
+  fetch)
+    # `git fetch --depth 1 origin <ref>` -- this is the network step we
+    # replace with a copy from the fixture tree.
+    : "${FAKE_UPSTREAM_DIR:?FAKE_UPSTREAM_DIR must be set for git stub}"
+    : "${work_dir:?git stub: fetch must be invoked with -C <clone_root>}"
+    cp -R "$FAKE_UPSTREAM_DIR/." "$work_dir/"
+    exit 0
+    ;;
+  checkout)
+    # `git checkout [--quiet] --detach FETCH_HEAD` -- contents already in
+    # place from the fetch stub, so this is a no-op.
+    exit 0
+    ;;
+  clone)
+    # Legacy passthrough for any caller still using `git clone --branch ...`.
+    dest="${args[$((${#args[@]}-1))]}"
+    mkdir -p "$dest"
+    cp -R "${FAKE_UPSTREAM_DIR:?FAKE_UPSTREAM_DIR must be set for git stub}/." "$dest/"
+    exit 0
+    ;;
+esac
+
 # Resolve the real git from PATH minus our stub dir.
 PATH="$(printf '%s\n' "$PATH" | tr ':' '\n' | grep -v -F "$(dirname "$0")" | paste -sd: -)" \
   exec git "$@"
@@ -300,6 +359,29 @@ if ! grep -q "upgrade-superagents-in-container.sh" "$SCAFFOLD_TEMPLATE"; then
   exit 1
 fi
 echo "  ok: scaffold-devcontainer.sh references the new template"
+
+# -------------------------------------------------------------------------
+# Case G: project has uncommitted scaffold edits -> guard compares against
+# committed blob, returns 0 even though working tree differs from upstream.
+# -------------------------------------------------------------------------
+echo "Case G: uncommitted scaffold edits do not trigger guard"
+PROJECT_G="$WORK_DIR/case-g/project"
+UPSTREAM_G="$WORK_DIR/case-g/upstream"
+populate_tree "$PROJECT_G"
+populate_tree "$UPSTREAM_G"
+( cd "$PROJECT_G" && git init -q && git -c user.email=t@t -c user.name=t \
+    -c commit.gpgsign=false add . && git -c user.email=t@t -c user.name=t \
+    -c commit.gpgsign=false commit -q -m init >/dev/null )
+# Now scribble on the working tree -- this should NOT trip the guard, since
+# the committed blob still matches upstream.
+printf 'operator scribbled in the working tree\n' \
+    > "$PROJECT_G/.devcontainer/devcontainer.json"
+
+set +e
+( scaffold_guard "$PROJECT_G" "$UPSTREAM_G" >/dev/null 2>&1 )
+rc_g=$?
+set -e
+assert_eq "case-G scaffold_guard returns 0 despite working-tree edit" "0" "$rc_g"
 
 echo
 echo "In-container upgrade guard tests: passed"

--- a/tests/test-in-container-upgrade-guard.sh
+++ b/tests/test-in-container-upgrade-guard.sh
@@ -20,6 +20,12 @@
 #   D. upstream missing a scaffold file -> guard fails (returns 2)
 #   E. end-to-end via --dry-run -> exit 0 when matching, exit 2 when differing,
 #      and ~/.claude/ is never touched
+#   F. scaffold-devcontainer.sh ships the new upgrade script template
+#   H. smoke-test-only drift does NOT trigger guard (locks guard scope to
+#      the four-file Phase 6 § 6.1 rebuild-trigger set)
+#   G. project has uncommitted scaffold edits -> guard reads the committed
+#      blob via `git show HEAD:<relpath>`, returns 0 when the committed
+#      blob still matches upstream
 set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
@@ -271,7 +277,7 @@ populate_tree "$UPSTREAM_E1"
 CLAUDE_DIR="${HOME:-}/.claude"
 claude_before="$WORK_DIR/case-e1/claude-before.txt"
 if [ -d "$CLAUDE_DIR" ]; then
-  ( cd "$CLAUDE_DIR" && find . -type f -print0 | xargs -0 sha256sum 2>/dev/null \
+  ( cd "$CLAUDE_DIR" && find . -type f -print0 | xargs -0 -r sha256sum 2>/dev/null \
       | LC_ALL=C sort ) > "$claude_before" || true
 else
   : > "$claude_before"
@@ -289,7 +295,7 @@ assert_eq "case-E1 dry-run exit code" "0" "$rc_e1"
 
 claude_after="$WORK_DIR/case-e1/claude-after.txt"
 if [ -d "$CLAUDE_DIR" ]; then
-  ( cd "$CLAUDE_DIR" && find . -type f -print0 | xargs -0 sha256sum 2>/dev/null \
+  ( cd "$CLAUDE_DIR" && find . -type f -print0 | xargs -0 -r sha256sum 2>/dev/null \
       | LC_ALL=C sort ) > "$claude_after" || true
 else
   : > "$claude_after"
@@ -314,7 +320,7 @@ printf 'upstream rewrote devcontainer.json\n' > "$UPSTREAM_E2/.devcontainer/devc
 
 claude_before2="$WORK_DIR/case-e2/claude-before.txt"
 if [ -d "$CLAUDE_DIR" ]; then
-  ( cd "$CLAUDE_DIR" && find . -type f -print0 | xargs -0 sha256sum 2>/dev/null \
+  ( cd "$CLAUDE_DIR" && find . -type f -print0 | xargs -0 -r sha256sum 2>/dev/null \
       | LC_ALL=C sort ) > "$claude_before2" || true
 else
   : > "$claude_before2"
@@ -337,7 +343,7 @@ fi
 
 claude_after2="$WORK_DIR/case-e2/claude-after.txt"
 if [ -d "$CLAUDE_DIR" ]; then
-  ( cd "$CLAUDE_DIR" && find . -type f -print0 | xargs -0 sha256sum 2>/dev/null \
+  ( cd "$CLAUDE_DIR" && find . -type f -print0 | xargs -0 -r sha256sum 2>/dev/null \
       | LC_ALL=C sort ) > "$claude_after2" || true
 else
   : > "$claude_after2"
@@ -359,6 +365,29 @@ if ! grep -q "upgrade-superagents-in-container.sh" "$SCAFFOLD_TEMPLATE"; then
   exit 1
 fi
 echo "  ok: scaffold-devcontainer.sh references the new template"
+
+# -------------------------------------------------------------------------
+# Case H: smoke-test-superagents.sh is intentionally NOT in SCAFFOLD_FILES,
+# so a smoke-test-only diff must NOT trigger the guard. This locks the
+# guard's scope to the four files Phase 6 § 6.1 treats as rebuild triggers.
+# (smoke-test is a runtime helper; smoke-test-only drift is handled by the
+# in-container update path, not by a host-side rebuild.)
+# -------------------------------------------------------------------------
+echo "Case H: smoke-test-only drift does not trigger guard"
+PROJECT_H="$WORK_DIR/case-h/project"
+UPSTREAM_H="$WORK_DIR/case-h/upstream"
+populate_tree "$PROJECT_H"
+populate_tree "$UPSTREAM_H"
+# Add the smoke-test file on both sides with deliberately different content.
+# The guard should not even compare it.
+printf 'project smoke-test\n'  > "$PROJECT_H/.devcontainer/smoke-test-superagents.sh"
+printf 'upstream smoke-test\n' > "$UPSTREAM_H/.devcontainer/smoke-test-superagents.sh"
+
+set +e
+( scaffold_guard "$PROJECT_H" "$UPSTREAM_H" >/dev/null 2>&1 )
+rc_h=$?
+set -e
+assert_eq "case-H scaffold_guard returns 0 (smoke-test ignored)" "0" "$rc_h"
 
 # -------------------------------------------------------------------------
 # Case G: project has uncommitted scaffold edits -> guard compares against

--- a/tests/test-in-container-upgrade-guard.sh
+++ b/tests/test-in-container-upgrade-guard.sh
@@ -1,0 +1,305 @@
+#!/usr/bin/env bash
+#
+# tests/test-in-container-upgrade-guard.sh
+#
+# Verifies the scaffold-guard logic in
+# skills/devcontainer-bootstrap/templates/upgrade-superagents-in-container.sh.
+#
+# Strategy: source the script (do NOT execute main) so we can call
+# scaffold_guard directly against fixture trees we build in temp dirs. Two
+# trees are constructed:
+#   1. a "project" tree representing what is currently committed under the
+#      consumer project's .devcontainer/
+#   2. an "upstream" tree representing what was just cloned from the
+#      configured SUPERAGENTS_REPO@SUPERAGENTS_REF
+#
+# Cases covered:
+#   A. matching scaffold files -> guard passes (returns 0)
+#   B. one scaffold file differs -> guard fails (returns 2)
+#   C. project missing a scaffold file -> guard fails (returns 2)
+#   D. upstream missing a scaffold file -> guard fails (returns 2)
+#   E. end-to-end via --dry-run -> exit 0 when matching, exit 2 when differing,
+#      and ~/.claude/ is never touched
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SCRIPT_PATH="$ROOT_DIR/skills/devcontainer-bootstrap/templates/upgrade-superagents-in-container.sh"
+
+if [ ! -f "$SCRIPT_PATH" ]; then
+  echo "FAIL: upgrade script not found at $SCRIPT_PATH" >&2
+  exit 1
+fi
+if [ ! -x "$SCRIPT_PATH" ]; then
+  echo "FAIL: upgrade script not executable at $SCRIPT_PATH" >&2
+  exit 1
+fi
+
+WORK_DIR="$(mktemp -d)"
+trap 'rm -rf "$WORK_DIR"' EXIT
+
+# -------------------------------------------------------------------------
+# Helpers
+# -------------------------------------------------------------------------
+SCAFFOLD_RELPATHS=(
+  ".devcontainer/Dockerfile"
+  ".devcontainer/devcontainer.json"
+  ".devcontainer/post-create-superagents.sh"
+  ".devcontainer/scaffold-devcontainer.sh"
+)
+
+# Populate a tree with byte-identical placeholder content for each scaffold
+# file. Callers can mutate individual files afterward to simulate drift.
+populate_tree() {
+  local root="$1"
+  mkdir -p "$root/.devcontainer"
+  for relpath in "${SCAFFOLD_RELPATHS[@]}"; do
+    printf 'baseline content for %s\n' "$relpath" > "$root/$relpath"
+  done
+  # The script also expects scripts/install.sh to be executable on the
+  # upstream side when running end-to-end. Tests stop at --dry-run so this
+  # is only needed for the dry-run-mode E2E case below.
+  mkdir -p "$root/scripts"
+  cat > "$root/scripts/install.sh" <<'EOF'
+#!/usr/bin/env bash
+echo "test fixture install.sh: refusing to run during tests" >&2
+exit 99
+EOF
+  chmod +x "$root/scripts/install.sh"
+}
+
+assert_eq() {
+  local label="$1"
+  local expected="$2"
+  local actual="$3"
+  if [ "$expected" != "$actual" ]; then
+    echo "FAIL [$label]: expected $expected, got $actual" >&2
+    exit 1
+  fi
+  echo "  ok: $label (=$actual)"
+}
+
+# -------------------------------------------------------------------------
+# Source the script in a guarded subshell so we can call its functions.
+# Because the script's tail is gated by `[ "${BASH_SOURCE[0]}" = "$0" ]`,
+# sourcing it does NOT execute main(). We get the helper functions only.
+# -------------------------------------------------------------------------
+# shellcheck disable=SC1090
+source "$SCRIPT_PATH"
+
+# -------------------------------------------------------------------------
+# Case A: all scaffold files match -> scaffold_guard returns 0
+# -------------------------------------------------------------------------
+echo "Case A: matching scaffold files"
+PROJECT_A="$WORK_DIR/case-a/project"
+UPSTREAM_A="$WORK_DIR/case-a/upstream"
+populate_tree "$PROJECT_A"
+populate_tree "$UPSTREAM_A"
+
+set +e
+( scaffold_guard "$PROJECT_A" "$UPSTREAM_A" >/dev/null 2>&1 )
+rc_a=$?
+set -e
+assert_eq "case-A scaffold_guard returns 0" "0" "$rc_a"
+
+# -------------------------------------------------------------------------
+# Case B: one scaffold file differs -> scaffold_guard returns 2
+# -------------------------------------------------------------------------
+echo "Case B: one scaffold file differs"
+PROJECT_B="$WORK_DIR/case-b/project"
+UPSTREAM_B="$WORK_DIR/case-b/upstream"
+populate_tree "$PROJECT_B"
+populate_tree "$UPSTREAM_B"
+printf 'upstream changed Dockerfile content\n' > "$UPSTREAM_B/.devcontainer/Dockerfile"
+
+set +e
+guard_b_output="$( scaffold_guard "$PROJECT_B" "$UPSTREAM_B" 2>&1 )"
+rc_b=$?
+set -e
+assert_eq "case-B scaffold_guard returns 2" "2" "$rc_b"
+if ! grep -q "Rebuild required" <<<"$guard_b_output"; then
+  echo "FAIL [case-B]: expected 'Rebuild required' in stderr, got:" >&2
+  echo "$guard_b_output" >&2
+  exit 1
+fi
+if ! grep -q "Dockerfile" <<<"$guard_b_output"; then
+  echo "FAIL [case-B]: expected the differing file 'Dockerfile' to be named in the message" >&2
+  echo "$guard_b_output" >&2
+  exit 1
+fi
+if ! grep -q "superagents-devcontainer skill" <<<"$guard_b_output"; then
+  echo "FAIL [case-B]: expected message to point at superagents-devcontainer skill" >&2
+  echo "$guard_b_output" >&2
+  exit 1
+fi
+echo "  ok: case-B message names differing file and points at devcontainer skill"
+
+# -------------------------------------------------------------------------
+# Case C: project is missing a scaffold file -> guard returns 2
+# -------------------------------------------------------------------------
+echo "Case C: project missing scaffold file"
+PROJECT_C="$WORK_DIR/case-c/project"
+UPSTREAM_C="$WORK_DIR/case-c/upstream"
+populate_tree "$PROJECT_C"
+populate_tree "$UPSTREAM_C"
+rm "$PROJECT_C/.devcontainer/scaffold-devcontainer.sh"
+
+set +e
+( scaffold_guard "$PROJECT_C" "$UPSTREAM_C" >/dev/null 2>&1 )
+rc_c=$?
+set -e
+assert_eq "case-C scaffold_guard returns 2" "2" "$rc_c"
+
+# -------------------------------------------------------------------------
+# Case D: upstream is missing a scaffold file -> guard returns 2
+# -------------------------------------------------------------------------
+echo "Case D: upstream missing scaffold file"
+PROJECT_D="$WORK_DIR/case-d/project"
+UPSTREAM_D="$WORK_DIR/case-d/upstream"
+populate_tree "$PROJECT_D"
+populate_tree "$UPSTREAM_D"
+rm "$UPSTREAM_D/.devcontainer/post-create-superagents.sh"
+
+set +e
+( scaffold_guard "$PROJECT_D" "$UPSTREAM_D" >/dev/null 2>&1 )
+rc_d=$?
+set -e
+assert_eq "case-D scaffold_guard returns 2" "2" "$rc_d"
+
+# -------------------------------------------------------------------------
+# Case E: end-to-end via --dry-run.
+# We can't have main() really clone from the network, so we replace `git`
+# in PATH with a stub that copies the upstream tree into the destination
+# the script asked it to clone into. Then we run the script with --dry-run
+# so install.sh is NEVER invoked. We assert exit 0 when matching, exit 2
+# when differing, and that ~/.claude/ is untouched in both cases.
+# -------------------------------------------------------------------------
+echo "Case E: end-to-end --dry-run"
+
+GIT_STUB_DIR="$WORK_DIR/git-stub-bin"
+mkdir -p "$GIT_STUB_DIR"
+# Stub `git`. When called as `git clone --depth 1 --branch X URL DEST`,
+# copy the contents of $FAKE_UPSTREAM_DIR into DEST. Otherwise fall through
+# to the real git so `git rev-parse --show-toplevel` keeps working.
+cat > "$GIT_STUB_DIR/git" <<'STUB'
+#!/usr/bin/env bash
+set -euo pipefail
+if [ "${1:-}" = "clone" ]; then
+  # Last positional argument is the destination directory.
+  dest="${@: -1}"
+  mkdir -p "$dest"
+  cp -R "${FAKE_UPSTREAM_DIR:?FAKE_UPSTREAM_DIR must be set for git stub}/." "$dest/"
+  exit 0
+fi
+# Resolve the real git from PATH minus our stub dir.
+PATH="$(printf '%s\n' "$PATH" | tr ':' '\n' | grep -v -F "$(dirname "$0")" | paste -sd: -)" \
+  exec git "$@"
+STUB
+chmod +x "$GIT_STUB_DIR/git"
+
+# Sub-case E1: matching scaffold files -> dry-run exits 0
+echo "  sub-case E1: matching scaffold -> dry-run exit 0"
+PROJECT_E1="$WORK_DIR/case-e1/project"
+UPSTREAM_E1="$WORK_DIR/case-e1/upstream"
+populate_tree "$PROJECT_E1"
+populate_tree "$UPSTREAM_E1"
+# Initialise the project as a git repo so `git rev-parse --show-toplevel`
+# resolves to PROJECT_E1 when we cd into it.
+( cd "$PROJECT_E1" && git init -q && git -c user.email=t@t -c user.name=t \
+    -c commit.gpgsign=false add . && git -c user.email=t@t -c user.name=t \
+    -c commit.gpgsign=false commit -q -m init >/dev/null )
+
+# Capture the ~/.claude/ snapshot before; assert it is unchanged after.
+CLAUDE_DIR="${HOME:-}/.claude"
+claude_before="$WORK_DIR/case-e1/claude-before.txt"
+if [ -d "$CLAUDE_DIR" ]; then
+  ( cd "$CLAUDE_DIR" && find . -type f -print0 | xargs -0 sha256sum 2>/dev/null \
+      | LC_ALL=C sort ) > "$claude_before" || true
+else
+  : > "$claude_before"
+fi
+
+set +e
+FAKE_UPSTREAM_DIR="$UPSTREAM_E1" \
+SUPERAGENTS_SKIP_HOST_GUARD=1 \
+PATH="$GIT_STUB_DIR:$PATH" \
+  bash -c "cd '$PROJECT_E1' && '$SCRIPT_PATH' --dry-run" \
+    >"$WORK_DIR/case-e1/stdout" 2>"$WORK_DIR/case-e1/stderr"
+rc_e1=$?
+set -e
+assert_eq "case-E1 dry-run exit code" "0" "$rc_e1"
+
+claude_after="$WORK_DIR/case-e1/claude-after.txt"
+if [ -d "$CLAUDE_DIR" ]; then
+  ( cd "$CLAUDE_DIR" && find . -type f -print0 | xargs -0 sha256sum 2>/dev/null \
+      | LC_ALL=C sort ) > "$claude_after" || true
+else
+  : > "$claude_after"
+fi
+if ! cmp -s "$claude_before" "$claude_after"; then
+  echo "FAIL [case-E1]: ~/.claude/ changed during --dry-run" >&2
+  diff "$claude_before" "$claude_after" >&2 || true
+  exit 1
+fi
+echo "  ok: case-E1 ~/.claude/ untouched"
+
+# Sub-case E2: differing scaffold -> dry-run exits 2, ~/.claude/ untouched
+echo "  sub-case E2: differing scaffold -> dry-run exit 2"
+PROJECT_E2="$WORK_DIR/case-e2/project"
+UPSTREAM_E2="$WORK_DIR/case-e2/upstream"
+populate_tree "$PROJECT_E2"
+populate_tree "$UPSTREAM_E2"
+printf 'upstream rewrote devcontainer.json\n' > "$UPSTREAM_E2/.devcontainer/devcontainer.json"
+( cd "$PROJECT_E2" && git init -q && git -c user.email=t@t -c user.name=t \
+    -c commit.gpgsign=false add . && git -c user.email=t@t -c user.name=t \
+    -c commit.gpgsign=false commit -q -m init >/dev/null )
+
+claude_before2="$WORK_DIR/case-e2/claude-before.txt"
+if [ -d "$CLAUDE_DIR" ]; then
+  ( cd "$CLAUDE_DIR" && find . -type f -print0 | xargs -0 sha256sum 2>/dev/null \
+      | LC_ALL=C sort ) > "$claude_before2" || true
+else
+  : > "$claude_before2"
+fi
+
+set +e
+FAKE_UPSTREAM_DIR="$UPSTREAM_E2" \
+SUPERAGENTS_SKIP_HOST_GUARD=1 \
+PATH="$GIT_STUB_DIR:$PATH" \
+  bash -c "cd '$PROJECT_E2' && '$SCRIPT_PATH' --dry-run" \
+    >"$WORK_DIR/case-e2/stdout" 2>"$WORK_DIR/case-e2/stderr"
+rc_e2=$?
+set -e
+assert_eq "case-E2 dry-run exit code (guard fired)" "2" "$rc_e2"
+if ! grep -q "Rebuild required" "$WORK_DIR/case-e2/stderr"; then
+  echo "FAIL [case-E2]: expected 'Rebuild required' in stderr" >&2
+  cat "$WORK_DIR/case-e2/stderr" >&2
+  exit 1
+fi
+
+claude_after2="$WORK_DIR/case-e2/claude-after.txt"
+if [ -d "$CLAUDE_DIR" ]; then
+  ( cd "$CLAUDE_DIR" && find . -type f -print0 | xargs -0 sha256sum 2>/dev/null \
+      | LC_ALL=C sort ) > "$claude_after2" || true
+else
+  : > "$claude_after2"
+fi
+if ! cmp -s "$claude_before2" "$claude_after2"; then
+  echo "FAIL [case-E2]: ~/.claude/ changed even though guard fired" >&2
+  diff "$claude_before2" "$claude_after2" >&2 || true
+  exit 1
+fi
+echo "  ok: case-E2 ~/.claude/ untouched after guard fire"
+
+# -------------------------------------------------------------------------
+# Case F: scaffold-devcontainer.sh ships the new template
+# -------------------------------------------------------------------------
+echo "Case F: scaffold-devcontainer.sh installs the new template"
+SCAFFOLD_TEMPLATE="$ROOT_DIR/skills/devcontainer-bootstrap/templates/scaffold-devcontainer.sh"
+if ! grep -q "upgrade-superagents-in-container.sh" "$SCAFFOLD_TEMPLATE"; then
+  echo "FAIL [case-F]: scaffold-devcontainer.sh does not copy upgrade-superagents-in-container.sh" >&2
+  exit 1
+fi
+echo "  ok: scaffold-devcontainer.sh references the new template"
+
+echo
+echo "In-container upgrade guard tests: passed"


### PR DESCRIPTION
## What does this PR do?

Implements issue #149 (epic #148): adds an in-container update path that refreshes `~/.claude/` from a target superagents ref without rebuilding the devcontainer, with a scaffold guard that bails with a clear "rebuild required" message when any of the four scaffold files differ.

This is the container-side mirror of #145 (project-local bundle regeneration). The two surfaces drift independently — project bundles under `<project>/.claude/skills/superagents/` and the user-level install under `~/.claude/`.

## Changes

- **New script** `skills/devcontainer-bootstrap/templates/upgrade-superagents-in-container.sh` (shipped to `<project>/.devcontainer/upgrade-superagents-in-container.sh` by `scaffold-devcontainer.sh`):
  - Honors `SUPERAGENTS_REF` env var (default `main`), mirroring `post-create-superagents.sh`
  - Shallow-clones the configured `SUPERAGENTS_REPO@SUPERAGENTS_REF` into a temp dir, cleaned up via `trap`
  - Host guard refuses to run on the host (would clobber host claude install); escape hatch via `SUPERAGENTS_SKIP_HOST_GUARD=1`
  - Scaffold guard compares `Dockerfile`, `devcontainer.json`, `post-create-superagents.sh`, `scaffold-devcontainer.sh`; exits 2 with the file list and a pointer to the `superagents-devcontainer` skill's Rebuild section when any differ; does not touch `~/.claude/`
  - When the guard passes, invokes `scripts/install.sh --tool claude-code --no-interactive` and reports added/removed/modified file paths under `~/.claude/`
  - `--dry-run` flag (used by tests) runs the guard only and skips `install.sh`
  - Documented exit codes: 0 success, 1 general failure, 2 scaffold guard fired, 3 host guard fired
- **`scaffold-devcontainer.sh`** now copies the new template into target projects' `.devcontainer/` and `chmod +x`s it alongside the existing two scripts
- **`skills/superagents-upgrade/SKILL.md`** gains a "Phase 5b — In-container update path" section between Phase 5 and Phase 6:
  - Surfaced when classification is `regeneration-recommended` or `regeneration-required` AND scaffold files match
  - Presented alongside the Phase 5 project-bundle option as a parallel choice with explicit trade-offs
  - When scaffold files differ, defers to Phase 6 (rebuild advisory) — does not offer the in-container path
  - Phase Map table and Success Criteria updated
- **`skills/superagents-devcontainer/SKILL.md`** gains a "## 4. Update Without Rebuild" section pointing at the new script, with command, exit codes, and restart-claude reminder. Frontmatter `description` and `argument-hint` extended to mention `update`.
- **New test** `tests/test-in-container-upgrade-guard.sh` (pure bash, no external deps):
  - Sources the script to call `scaffold_guard` directly against fixture trees
  - Case A: matching scaffold files -> guard returns 0
  - Case B: one scaffold file differs -> guard returns 2, message names the differing file and points at the devcontainer skill
  - Case C: project missing a scaffold file -> guard returns 2
  - Case D: upstream missing a scaffold file -> guard returns 2
  - Case E: end-to-end via `--dry-run` with a `git` stub that copies a fake upstream tree, asserting exit code AND that `~/.claude/` is not modified in either branch
  - Case F: `scaffold-devcontainer.sh` references the new template

## Coordination with parallel sub-agents

- #146 (Phase 7) and #147 (Phase 6) are running concurrently against `skills/superagents-upgrade/SKILL.md`. This PR only adds a new "Phase 5b" section between Phase 5 and Phase 6 and updates the Phase Map / Success Criteria — it does not touch Phase 6 or Phase 7 prose. Merge collision risk is limited to the Phase Map table and the Reference / Success Criteria lists; conflicts there should be straightforward three-way merges.
- This PR is the only one touching `skills/superagents-devcontainer/SKILL.md`.

## Manual smoke test (post-merge maintainer verification)

Acceptance criterion 5 ("change is visible to `claude` running in the same container session") cannot be exercised inside this worktree because there is no live container. Sequence for a maintainer to run after merge:

1. From a project bootstrapped via `superagents-devcontainer-bootstrap`, run `scaffold-devcontainer.sh` once to drop the new template into `.devcontainer/`. (Existing projects that were scaffolded before this PR will need to copy the template once: `cp ~/.claude/skills/superagents-devcontainer-bootstrap/templates/upgrade-superagents-in-container.sh .devcontainer/ && chmod +x .devcontainer/upgrade-superagents-in-container.sh`.)
2. Open the project in its devcontainer. Confirm `~/.claude/skills/superagents-devcontainer/SKILL.md` exists.
3. From the container terminal:
   ```bash
   .devcontainer/upgrade-superagents-in-container.sh
   ```
   Expected: clone runs, scaffold guard reports "passed", `install.sh` reinstalls, and the script prints a list of file paths under `~/.claude/` that changed (or "no changes detected" if already in sync). Exit 0.
4. To exercise the guard fire path, locally edit a scaffold file (e.g. add a comment to `.devcontainer/Dockerfile`), then re-run. Expected: exit 2, "Rebuild required" message names `Dockerfile`, `~/.claude/` is not modified.
5. To exercise the host guard, run the script from the host terminal. Expected: exit 3, "must run inside the superagents devcontainer" message.
6. To pin a ref: `SUPERAGENTS_REF=v0.2.0 .devcontainer/upgrade-superagents-in-container.sh` (replace tag with an actual published one).
7. After a successful run that changed an open `SKILL.md`, restart the running `claude` session and confirm the new content is loaded. (The script prints a reminder when changes are detected.)

## Test plan

- [x] `tests/test-in-container-upgrade-guard.sh` passes (cases A-F)
- [x] `tests/test-manifest-upgrade-metadata.sh` passes
- [x] `tests/test-skill-builder-runtime-target-contract.sh` passes
- [x] `tests/test-dogfooding-guardrails.sh` passes
- [x] `bash -n` clean on all touched scripts
- [ ] `tests/test-doc-link-integrity.sh` and `tests/test-fragment-contract-validation.sh` skipped locally (no ruby in this worktree); CI will run them
- [ ] `shellcheck` not available locally; CI will run it if configured
- [ ] Manual smoke test sequence above (post-merge, on a real devcontainer)

Closes #149

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an in-container upgrade command to refresh the installed agent surface without rebuilding; supports dry-run, help output, and reports changed/added/deleted files.

* **Documentation**
  * Updated upgrade workflow to document the in-container update path, options, exit codes, safety guards, and operator flow.

* **Tests**
  * Added tests validating guard logic, dry-run behavior, and that failed guards leave user data unchanged.

* **Chores**
  * Scaffold now includes the new upgrade script and marks it executable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->