### PR TITLE
Fix scaffold patcher: robust firewall-block removal and sudoers guard

### DIFF
--- a/skills/devcontainer-bootstrap/templates/scaffold-devcontainer.sh
+++ b/skills/devcontainer-bootstrap/templates/scaffold-devcontainer.sh
@@ -173,6 +173,106 @@ if (!updated.includes('githubcli-archive-keyring.gpg')) {
 fs.writeFileSync(file, updated);
 NODE
 
+# Strip the upstream init-firewall block. The Anthropic base Dockerfile installs
+# /usr/local/bin/init-firewall.sh and an associated sudoers entry; we don't ship
+# the script (network locked down differently in this fork), so its references
+# would break the build. Use a line-based scanner that's robust against minor
+# upstream formatting changes (extra blank lines, missing optional USER lines,
+# multi-line RUN continuations).
+#
+# IMPORTANT: this MUST run BEFORE the passwordless-sudo patch below, because
+# the upstream block writes to /etc/sudoers.d/node-firewall and its presence
+# can confuse a substring-based guard on the sudo patch.
+node - "$TARGET_DIR/Dockerfile" <<'NODE'
+const fs = require('fs');
+const file = process.argv[2];
+const original = fs.readFileSync(file, 'utf8');
+
+const lines = original.split('\n');
+const out = [];
+let i = 0;
+let removed = false;
+
+while (i < lines.length) {
+  const line = lines[i];
+
+  // Detect the start of the firewall block. The canonical anchor is the
+  // `COPY init-firewall.sh` line; the preceding comment is optional.
+  if (/^\s*COPY\s+init-firewall\.sh\b/.test(line)) {
+    // Drop a trailing comment we may have just appended that introduces the
+    // firewall block (e.g. "# Copy and set up firewall script").
+    while (
+      out.length > 0 &&
+      /^\s*#[^\n]*firewall/i.test(out[out.length - 1])
+    ) {
+      out.pop();
+    }
+    // Also drop any trailing blank lines that lead into the block, so we
+    // don't leave a double-blank gap behind.
+    while (out.length > 0 && /^\s*$/.test(out[out.length - 1])) {
+      out.pop();
+    }
+
+    // Skip the COPY line itself.
+    i++;
+
+    // Optional USER root.
+    if (i < lines.length && /^\s*USER\s+root\s*$/.test(lines[i])) {
+      i++;
+    }
+
+    // Skip the RUN block. Anthropic's RUN spans multiple lines via trailing
+    // backslashes; consume continuation lines until we see one without a
+    // trailing backslash. Only treat it as the firewall RUN if the first
+    // line mentions init-firewall (defensive: avoid eating an unrelated RUN).
+    if (
+      i < lines.length &&
+      /^\s*RUN\b[^\n]*init-firewall/.test(lines[i])
+    ) {
+      let runLine = lines[i];
+      i++;
+      while (/\\\s*$/.test(runLine) && i < lines.length) {
+        runLine = lines[i];
+        i++;
+      }
+    }
+
+    // Optional trailing USER node.
+    if (i < lines.length && /^\s*USER\s+node\s*$/.test(lines[i])) {
+      i++;
+    }
+
+    removed = true;
+    continue;
+  }
+
+  out.push(line);
+  i++;
+}
+
+let updated = out.join('\n');
+
+// Final safety net: if any stray init-firewall reference remains (e.g. a new
+// upstream variation we didn't anticipate), strip the remaining lines that
+// mention it so the acceptance criterion (zero init-firewall references) is
+// always satisfied. This is intentionally conservative: it only drops lines
+// that explicitly reference init-firewall or sudoers.d/node-firewall.
+if (/init-firewall|sudoers\.d\/node-firewall/.test(updated)) {
+  updated = updated
+    .split('\n')
+    .filter((l) => !/init-firewall|sudoers\.d\/node-firewall/.test(l))
+    .join('\n');
+  removed = true;
+}
+
+// Collapse 3+ consecutive blank lines down to 2 to keep diffs tidy.
+updated = updated.replace(/\n{3,}/g, '\n\n');
+
+if (removed) {
+  fs.writeFileSync(file, updated);
+}
+NODE
+
 # Enable passwordless sudo for the node user (devcontainer-only).
 node - "$TARGET_DIR/Dockerfile" <<'NODE'
 const fs = require('fs');

--- a/skills/devcontainer-bootstrap/templates/scaffold-devcontainer.sh
+++ b/skills/devcontainer-bootstrap/templates/scaffold-devcontainer.sh
@@ -274,12 +274,20 @@ if (removed) {
 NODE
 
 # Enable passwordless sudo for the node user (devcontainer-only).
+#
+# NOTE: The guard checks for the literal `NOPASSWD:ALL` rule that this patch
+# installs, NOT for any path under /etc/sudoers.d/. Earlier versions used
+# `sudoers.d/node` as the sentinel, which false-positives on
+# `sudoers.d/node-firewall` (a substring) when the upstream firewall block is
+# present. Ordering: the firewall-stripping block above runs first, so by this
+# point `sudoers.d/node-firewall` should be gone — but the `NOPASSWD:ALL`
+# sentinel is robust regardless of order.
 node - "$TARGET_DIR/Dockerfile" <<'NODE'
 const fs = require('fs');
 const file = process.argv[2];
 let updated = fs.readFileSync(file, 'utf8');
 
-if (!updated.includes('sudoers.d/node')) {
+if (!updated.includes('NOPASSWD:ALL')) {
   const sudoersBlock = [
     '',
     '# Allow the node user to run sudo without a password (devcontainer-only).',

--- a/tests/fixtures/scaffold-devcontainer/anthropic-base-dockerfile.txt
+++ b/tests/fixtures/scaffold-devcontainer/anthropic-base-dockerfile.txt
@@ -1,0 +1,91 @@
+FROM node:20
+
+ARG TZ
+ENV TZ="$TZ"
+
+ARG CLAUDE_CODE_VERSION=latest
+
+# Install basic development tools and iptables/ipset
+RUN apt-get update && apt-get install -y --no-install-recommends \
+  less \
+  git \
+  procps \
+  sudo \
+  fzf \
+  zsh \
+  man-db \
+  unzip \
+  gnupg2 \
+  gh \
+  iptables \
+  ipset \
+  iproute2 \
+  dnsutils \
+  aggregate \
+  jq \
+  nano \
+  vim \
+  && apt-get clean && rm -rf /var/lib/apt/lists/*
+
+# Ensure default node user has access to /usr/local/share
+RUN mkdir -p /usr/local/share/npm-global && \
+  chown -R node:node /usr/local/share
+
+ARG USERNAME=node
+
+# Persist bash history.
+RUN SNIPPET="export PROMPT_COMMAND='history -a' && export HISTFILE=/commandhistory/.bash_history" \
+  && mkdir /commandhistory \
+  && touch /commandhistory/.bash_history \
+  && chown -R $USERNAME /commandhistory
+
+# Set `DEVCONTAINER` environment variable to help with orientation
+ENV DEVCONTAINER=true
+
+# Create workspace and config directories and set permissions
+RUN mkdir -p /workspace /home/node/.claude && \
+  chown -R node:node /workspace /home/node/.claude
+
+WORKDIR /workspace
+
+ARG GIT_DELTA_VERSION=0.18.2
+RUN ARCH=$(dpkg --print-architecture) && \
+  wget "https://github.com/dandavison/delta/releases/download/${GIT_DELTA_VERSION}/git-delta_${GIT_DELTA_VERSION}_${ARCH}.deb" && \
+  sudo dpkg -i "git-delta_${GIT_DELTA_VERSION}_${ARCH}.deb" && \
+  rm "git-delta_${GIT_DELTA_VERSION}_${ARCH}.deb"
+
+# Set up non-root user
+USER node
+
+# Install global packages
+ENV NPM_CONFIG_PREFIX=/usr/local/share/npm-global
+ENV PATH=$PATH:/usr/local/share/npm-global/bin
+
+# Set the default shell to zsh rather than sh
+ENV SHELL=/bin/zsh
+
+# Set the default editor and visual
+ENV EDITOR=nano
+ENV VISUAL=nano
+
+# Default powerline10k theme
+ARG ZSH_IN_DOCKER_VERSION=1.2.0
+RUN sh -c "$(wget -O- https://github.com/deluan/zsh-in-docker/releases/download/v${ZSH_IN_DOCKER_VERSION}/zsh-in-docker.sh)" -- \
+  -p git \
+  -p fzf \
+  -a "source /usr/share/doc/fzf/examples/key-bindings.zsh" \
+  -a "source /usr/share/doc/fzf/examples/completion.zsh" \
+  -a "export PROMPT_COMMAND='history -a' && export HISTFILE=/commandhistory/.bash_history" \
+  -x
+
+# Install Claude
+RUN npm install -g @anthropic-ai/claude-code@${CLAUDE_CODE_VERSION}
+
+
+# Copy and set up firewall script
+COPY init-firewall.sh /usr/local/bin/
+USER root
+RUN chmod +x /usr/local/bin/init-firewall.sh && \
+  echo "node ALL=(root) NOPASSWD: /usr/local/bin/init-firewall.sh" > /etc/sudoers.d/node-firewall && \
+  chmod 0440 /etc/sudoers.d/node-firewall
+USER node

--- a/tests/test-scaffold-devcontainer-patches.sh
+++ b/tests/test-scaffold-devcontainer-patches.sh
@@ -1,0 +1,137 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Verifies that scaffold-devcontainer.sh:
+#   - removes every init-firewall reference from the Anthropic base Dockerfile
+#     (issue #141)
+#   - applies the passwordless NOPASSWD:ALL sudoers block even when the source
+#     contains /etc/sudoers.d/node-firewall (issue #142)
+#   - is idempotent: a second run does not double-apply the patch or fail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SCAFFOLD="$ROOT_DIR/skills/devcontainer-bootstrap/templates/scaffold-devcontainer.sh"
+FIXTURE="$ROOT_DIR/tests/fixtures/scaffold-devcontainer/anthropic-base-dockerfile.txt"
+
+[[ -x "$SCAFFOLD" ]] || { echo "Missing or non-executable scaffold script: $SCAFFOLD" >&2; exit 1; }
+[[ -f "$FIXTURE" ]]  || { echo "Missing fixture: $FIXTURE" >&2; exit 1; }
+
+TMP_ROOT="$(mktemp -d)"
+trap 'rm -rf "$TMP_ROOT"' EXIT
+
+# Stand up a fake "Anthropic upstream" served from the local filesystem so the
+# scaffold's curl call is hermetic. The scaffold's BASE_URL is consumed by curl
+# directly, so a file:// URL prefix works.
+UPSTREAM_DIR="$TMP_ROOT/upstream"
+mkdir -p "$UPSTREAM_DIR"
+cp "$FIXTURE" "$UPSTREAM_DIR/Dockerfile"
+
+# Minimal devcontainer.json sufficient for the scaffold's JSON patch step.
+cat >"$UPSTREAM_DIR/devcontainer.json" <<'JSON'
+{
+  "name": "test",
+  "build": { "dockerfile": "Dockerfile" },
+  "runArgs": ["--cap-add", "NET_ADMIN", "--cap-add", "NET_RAW"],
+  "mounts": [],
+  "containerEnv": {},
+  "postStartCommand": "echo hi",
+  "waitFor": "postStartCommand"
+}
+JSON
+
+# Run scaffold inside a fake repo with a known name that exists in ports.yaml.
+# Pick the first project entry from the real ports registry so the lookup
+# succeeds without us having to mutate the registry.
+PORTS_YAML="$ROOT_DIR/skills/devcontainer-bootstrap/ports.yaml"
+[[ -f "$PORTS_YAML" ]] || { echo "Missing ports registry at $PORTS_YAML" >&2; exit 1; }
+REPO_NAME="$(python3 - "$PORTS_YAML" <<'PYEOF'
+import sys, re
+with open(sys.argv[1]) as f:
+    in_projects = False
+    for line in f:
+        s = line.strip()
+        if s.startswith('#') or not s:
+            continue
+        if s == 'projects:':
+            in_projects = True
+            continue
+        if in_projects:
+            if re.match(r'^\S', line) and not line.startswith(' '):
+                break
+            m = re.match(r'^\s+(\S+):\s*\d+', line)
+            if m:
+                print(m.group(1))
+                sys.exit(0)
+PYEOF
+)"
+[[ -n "$REPO_NAME" ]] || { echo "Could not pick a repo name from $PORTS_YAML" >&2; exit 1; }
+
+REPO_DIR="$TMP_ROOT/$REPO_NAME"
+mkdir -p "$REPO_DIR"
+git -C "$REPO_DIR" init -q
+git -C "$REPO_DIR" config user.email "test@example.com"
+git -C "$REPO_DIR" config user.name  "Test"
+git -C "$REPO_DIR" commit --allow-empty -q -m "init"
+
+TARGET_DIR="$REPO_DIR/.devcontainer"
+
+run_scaffold() {
+  ( cd "$REPO_DIR" \
+    && ANTHROPIC_DEVCONTAINER_BASE_URL="file://$UPSTREAM_DIR" \
+       "$SCAFFOLD" "$TARGET_DIR" >/dev/null )
+}
+
+assert_dockerfile() {
+  local label="$1"
+  local dockerfile="$TARGET_DIR/Dockerfile"
+
+  [[ -f "$dockerfile" ]] || { echo "[$label] Dockerfile not produced at $dockerfile" >&2; exit 1; }
+
+  if grep -q "init-firewall" "$dockerfile"; then
+    echo "[$label] FAIL: Dockerfile still contains init-firewall references:" >&2
+    grep -n "init-firewall" "$dockerfile" >&2 || true
+    exit 1
+  fi
+
+  if grep -q "sudoers.d/node-firewall" "$dockerfile"; then
+    echo "[$label] FAIL: Dockerfile still references sudoers.d/node-firewall" >&2
+    exit 1
+  fi
+
+  if ! grep -q "NOPASSWD:ALL" "$dockerfile"; then
+    echo "[$label] FAIL: Dockerfile missing NOPASSWD:ALL passwordless sudo block" >&2
+    exit 1
+  fi
+
+  local count
+  count="$(grep -c "NOPASSWD:ALL" "$dockerfile" || true)"
+  if [[ "$count" -ne 1 ]]; then
+    echo "[$label] FAIL: expected exactly 1 NOPASSWD:ALL line, found $count" >&2
+    exit 1
+  fi
+
+  # Sanity: the COPY init-firewall and its companion USER root/RUN chmod block
+  # should be gone, but the rest of the Dockerfile (e.g. FROM, USER node, the
+  # claude-code install) should still be present.
+  grep -q "^FROM node:" "$dockerfile" || { echo "[$label] FAIL: missing FROM node line" >&2; exit 1; }
+  grep -q "@anthropic-ai/claude-code" "$dockerfile" || { echo "[$label] FAIL: missing claude-code install line" >&2; exit 1; }
+}
+
+# First run: patches apply against unmodified upstream content.
+run_scaffold
+assert_dockerfile "first run"
+
+# Snapshot for idempotency comparison.
+FIRST_HASH="$(sha256sum "$TARGET_DIR/Dockerfile" | awk '{print $1}')"
+
+# Second run: must not double-apply, must not fail.
+run_scaffold
+assert_dockerfile "second run"
+
+SECOND_HASH="$(sha256sum "$TARGET_DIR/Dockerfile" | awk '{print $1}')"
+if [[ "$FIRST_HASH" != "$SECOND_HASH" ]]; then
+  echo "FAIL: scaffold is not idempotent (Dockerfile hash changed between runs)" >&2
+  diff <(echo "first") <(echo "second") || true
+  exit 1
+fi
+
+echo "scaffold-devcontainer patches tests: passed"


### PR DESCRIPTION
## What does this PR do?

Fixes two related bugs in the scaffold-devcontainer patcher (`skills/devcontainer-bootstrap/templates/scaffold-devcontainer.sh`) that surfaced together during the Apr 30 bootstrap run.

- **#141** — The firewall-block stripper was a single tightly anchored multi-line regex that silently failed when upstream Anthropic shifted formatting, leaving `COPY init-firewall.sh`, the matching `RUN chmod ... sudoers.d/node-firewall ...`, and the surrounding `USER root` / `USER node` lines in the generated Dockerfile and breaking the build. Replaced with a line-based scanner that anchors on the canonical `COPY init-firewall.sh` line and consumes the contiguous block (preceding firewall comment, optional `USER root`, multi-line `RUN` continuation, optional trailing `USER node`). A defensive fallback strips any stray `init-firewall` / `sudoers.d/node-firewall` lines so the acceptance criterion (zero references) is satisfied even against unanticipated future variations.
- **#142** — The passwordless-sudo guard used `updated.includes('sudoers.d/node')`, which is a substring of `'sudoers.d/node-firewall'`. When the upstream firewall block was present, the guard returned `false` and the `NOPASSWD:ALL` block was silently skipped. Switched the sentinel to the literal `NOPASSWD:ALL` directive this patch installs, which is not a substring of anything upstream ships. The firewall-strip pass also now runs first, so the substring would no longer be present at guard time anyway — but the new sentinel is robust regardless of order.

The two fixes ship together because they touch the same Node.js patcher and only matter as a pair: the bad guard only mattered when the firewall block survived, and the firewall regex only mattered because it left content behind that confused the guard.

## Changes

- `skills/devcontainer-bootstrap/templates/scaffold-devcontainer.sh` — new firewall-stripping node block (placed before the sudoers patch with an inline ordering comment); guard updated to `NOPASSWD:ALL`.
- `tests/fixtures/scaffold-devcontainer/anthropic-base-dockerfile.txt` — captured snapshot of the current upstream `.devcontainer/Dockerfile` from `anthropics/claude-code` `main`, including the firewall block.
- `tests/test-scaffold-devcontainer-patches.sh` — new test that stands up a hermetic `file://`-served upstream, runs the scaffold against a tmp repo, and asserts: no `init-firewall` references remain, no `sudoers.d/node-firewall` references remain, exactly one `NOPASSWD:ALL` line is present, and the scaffold is idempotent (sha256 of the generated Dockerfile is stable across two runs).

## Closes

Closes #141
Closes #142

## Test plan

- [x] `./tests/test-scaffold-devcontainer-patches.sh` passes locally
- [x] `./tests/test-dogfooding-guardrails.sh` passes locally
- [x] `bash -n skills/devcontainer-bootstrap/templates/scaffold-devcontainer.sh` clean
- [x] Manual: scaffold run against captured fixture produces a Dockerfile with zero `init-firewall` references and exactly one `NOPASSWD:ALL` block
- [ ] CI green
- [ ] CodeRabbit pass

## Checklist

- [x] Follows the agent template structure from CONTRIBUTING.md (n/a — bug fix)
- [x] Includes YAML frontmatter with `name`, `description`, `color` (n/a — bug fix)
- [x] Has concrete code/template examples (n/a — bug fix)
- [x] Tested in real scenarios
- [x] Proofread and formatted correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Devcontainer scaffolding now removes firewall-related components from generated containers.
  * Improved passwordless-sudo detection to prevent false positives from configuration matching.

* **Tests**
  * Added comprehensive test suite validating devcontainer patch consistency and correctness across multiple runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->