### PR TITLE
Install CLI helper scripts at project root for devcontainer build/launch/shell

### DIFF
--- a/skills/devcontainer-bootstrap/templates/dc-build
+++ b/skills/devcontainer-bootstrap/templates/dc-build
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# dc-build — force a clean rebuild of this project's devcontainer.
+#
+# Wraps:
+#   devcontainer up --workspace-folder . --remove-existing-container
+#
+# Run this from the project root on the host (not inside the container).
+
+# Refuse to run inside the container — these are host-side commands.
+if [ -f /.dockerenv ] || [ -n "${DEVCONTAINER:-}" ]; then
+  echo "error: this is a host-side helper. Run from your host shell, not inside the container." >&2
+  exit 1
+fi
+
+# Verify the devcontainer CLI is available.
+if ! command -v devcontainer >/dev/null 2>&1; then
+  echo "error: devcontainer CLI not found. Install with: npm install -g @devcontainers/cli" >&2
+  exit 1
+fi
+
+exec devcontainer up --workspace-folder . --remove-existing-container "$@"

--- a/skills/devcontainer-bootstrap/templates/dc-shell
+++ b/skills/devcontainer-bootstrap/templates/dc-shell
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# dc-shell — enter the running devcontainer with a zsh shell.
+#
+# Wraps:
+#   devcontainer exec --workspace-folder . zsh
+#
+# Run this from the project root on the host (not inside the container). The
+# container must already be running — start it with ./dc-up if not.
+
+# Refuse to run inside the container — these are host-side commands.
+if [ -f /.dockerenv ] || [ -n "${DEVCONTAINER:-}" ]; then
+  echo "error: this is a host-side helper. Run from your host shell, not inside the container." >&2
+  exit 1
+fi
+
+# Verify the devcontainer CLI is available.
+if ! command -v devcontainer >/dev/null 2>&1; then
+  echo "error: devcontainer CLI not found. Install with: npm install -g @devcontainers/cli" >&2
+  exit 1
+fi
+
+# Verify zsh is available inside the container before invoking it. The
+# Superagents post-create script installs zsh by default; if it's missing,
+# guide the operator to add it back rather than dropping into a confusing
+# "exec failed" error from the runtime.
+if ! devcontainer exec --workspace-folder . sh -c 'command -v zsh' >/dev/null 2>&1; then
+  echo "error: zsh not found inside the container." >&2
+  echo "       Add zsh to .devcontainer/post-create-superagents.sh and rebuild with ./dc-build." >&2
+  exit 1
+fi
+
+exec devcontainer exec --workspace-folder . zsh "$@"

--- a/skills/devcontainer-bootstrap/templates/dc-up
+++ b/skills/devcontainer-bootstrap/templates/dc-up
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# dc-up — launch this project's devcontainer (cached, idempotent).
+#
+# Wraps:
+#   devcontainer up --workspace-folder .
+#
+# Run this from the project root on the host (not inside the container). If the
+# container is already up, this is a no-op; if config changed and you want a
+# clean rebuild, use ./dc-build instead.
+
+# Refuse to run inside the container — these are host-side commands.
+if [ -f /.dockerenv ] || [ -n "${DEVCONTAINER:-}" ]; then
+  echo "error: this is a host-side helper. Run from your host shell, not inside the container." >&2
+  exit 1
+fi
+
+# Verify the devcontainer CLI is available.
+if ! command -v devcontainer >/dev/null 2>&1; then
+  echo "error: devcontainer CLI not found. Install with: npm install -g @devcontainers/cli" >&2
+  exit 1
+fi
+
+exec devcontainer up --workspace-folder . "$@"

--- a/skills/devcontainer-bootstrap/templates/scaffold-devcontainer.sh
+++ b/skills/devcontainer-bootstrap/templates/scaffold-devcontainer.sh
@@ -18,6 +18,31 @@ chmod +x \
   "$TARGET_DIR/smoke-test-superagents.sh" \
   "$TARGET_DIR/upgrade-superagents-in-container.sh"
 
+# --- CLI helper scripts (project root) ---
+# Install dc-build / dc-up / dc-shell at the *project root* (not under
+# .devcontainer/). These are host-side wrappers around the `devcontainer` CLI
+# so operators can `./dc-build`, `./dc-up`, `./dc-shell` from the project root.
+#
+# The project root is the parent of TARGET_DIR (TARGET_DIR is conventionally
+# <project>/.devcontainer, but callers can pass any path; resolve the parent
+# explicitly so we don't depend on cwd).
+PROJECT_ROOT="$(cd "$(dirname "$TARGET_DIR")" && pwd)"
+
+# Idempotency: if a helper already exists at the destination, skip it with a
+# notice rather than overwriting an operator-modified version. Mirrors the
+# install_aider / install_windsurf pattern in scripts/install.sh.
+for helper in dc-build dc-up dc-shell; do
+  src="$TEMPLATE_DIR/$helper"
+  dest="$PROJECT_ROOT/$helper"
+  if [ -f "$dest" ]; then
+    echo "Skipping $helper: $dest already exists (remove to reinstall)."
+    continue
+  fi
+  cp "$src" "$dest"
+  chmod +x "$dest"
+  echo "Installed $helper -> $dest"
+done
+
 # ---------------------------------------------------------------------------
 # Port designation
 # ---------------------------------------------------------------------------

--- a/skills/devcontainer-bootstrap/templates/scaffold-devcontainer.sh
+++ b/skills/devcontainer-bootstrap/templates/scaffold-devcontainer.sh
@@ -34,7 +34,7 @@ PROJECT_ROOT="$(cd "$(dirname "$TARGET_DIR")" && pwd)"
 for helper in dc-build dc-up dc-shell; do
   src="$TEMPLATE_DIR/$helper"
   dest="$PROJECT_ROOT/$helper"
-  if [ -f "$dest" ]; then
+  if [ -e "$dest" ]; then
     echo "Skipping $helper: $dest already exists (remove to reinstall)."
     continue
   fi

--- a/skills/superagents-devcontainer/SKILL.md
+++ b/skills/superagents-devcontainer/SKILL.md
@@ -16,6 +16,39 @@ Use this skill when you need to manage the lifecycle of a Superagents devcontain
 
 ---
 
+## CLI Helpers (Recommended Entry Points)
+
+The `superagents-devcontainer-bootstrap` skill installs three small host-side
+helper scripts at the **project root** during scaffold. These are the
+recommended way to drive the devcontainer lifecycle from a CLI-first workflow
+(no VS Code required):
+
+| Helper | Action | Wraps |
+|---|---|---|
+| `./dc-build` | Force a clean rebuild | `devcontainer up --workspace-folder . --remove-existing-container` |
+| `./dc-up` | Launch (cached, idempotent) | `devcontainer up --workspace-folder .` |
+| `./dc-shell` | Enter the running container with zsh | `devcontainer exec --workspace-folder . zsh` |
+
+Run all three from the **project root on the host** (not inside the container).
+Each helper:
+
+- Verifies `devcontainer` is on `PATH` and bails with an install hint
+  (`npm install -g @devcontainers/cli`) when missing.
+- Refuses to run inside a container (using `/.dockerenv` and `DEVCONTAINER`
+  heuristics) — they are host-side wrappers only.
+- For `./dc-shell`: also checks that `zsh` is available inside the container
+  before invoking it.
+
+If the helpers are missing from your project (e.g. it was scaffolded before
+they shipped), re-run `skills/devcontainer-bootstrap/templates/scaffold-devcontainer.sh`
+to install them. The scaffold is idempotent: existing helpers are skipped
+rather than overwritten, so operator-modified versions are preserved.
+
+The explicit `devcontainer …` commands in the sections below still work and
+are kept for operators not using the helpers.
+
+---
+
 ## 1. Rebuild
 
 ### When to Use
@@ -42,15 +75,25 @@ Either:
 
 **CLI (host terminal):**
 
+The recommended path is the helper scripts installed at the project root by
+the bootstrap scaffold:
+
 ```bash
 # Standard rebuild (uses cached layers where possible)
-devcontainer up --workspace-folder .
+./dc-up                          # (devcontainer up --workspace-folder .)
 
 # Force a clean rebuild (no cached layers)
+./dc-build                       # (devcontainer up --workspace-folder . --remove-existing-container)
+```
+
+If you prefer the explicit invocations, or your project predates the helpers:
+
+```bash
+devcontainer up --workspace-folder .
 devcontainer up --workspace-folder . --remove-existing-container
 ```
 
-Run both commands from the **project root on the host** (not inside the container).
+Run all of these from the **project root on the host** (not inside the container).
 
 ### Prerequisite Check
 
@@ -141,7 +184,7 @@ sudo apt-get install -y \
 Then rebuild:
 
 ```bash
-devcontainer up --workspace-folder . --remove-existing-container
+./dc-build                       # (devcontainer up --workspace-folder . --remove-existing-container)
 ```
 
 ### Where to Run

--- a/tests/test-cli-helper-scaffold.sh
+++ b/tests/test-cli-helper-scaffold.sh
@@ -1,0 +1,192 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Verifies that scaffold-devcontainer.sh installs the dc-build, dc-up, and
+# dc-shell host-side CLI helper scripts at the project root, with the right
+# shebang, perms, guards, and command bodies (issue #156).
+#
+# Also verifies idempotency: a second scaffold run against a project where the
+# operator has modified dc-up MUST NOT clobber the modification.
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SCAFFOLD="$ROOT_DIR/skills/devcontainer-bootstrap/templates/scaffold-devcontainer.sh"
+FIXTURE="$ROOT_DIR/tests/fixtures/scaffold-devcontainer/anthropic-base-dockerfile.txt"
+
+[[ -x "$SCAFFOLD" ]] || { echo "Missing or non-executable scaffold script: $SCAFFOLD" >&2; exit 1; }
+[[ -f "$FIXTURE" ]]  || { echo "Missing fixture: $FIXTURE" >&2; exit 1; }
+
+TMP_ROOT="$(mktemp -d)"
+trap 'rm -rf "$TMP_ROOT"' EXIT
+
+# Stand up a fake "Anthropic upstream" served from the local filesystem so the
+# scaffold's curl call is hermetic. The scaffold's BASE_URL is consumed by curl
+# directly, so a file:// URL prefix works.
+UPSTREAM_DIR="$TMP_ROOT/upstream"
+mkdir -p "$UPSTREAM_DIR"
+cp "$FIXTURE" "$UPSTREAM_DIR/Dockerfile"
+
+# Minimal devcontainer.json sufficient for the scaffold's JSON patch step.
+cat >"$UPSTREAM_DIR/devcontainer.json" <<'JSON'
+{
+  "name": "test",
+  "build": { "dockerfile": "Dockerfile" },
+  "runArgs": ["--cap-add", "NET_ADMIN", "--cap-add", "NET_RAW"],
+  "mounts": [],
+  "containerEnv": {},
+  "postStartCommand": "echo hi",
+  "waitFor": "postStartCommand"
+}
+JSON
+
+# Run scaffold inside a fake repo with a known name that exists in ports.yaml.
+# Pick the first project entry from the real ports registry so the lookup
+# succeeds without us having to mutate the registry.
+PORTS_YAML="$ROOT_DIR/skills/devcontainer-bootstrap/ports.yaml"
+[[ -f "$PORTS_YAML" ]] || { echo "Missing ports registry at $PORTS_YAML" >&2; exit 1; }
+REPO_NAME="$(python3 - "$PORTS_YAML" <<'PYEOF'
+import sys, re
+with open(sys.argv[1]) as f:
+    in_projects = False
+    for line in f:
+        s = line.strip()
+        if s.startswith('#') or not s:
+            continue
+        if s == 'projects:':
+            in_projects = True
+            continue
+        if in_projects:
+            if re.match(r'^\S', line) and not line.startswith(' '):
+                break
+            m = re.match(r'^\s+(\S+):\s*\d+', line)
+            if m:
+                print(m.group(1))
+                sys.exit(0)
+PYEOF
+)"
+[[ -n "$REPO_NAME" ]] || { echo "Could not pick a repo name from $PORTS_YAML" >&2; exit 1; }
+
+REPO_DIR="$TMP_ROOT/$REPO_NAME"
+mkdir -p "$REPO_DIR"
+git -C "$REPO_DIR" init -q
+git -C "$REPO_DIR" config user.email "test@example.com"
+git -C "$REPO_DIR" config user.name  "Test"
+git -C "$REPO_DIR" commit --allow-empty -q -m "init"
+
+TARGET_DIR="$REPO_DIR/.devcontainer"
+
+run_scaffold() {
+  ( cd "$REPO_DIR" \
+    && ANTHROPIC_DEVCONTAINER_BASE_URL="file://$UPSTREAM_DIR" \
+       "$SCAFFOLD" "$TARGET_DIR" >/dev/null )
+}
+
+assert_helper_common() {
+  local label="$1"
+  local helper="$2"
+  local path="$REPO_DIR/$helper"
+
+  [[ -f "$path" ]] || { echo "[$label] FAIL: $helper not produced at $path" >&2; exit 1; }
+  [[ -x "$path" ]] || { echo "[$label] FAIL: $helper at $path is not executable" >&2; exit 1; }
+
+  # Shebang must be the portable env form.
+  local first_line
+  first_line="$(head -n 1 "$path")"
+  if [[ "$first_line" != "#!/usr/bin/env bash" ]]; then
+    echo "[$label] FAIL: $helper has unexpected shebang: $first_line" >&2
+    exit 1
+  fi
+
+  # Strict mode preamble.
+  if ! grep -q "set -euo pipefail" "$path"; then
+    echo "[$label] FAIL: $helper missing 'set -euo pipefail'" >&2
+    exit 1
+  fi
+
+  # Host-side guard: must reference either /.dockerenv or DEVCONTAINER env.
+  if ! grep -qE "/\.dockerenv|DEVCONTAINER" "$path"; then
+    echo "[$label] FAIL: $helper missing host-side guard (no /.dockerenv or DEVCONTAINER check)" >&2
+    exit 1
+  fi
+
+  # devcontainer-on-PATH self-check.
+  if ! grep -q "command -v devcontainer" "$path"; then
+    echo "[$label] FAIL: $helper missing 'command -v devcontainer' PATH check" >&2
+    exit 1
+  fi
+}
+
+assert_dc_build() {
+  local label="$1"
+  local path="$REPO_DIR/dc-build"
+  if ! grep -q "devcontainer up" "$path"; then
+    echo "[$label] FAIL: dc-build does not invoke 'devcontainer up'" >&2
+    exit 1
+  fi
+  if ! grep -q -- "--remove-existing-container" "$path"; then
+    echo "[$label] FAIL: dc-build missing --remove-existing-container flag" >&2
+    exit 1
+  fi
+}
+
+assert_dc_up() {
+  local label="$1"
+  local path="$REPO_DIR/dc-up"
+  if ! grep -q "devcontainer up" "$path"; then
+    echo "[$label] FAIL: dc-up does not invoke 'devcontainer up'" >&2
+    exit 1
+  fi
+  # dc-up must NOT include --remove-existing-container — that's dc-build's job.
+  if grep -q -- "--remove-existing-container" "$path"; then
+    echo "[$label] FAIL: dc-up unexpectedly includes --remove-existing-container" >&2
+    exit 1
+  fi
+}
+
+assert_dc_shell() {
+  local label="$1"
+  local path="$REPO_DIR/dc-shell"
+  if ! grep -q "devcontainer exec" "$path"; then
+    echo "[$label] FAIL: dc-shell does not invoke 'devcontainer exec'" >&2
+    exit 1
+  fi
+  if ! grep -qw "zsh" "$path"; then
+    echo "[$label] FAIL: dc-shell does not invoke zsh" >&2
+    exit 1
+  fi
+}
+
+# First run: helpers should be installed cleanly.
+run_scaffold
+
+for helper in dc-build dc-up dc-shell; do
+  assert_helper_common "first run" "$helper"
+done
+assert_dc_build "first run"
+assert_dc_up    "first run"
+assert_dc_shell "first run"
+
+# Idempotency: simulate operator modification of dc-up, then re-run scaffold.
+# The modification must survive (skip-if-exists semantics).
+SENTINEL="# operator-edit: do-not-clobber-${RANDOM}"
+printf '\n%s\n' "$SENTINEL" >> "$REPO_DIR/dc-up"
+MODIFIED_HASH="$(sha256sum "$REPO_DIR/dc-up" | awk '{print $1}')"
+
+run_scaffold
+
+POST_HASH="$(sha256sum "$REPO_DIR/dc-up" | awk '{print $1}')"
+if [[ "$MODIFIED_HASH" != "$POST_HASH" ]]; then
+  echo "FAIL: scaffold clobbered operator-modified dc-up on second run" >&2
+  exit 1
+fi
+if ! grep -qF "$SENTINEL" "$REPO_DIR/dc-up"; then
+  echo "FAIL: operator sentinel missing from dc-up after second scaffold run" >&2
+  exit 1
+fi
+
+# Sanity: dc-build and dc-shell should still pass their checks after re-run.
+assert_helper_common "second run" "dc-build"
+assert_helper_common "second run" "dc-shell"
+assert_dc_build "second run"
+assert_dc_shell "second run"
+
+echo "cli-helper scaffold tests: passed"


### PR DESCRIPTION
## What does this PR do?

Installs three small host-side CLI helper scripts at the project root during devcontainer scaffold so CLI-first operators can drive the devcontainer lifecycle without typing the full `devcontainer …` invocations or relying on VS Code:

- `./dc-build` — `devcontainer up --workspace-folder . --remove-existing-container` (force clean rebuild)
- `./dc-up` — `devcontainer up --workspace-folder .` (idempotent launch)
- `./dc-shell` — `devcontainer exec --workspace-folder . zsh` (enter running container)

Each helper:

- Refuses to run inside the container (`/.dockerenv` and `DEVCONTAINER` heuristics).
- Verifies `devcontainer` is on `PATH` and bails with `npm install -g @devcontainers/cli` when missing.
- `dc-shell` additionally verifies `zsh` is present in the container before invoking it, with a hint to add it back to `post-create-superagents.sh` if missing.

`scaffold-devcontainer.sh` now copies the templates into the project root (parent of `TARGET_DIR`). Idempotency mirrors `install_aider` / `install_windsurf` in `scripts/install.sh`: existing helpers are skipped with a notice rather than overwritten, preserving operator-modified versions.

`skills/superagents-devcontainer/SKILL.md` adds a top-of-file section recommending the helpers as the primary CLI entry points and rewrites the inline `devcontainer up …` examples to reference the helper plus the canonical command in parentheses (explicit invocations are kept for operators who want them).

The patcher logic added in #157 is untouched — only a new `# --- CLI helper scripts (project root) ---` section was added to the scaffold.

Closes #156

## Agent Information (if adding/modifying an agent)

N/A — infrastructure change, not an agent.

## Checklist

- [x] Three new templates under `skills/devcontainer-bootstrap/templates/`: `dc-build`, `dc-up`, `dc-shell`
- [x] Each is `chmod +x`, starts with `#!/usr/bin/env bash` and `set -euo pipefail`
- [x] Scaffold copies all three into the project root with skip-if-exists idempotency
- [x] Each script self-checks `devcontainer` on PATH and refuses to run in-container
- [x] `dc-shell` verifies `zsh` in the container before invoking it
- [x] `superagents-devcontainer/SKILL.md` updated with a recommended-helpers section and inline references
- [x] New test `tests/test-cli-helper-scaffold.sh` covers shebang, perms, guards, command bodies, and idempotency (operator edits to `dc-up` survive a second scaffold run)
- [x] Existing `tests/test-scaffold-devcontainer-patches.sh` still passes
- [x] `tests/test-dogfooding-guardrails.sh` passes
- [x] `bash -n` passes on all new and modified shell scripts

## Test plan

- `./tests/test-cli-helper-scaffold.sh` — passed locally
- `./tests/test-scaffold-devcontainer-patches.sh` — passed locally
- `./tests/test-dogfooding-guardrails.sh` — passed locally
- `bash -n` on `dc-build`, `dc-up`, `dc-shell`, `scaffold-devcontainer.sh` — clean
- `ruby` and `shellcheck` not available in this environment, so `test-doc-link-integrity.sh`, `test-fragment-contract-validation.sh`, and `shellcheck` were skipped per instructions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added three new CLI helper scripts (`dc-build`, `dc-up`, `dc-shell`) for streamlined devcontainer management from the project root.
  * `dc-build` enables clean container rebuilds.
  * `dc-up` provides cached, idempotent container startup.
  * `dc-shell` offers quick shell access into the running container.

* **Documentation**
  * Updated guides with a recommended CLI-first workflow showcasing the new helper scripts and their use cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->